### PR TITLE
添加aria2快速下载依赖库和扩展；添加依赖库GMP；添加依赖库libmcrypt； 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea
+runtime/
+docker/libraries/
+docker/extensions/
+docker/source/

--- a/README.md
+++ b/README.md
@@ -61,8 +61,10 @@ cat micro.sfx code.php > single-app && chmod +x single-app
 可以自己使用 Dockerfile 进行编译构建：
 
 ```bash
+
 git clone https://github.com/crazywhalecc/static-php-cli.git
 cd static-php-cli/docker
+export DOCKER_BUILDKIT=1
 docker build -t static-php . --build-arg USE_BACKUP_ADDRESS=no
 # 新建一个用于放置构建好的二进制的文件夹
 mkdir dist

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,13 +19,10 @@ RUN if [ "${USE_BACKUP}" = "" ]; then \
         export USE_BACKUP="no" ; \
     fi
 
-RUN if [ "${USE_BACKUP}" = "yes" ]; then \
-        echo "Using backup original address..." ; \
-    else \
-        echo "Using mirror address..." && \
-        sed -i 's/dl-cdn.alpinelinux.org/'${LINK_APK_REPO}'/g' /etc/apk/repositories ; \
-    fi
+RUN sed -i.backup 's/dl-cdn.alpinelinux.org/'${LINK_APK_REPO}'/g' /etc/apk/repositories ;
 
+RUN if [ "${USE_BACKUP}" = "no" ]; then cp -f /etc/apk/repositories.backup /etc/apk/repositories; fi
+RUN cat /etc/apk/repositories
 # build requirements
 RUN apk add bash file wget cmake gcc g++ jq autoconf git libstdc++ linux-headers make m4 libgcc binutils ncurses dialog > /dev/null
 # php zlib dependencies
@@ -50,26 +47,43 @@ RUN apk add libffi libffi-dev > /dev/null
 RUN apk add zstd-static > /dev/null
 # php readline dependencies
 RUN apk add readline-static ncurses-static readline-dev > /dev/null
+RUN apk add aria2
 
 RUN mkdir /app
 
 WORKDIR /app
 
-COPY ./* /app/
+ADD  ./ /app/
 
-RUN chmod +x /app/*.sh
+# RUN chmod +x /app/*.sh
 
-RUN ./download.sh swoole ${USE_BACKUP} && \
-    ./download.sh inotify ${USE_BACKUP} && \
-    ./download.sh mongodb ${USE_BACKUP} && \
-    ./download.sh event ${USE_BACKUP} && \
-    ./download.sh redis ${USE_BACKUP} && \
-    ./download.sh libxml2 ${USE_BACKUP} && \
-    ./download.sh xz ${USE_BACKUP} && \
-    ./download.sh curl ${USE_BACKUP} && \
-    ./download.sh libzip ${USE_BACKUP} && \
-    ./download.sh libiconv ${USE_BACKUP} && \
-    ./download-git.sh dixyes/phpmicro phpmicro ${USE_BACKUP}
+# use proxy
+# ENV http_proxy=http://192.168.3.26:8015
+# ENV https_proxy=http://192.168.3.26:8015
 
-RUN ./compile-deps.sh
+# 提前下载好，就可以跳过两步
+# (容器外提前执行 下面两个命令）
+RUN sh ./download-library-batch-aria2.sh
+RUN sh ./download-extension-batch-aria2.sh
+
+#ENV http_proxy=''
+#ENV https_proxy=''
+RUN ls -lh source/libraries
+RUN ls -lh source/extensions
+# quick test complie
+# RUN bash ./compile-deps.sh
+
+RUN sh ./download.sh swoole ${USE_BACKUP} && \
+    sh ./download.sh inotify ${USE_BACKUP} && \
+    sh ./download.sh mongodb ${USE_BACKUP} && \
+    sh ./download.sh event ${USE_BACKUP} && \
+    sh ./download.sh redis ${USE_BACKUP} && \
+    sh ./download.sh libxml2 ${USE_BACKUP} && \
+    sh ./download.sh xz ${USE_BACKUP} && \
+    sh ./download.sh curl ${USE_BACKUP} && \
+    sh ./download.sh libzip ${USE_BACKUP} && \
+    sh ./download.sh libiconv ${USE_BACKUP} && \
+    sh ./download-git.sh dixyes/phpmicro phpmicro ${USE_BACKUP}
+
+RUN bash ./compile-deps.sh
 RUN echo -e "#!/usr/bin/env bash\n/app/compile-php.sh \$@" > /bin/build-php && chmod +x /bin/build-php

--- a/docker/compile-deps.sh
+++ b/docker/compile-deps.sh
@@ -52,7 +52,9 @@ function do_iconv_compiler() {
 }
 
 if [ ! -f "$self_dir/source/.deps-compiled" ]; then
-    do_xml_compiler && \
+        source ${self_dir}/deps-modules/libmcrypt.sh
+        source ${self_dir}/deps-modules/gmp.sh
+        do_xml_compiler && \
         do_curl_compiler && \
         do_libzip_compiler && \
         do_iconv_compiler && \

--- a/docker/deps-modules/gmp.sh
+++ b/docker/deps-modules/gmp.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+if [ -n "$__MODULE_SH__" ]; then
+    return
+fi
+__MODULE_SH__='gmp.sh'
+
+set -exu
+__DIR__=$(
+  cd "$(dirname "$0")"
+  pwd
+)
+cd ${__DIR__}
+
+# cpu 核数 ，前面为mac 后面为macos
+cpu_nums=`nproc 2> /dev/null || sysctl -n hw.ncpu`
+# cpu_nums=`grep "processor" /proc/cpuinfo | sort -u | wc -l`
+
+function do_gmp_compiler() {
+    pwd
+    mkdir -p /app/source/builder_dir/gmp
+    tar --strip-components=1 -C ${__DIR__}/source/builder_dir/gmp -xf ${__DIR__}/source/libraries/gmp-6.2.1.tar.lz
+    cd ${__DIR__}/source/builder_dir/gmp
+
+    ./configure --prefix=/usr/gmp --enable-static --disable-shared
+    make -j $cpu_nums
+    echo "gmp compiled!" && \
+    make install && \
+    echo "gmp compiled!"
+    return $?
+}
+
+do_gmp_compiler

--- a/docker/deps-modules/gmp.sh
+++ b/docker/deps-modules/gmp.sh
@@ -11,7 +11,7 @@ __DIR__=$(
 )
 cd ${__DIR__}
 
-# cpu 核数 ，前面为mac 后面为macos
+# cpu 核数 ，前面为linux 后面为macos
 cpu_nums=`nproc 2> /dev/null || sysctl -n hw.ncpu`
 # cpu_nums=`grep "processor" /proc/cpuinfo | sort -u | wc -l`
 

--- a/docker/deps-modules/libmcrypt.sh
+++ b/docker/deps-modules/libmcrypt.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+if [ -n "$__MODULE_SH__" ]; then
+    return
+fi
+__MODULE_SH__='libmcrypt.sh'
+
+set -exu
+__DIR__=$(
+  cd "$(dirname "$0")"
+  pwd
+)
+cd ${__DIR__}
+
+# cpu 核数 ，前面为mac 后面为macos
+cpu_nums=`nproc 2> /dev/null || sysctl -n hw.ncpu`
+# cpu_nums=`grep "processor" /proc/cpuinfo | sort -u | wc -l`
+
+
+function do_libmcrypt_compiler() {
+    pwd
+    mkdir -p /app/source/builder_dir/libmcrypt
+    tar --strip-components=1 -C ${__DIR__}/source/builder_dir/libmcrypt -xf ${__DIR__}/source/libraries/libmcrypt-2.5.8-3.4.tar.gz
+    cd ${__DIR__}/source/builder_dir/libmcrypt
+
+    chmod a+x ./install-sh
+    sh ./configure --prefix=/usr/libmcrypt \
+    --enable-static=yes \
+    --enable-shared=no
+    make -j $cpu_nums
+    echo "libmcrypt compiled!" && \
+    make install && \
+    echo "libmcrypt compiled!"
+    return $?
+}
+do_libmcrypt_compiler

--- a/docker/deps-modules/libmcrypt.sh
+++ b/docker/deps-modules/libmcrypt.sh
@@ -11,7 +11,7 @@ __DIR__=$(
 )
 cd ${__DIR__}
 
-# cpu 核数 ，前面为mac 后面为macos
+# cpu 核数 ，前面为linux 后面为macos
 cpu_nums=`nproc 2> /dev/null || sysctl -n hw.ncpu`
 # cpu_nums=`grep "processor" /proc/cpuinfo | sort -u | wc -l`
 

--- a/docker/download-extension-batch-aria2.sh
+++ b/docker/download-extension-batch-aria2.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -exu
+__DIR__=$(
+  cd "$(dirname "$0")"
+  pwd
+)
+
+cd ${__DIR__}
+
+# https://aria2.github.io/manual/en/html/aria2c.html#http-ftp-segmented-downloads
+# https://aria2.github.io/manual/en/html/aria2c.html
+# -with-config-file-path=/usr/local/php/etc
+# -U, --user-agent
+# aria2c -h
+# aria2c --conf-path=/etc/aria2/aria2.conf
+
+:<<EOF
+-c, --continue [true|false]
+-s, --split=<N>
+-x, --max-connection-per-server=<NUM>
+-k, --min-split-size=<SIZE>
+-j, --max-concurrent-downloads=<N>
+-i, --input-file=<FILE>
+EOF
+
+user_agent='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36'
+
+
+test -f download_extension_urls.txt  && aria2c -c -j 10 -s 10 -x 8 -k 10M --allow-overwrite=true --max-tries=30  --retry-wait=15 --user-agent=$user_agent \
+ -d extensions --input-file=download_extension_urls.txt
+
+mkdir -p source/extensions
+awk 'BEGIN { cmd="cp -ri extensions/* source/extensions/"  ; print "n" |cmd; }'

--- a/docker/download-library-batch-aria2.sh
+++ b/docker/download-library-batch-aria2.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -exu
+__DIR__=$(
+  cd "$(dirname "$0")"
+  pwd
+)
+
+cd ${__DIR__}
+
+# https://aria2.github.io/manual/en/html/aria2c.html#http-ftp-segmented-downloads
+# https://aria2.github.io/manual/en/html/aria2c.html
+# -with-config-file-path=/usr/local/php/etc
+# -U, --user-agent
+# aria2c -h
+# aria2c --conf-path=/etc/aria2/aria2.conf
+
+:<<EOF
+-c, --continue [true|false]
+-s, --split=<N>
+-x, --max-connection-per-server=<NUM>
+-k, --min-split-size=<SIZE>
+-j, --max-concurrent-downloads=<N>
+-i, --input-file=<FILE>
+EOF
+
+user_agent='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36'
+
+
+test -f download_library_urls.txt  && aria2c -c -j 10 -s 10 -x 8 -k 10M --allow-overwrite=true --max-tries=30  --retry-wait=15 --user-agent=$user_agent \
+ -d libraries --input-file=download_library_urls.txt
+
+mkdir -p source/libraries
+awk 'BEGIN { cmd="cp -ri libraries/* source/libraries/"  ; print "n" |cmd; }'

--- a/docker/download_extension_urls.bak.txt
+++ b/docker/download_extension_urls.bak.txt
@@ -1,0 +1,22 @@
+https://pecl.php.net/get/redis-5.3.7.tgz
+ out=redis-5.3.7.tgz
+https://pecl.php.net/get/yaml-2.2.2.tgz
+ out=yaml-2.2.2.tgz
+https://pecl.php.net/get/imagick-3.6.0.tgz
+ out=imagick-3.6.0.tgz
+https://pecl.php.net/get/mongodb-1.14.2.tgz
+ out=mongodb-1.14.2.tgz
+https://pecl.php.net/get/apcu-5.1.22.tgz
+ out=apcu-5.1.22.tgz
+https://pecl.php.net/get/ds-1.4.0.tgz
+ out=ds-1.4.0.tgz
+https://pecl.php.net/get/inotify-3.0.0.tgz
+ out=inotify-3.0.0.tgz
+https://pecl.php.net/get/xlswriter-1.5.2.tgz
+ out=xlswriter-1.5.2.tgz
+https://pecl.php.net/get/zstd-0.12.1.tgz
+ out=zstd-0.12.1.tgz
+https://pecl.php.net/get/event-3.0.8.tgz
+ out=event-3.0.8.tgz
+https://pecl.php.net/get/mcrypt-1.0.5.tgz
+ out=mcrypt-1.0.5.tgz

--- a/docker/download_extension_urls.txt
+++ b/docker/download_extension_urls.txt
@@ -1,0 +1,4 @@
+https://pecl.php.net/get/mcrypt-1.0.5.tgz
+ out=mcrypt-1.0.5.tgz
+https://pecl.php.net/get/apcu-5.1.22.tgz
+ out=apcu-5.1.22.tgz

--- a/docker/download_library_urls.bak.txt
+++ b/docker/download_library_urls.bak.txt
@@ -1,0 +1,72 @@
+https://www.openssl.org/source/openssl-1.1.1p.tar.gz
+ out=openssl-1.1.1p.tar.gz
+https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.16.tar.gz
+ out=libiconv-1.16.tar.gz
+https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.9.10/libxml2-v2.9.10.tar.gz
+ out=libxml2-v2.9.10.tar.gz
+https://gitlab.gnome.org/GNOME/libxslt/-/archive/v1.1.34/libxslt-v1.1.34.tar.gz
+ out=libxslt-v1.1.34.tar.gz
+https://github.com/google/brotli/archive/refs/tags/v1.0.9.tar.gz
+ out=brotli-1.0.9.tar.gz
+https://c-ares.org/download/c-ares-1.19.0.tar.gz
+ out=c-ares-1.19.0.tar.gz
+https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz
+ out=gmp-6.2.1.tar.lz
+https://mirrors.tuna.tsinghua.edu.cn/gnu/ncurses/ncurses-6.3.tar.gz	https://mirrors.ustc.edu.cn/gnu/ncurses/ncurses-6.3.tar.gz	https://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.3.tar.gz
+ out=ncurses-6.3.tar.gz
+https://mirrors.tuna.tsinghua.edu.cn/gnu/readline/readline-8.2.tar.gz	https://mirrors.ustc.edu.cn/gnu/readline/readline-8.2.tar.gz	https://ftp.gnu.org/gnu/readline/readline-8.2.tar.gz
+ out=readline-8.2.tar.gz
+https://pyyaml.org/download/libyaml/yaml-0.2.5.tar.gz
+ out=yaml-0.2.5.tar.gz
+https://download.libsodium.org/libsodium/releases/libsodium-1.0.18.tar.gz
+ out=libsodium-1.0.18.tar.gz
+https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz
+ out=bzip2-1.0.8.tar.gz
+https://udomain.dl.sourceforge.net/project/libpng/zlib/1.2.11/zlib-1.2.11.tar.gz
+ out=zlib-1.2.11.tar.gz
+https://github.com/lz4/lz4/archive/refs/tags/v1.9.4.tar.gz
+ out=lz4-v1.9.4.tar.gz
+https://github.com/tukaani-project/xz/releases/download/v5.4.1/xz-5.4.1.tar.gz
+ out=xz-5.4.1.tar.gz
+https://github.com/facebook/zstd/releases/download/v1.5.2/zstd-1.5.2.tar.gz
+ out=zstd-1.5.2.tar.gz
+https://libzip.org/download/libzip-1.9.2.tar.gz
+ out=libzip-1.9.2.tar.gz
+https://www.sqlite.org/2021/sqlite-autoconf-3370000.tar.gz
+ out=sqlite-autoconf-3370000.tar.gz
+https://github.com/unicode-org/icu/releases/download/release-60-3/icu4c-60_3-src.tgz
+ out=icu4c-60_3-src.tgz
+https://codeload.github.com/kkos/oniguruma/tar.gz/refs/tags/v6.9.7
+ out=oniguruma-6.9.7.tar.gz
+https://github.com/microsoft/mimalloc/archive/refs/tags/v2.0.7.tar.gz
+ out=mimalloc-2.0.7.tar.gz
+https://codeload.github.com/libjpeg-turbo/libjpeg-turbo/tar.gz/refs/tags/2.1.2
+ out=libjpeg-turbo-2.1.2.tar.gz
+https://nchc.dl.sourceforge.net/project/giflib/giflib-5.2.1.tar.gz
+ out=giflib-5.2.1.tar.gz
+https://nchc.dl.sourceforge.net/project/libpng/libpng16/1.6.37/libpng-1.6.37.tar.gz
+ out=libpng-1.6.37.tar.gz
+https://codeload.github.com/webmproject/libwebp/tar.gz/refs/tags/v1.2.1
+ out=libwebp-1.2.1.tar.gz
+https://download.savannah.gnu.org/releases/freetype/freetype-2.10.4.tar.gz
+ out=freetype-2.10.4.tar.gz
+https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.0-62.tar.gz
+ out=ImageMagick-v7.1.0-62.tar.gz
+https://ftp.gnu.org/gnu/libidn/libidn2-2.3.4.tar.gz
+ out=libidn2-2.3.4.tar.gz
+https://curl.se/download/curl-7.88.0.tar.gz
+ out=curl-7.88.0.tar.gz
+https://ftp.postgresql.org/pub/source/v15.1/postgresql-15.1.tar.gz
+ out=postgresql-15.1.tar.gz
+https://github.com/libffi/libffi/releases/download/v3.4.4/libffi-3.4.4.tar.gz
+ out=libffi-3.4.4.tar.gz
+https://github.com/winlibs/libmcrypt/archive/refs/tags/libmcrypt-2.5.8-3.4.tar.gz
+ out=libmcrypt-2.5.8-3.4.tar.gz
+https://github.com/jmcnamara/libxlsxwriter/archive/refs/tags/RELEASE_1.1.5.tar.gz
+ out=libxlsxwriter-1.1.5.tar.gz
+https://github.com/libevent/libevent/releases/download/release-2.1.12-stable/libevent-2.1.12-stable.tar.gz
+ out=libevent-2.1.12-stable.tar.gz
+https://github.com/libuv/libuv/archive/refs/tags/v1.44.2.tar.gz
+ out=libuv-v1.44.2.tar.gz
+https://github.com/php/php-src/archive/refs/tags/php-8.1.12.tar.gz
+ out=php-8.1.12.tar.gz

--- a/docker/download_library_urls.txt
+++ b/docker/download_library_urls.txt
@@ -1,0 +1,4 @@
+https://github.com/winlibs/libmcrypt/archive/refs/tags/libmcrypt-2.5.8-3.4.tar.gz
+ out=libmcrypt-2.5.8-3.4.tar.gz
+https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz
+ out=gmp-6.2.1.tar.lz


### PR DESCRIPTION
把我参与的swoole-cli 项目里的代码，用的上的搬过来

install_libmcrypt 代码搬运来自： https://github.com/jingjingxyk/swoole-cli/blob/a7986894753ea9f7d9cf470de29e755d03beb3d5/library_install_builder_test.php#L1594

 install_gmp 代码搬运来自： https://github.com/jingjingxyk/swoole-cli/blob/a7986894753ea9f7d9cf470de29e755d03beb3d5/library_install_builder.php#L159

生成依赖库批量下载链接文件 代码搬运来自：  https://github.com/swoole/swoole-cli/pull/26

依赖库和扩展批量下载的链接地址 来自： https://github.com/jingjingxyk/swoole-cli/blob/13b34a9a8499c94d6fbe645f42c999fa9e716687/sapi/Preprocessor.php#L893