### PR TITLE
Fix output of ExtractCommand

### DIFF
--- a/src/SPC/command/ExtractCommand.php
+++ b/src/SPC/command/ExtractCommand.php
@@ -25,7 +25,7 @@ class ExtractCommand extends BaseCommand
     {
         $sources = array_map('trim', array_filter(explode(',', $this->getArgument('sources'))));
         if (empty($sources)) {
-            $this->output->writeln('<erorr>sources cannot be empty, at least contain one !</erorr>');
+            $this->output->writeln('<error>sources cannot be empty, at least contain one !</error>');
             return 1;
         }
         SourceExtractor::initSource(sources: $sources);


### PR DESCRIPTION
I hope now the output will be 🔴 red.

[_source_](https://github.com/szepeviktor/byte-level-care/blob/fa0a43920de80b54c4b1b7bc46ec73a0a1db4efb/.github/workflows/spelling.yml#L30-L32)
