### PR TITLE
add --with-config-file-path=/etc

### DIFF
--- a/docker/compile-php.sh
+++ b/docker/compile-php.sh
@@ -30,6 +30,7 @@ function php_compile_args() {
     _php_arg="$_php_arg --with-pear=no"
     _php_arg="$_php_arg --disable-cgi"
     _php_arg="$_php_arg --disable-phpdbg"
+    _php_arg="$_php_arg --with-config-file-path=/etc"
     _php_arg="$_php_arg $($self_dir/check-extensions.sh check_in_configure $1)"
     echo $_php_arg
 }


### PR DESCRIPTION
一般情况下,`php.ini`会放到`/etc`下，所以希望可以给个默认值