### PR TITLE
Add intl/ICU support

### DIFF
--- a/config/lib.json
+++ b/config/lib.json
@@ -460,5 +460,18 @@
         "static-libs-unix": [
             "libsodium.a"
         ]
+    },
+    "icu": {
+        "source": "icu",
+        "static-libs-unix": [
+            "libicudata.a",
+            "libicui18n.a",
+            "libicuio.a",
+            "libicutu.a",
+            "libicuuc.a"
+        ],
+        "headers": [
+
+        ]
     }
 }

--- a/config/source.json
+++ b/config/source.json
@@ -419,5 +419,13 @@
             "type": "file",
             "path": "LICENSE"
         }
+    },
+    "icu": {
+        "type": "url",
+        "url": "https://github.com/unicode-org/icu/releases/download/release-73-1/icu4c-73_1-src.tgz",
+        "license": {
+            "type": "file",
+            "path": "LICENSE"
+        }
     }
 }

--- a/src/SPC/builder/linux/LinuxBuilder.php
+++ b/src/SPC/builder/linux/LinuxBuilder.php
@@ -139,7 +139,7 @@ class LinuxBuilder extends BuilderBase
                 )
             );
         }
-        if ($this->getExt('swoole')) {
+        if ($this->getExt('swoole') || $this->getExt('intl')) {
             $extra_libs .= ' -lstdc++';
         }
         if ($this->getExt('imagick')) {

--- a/src/SPC/builder/linux/library/icu.php
+++ b/src/SPC/builder/linux/library/icu.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\linux\library;
+
+class icu extends LinuxLibraryBase
+{
+    public const NAME = 'icu';
+
+    protected function build()
+    {
+        $root = BUILD_ROOT_PATH;
+        shell()->cd($this->source_dir . '/source')
+            ->exec("{$this->builder->configure_env} ./runConfigureICU Linux --enable-static --disable-shared --prefix={$root}")
+            ->exec('make clean')
+            ->exec("make -j{$this->builder->concurrency}")
+            ->exec('make install');
+    }
+}

--- a/src/SPC/builder/macos/MacOSBuilder.php
+++ b/src/SPC/builder/macos/MacOSBuilder.php
@@ -123,7 +123,7 @@ class MacOSBuilder extends BuilderBase
      */
     public function buildPHP(int $build_target = BUILD_TARGET_NONE, bool $bloat = false): void
     {
-        $extra_libs = $this->getFrameworks(true) . ' ' . ($this->getExt('swoole') ? '-lc++ ' : '');
+        $extra_libs = $this->getFrameworks(true) . ' ' . ($this->getExt('swoole') || $this->getExt('intl') ? '-lc++ ' : '');
         if (!$bloat) {
             $extra_libs .= implode(' ', $this->getAllStaticLibFiles());
         } else {

--- a/src/SPC/builder/macos/library/icu.php
+++ b/src/SPC/builder/macos/library/icu.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\macos\library;
+
+class icu extends MacOSLibraryBase
+{
+    public const NAME = 'icu';
+
+    protected function build()
+    {
+        $root = BUILD_ROOT_PATH;
+        shell()->cd($this->source_dir . '/source')
+            ->exec("{$this->builder->configure_env} ./runConfigureICU MacOSX --enable-static --disable-shared --prefix={$root}")
+            ->exec('make clean')
+            ->exec("make -j{$this->builder->concurrency}")
+            ->exec('make install');
+    }
+}

--- a/src/globals/tests/intl.php
+++ b/src/globals/tests/intl.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+assert(class_exists(NumberFormatter::class));


### PR DESCRIPTION
This PR adds support for the intl extension by compiling ICU statically.

I only tested MacOS support so far but modified the Linux build settings accordingly.

The download link for ICU points to a fixed version number, because the [GitHub releases](https://github.com/unicode-org/icu/releases) also contain other releases that are missing the file we actually want.
