### PR TITLE
minor: prevent warning when installing cmake with Homebrew

### DIFF
--- a/src/SPC/doctor/item/MacOSToolCheckList.php
+++ b/src/SPC/doctor/item/MacOSToolCheckList.php
@@ -73,7 +73,7 @@ class MacOSToolCheckList
     {
         foreach ($missing as $cmd) {
             try {
-                shell(true)->exec('brew install ' . escapeshellarg($cmd));
+                shell(true)->exec('brew install --formula ' . escapeshellarg($cmd));
             } catch (RuntimeException) {
                 return false;
             }


### PR DESCRIPTION
Prevents this warning to be displayed when installing cmake:

> Warning: Treating cmake as a formula. For the cask, use homebrew/cask/cmake