### PR TITLE
fix: disable Zend Signals and enable Zend Max Execution Timers for ZTS builds

### DIFF
--- a/src/SPC/builder/linux/LinuxBuilder.php
+++ b/src/SPC/builder/linux/LinuxBuilder.php
@@ -168,8 +168,11 @@ class LinuxBuilder extends BuilderBase
 
         SourcePatcher::patchBeforeConfigure($this);
 
-        $json_74 = $this->getPHPVersionID() < 80000 ? '--enable-json ' : '';
-        $zts = $this->getOption('enable-zts', false) ? '--enable-zts --disable-zend-signals --enable-zend-max-execution-timers ' : '';
+        $phpVersionID = $this->getPHPVersionID();
+
+        $json_74 = $phpVersionID < 80000 ? '--enable-json ' : '';
+        $maxExecutionTimers = $this->getOption('enable-zts', false) && $this->getPHPVersionID() > 81000 ? '--enable-zend-max-execution-timers ' : '';
+        $zts = $this->getOption('enable-zts', false) ? '--enable-zts --disable-zend-signals ' : '';
 
         shell()->cd(SOURCE_PATH . '/php-src')
             ->exec(
@@ -185,6 +188,7 @@ class LinuxBuilder extends BuilderBase
                 '--enable-fpm ' .
                 $json_74 .
                 $zts .
+                $maxExecutionTimers .
                 '--enable-micro=all-static ' .
                 $this->makeExtensionArgs() . ' ' .
                 $envs

--- a/src/SPC/builder/linux/LinuxBuilder.php
+++ b/src/SPC/builder/linux/LinuxBuilder.php
@@ -169,7 +169,7 @@ class LinuxBuilder extends BuilderBase
         SourcePatcher::patchBeforeConfigure($this);
 
         $json_74 = $this->getPHPVersionID() < 80000 ? '--enable-json ' : '';
-        $zts = $this->getOption('enable-zts', false) ? '--enable-zts ' : '';
+        $zts = $this->getOption('enable-zts', false) ? '--enable-zts --disable-zend-signals --enable-zend-max-execution-timers ' : '';
 
         shell()->cd(SOURCE_PATH . '/php-src')
             ->exec(

--- a/src/SPC/builder/linux/LinuxBuilder.php
+++ b/src/SPC/builder/linux/LinuxBuilder.php
@@ -169,10 +169,15 @@ class LinuxBuilder extends BuilderBase
         SourcePatcher::patchBeforeConfigure($this);
 
         $phpVersionID = $this->getPHPVersionID();
-
         $json_74 = $phpVersionID < 80000 ? '--enable-json ' : '';
-        $maxExecutionTimers = $this->getOption('enable-zts', false) && $this->getPHPVersionID() > 81000 ? '--enable-zend-max-execution-timers ' : '';
-        $zts = $this->getOption('enable-zts', false) ? '--enable-zts --disable-zend-signals ' : '';
+
+        if ($this->getOption('enable-zts', false)) {
+            $maxExecutionTimers = $phpVersionID >= 80100 ? '--enable-zend-max-execution-timers ' : '';
+            $zts = '--enable-zts --disable-zend-signals ';
+        } else {
+            $maxExecutionTimers = '';
+            $zts = '';
+        }
 
         shell()->cd(SOURCE_PATH . '/php-src')
             ->exec(

--- a/src/SPC/builder/macos/MacOSBuilder.php
+++ b/src/SPC/builder/macos/MacOSBuilder.php
@@ -149,7 +149,7 @@ class MacOSBuilder extends BuilderBase
         SourcePatcher::patchBeforeConfigure($this);
 
         $json_74 = $this->getPHPVersionID() < 80000 ? '--enable-json ' : '';
-        $zts = $this->getOption('enable-zts', false) ? '--enable-zts ' : '';
+        $zts = $this->getOption('enable-zts', false) ? '--enable-zts --disable-zend-signals ' : '';
 
         shell()->cd(SOURCE_PATH . '/php-src')
             ->exec(


### PR DESCRIPTION
* Zend Signals are known to be currently broken with ZTS builds, they should be disabled
* The new Zend Max Execution Timers feature (specially designed for ZTS) fixes timeout support when using ZTS. It is enabled by default for ZTS build starting with PHP 8.3, but must be enabled manually for 8.1+ to preserve ABI compatibility, which isn't an issue here because we're creating a static build.

Related PHP issues:
* https://github.com/php/php-src/issues/9649#issuecomment-1264330874
* https://github.com/php/php-src/pull/5591#issuecomment-650064098
* https://github.com/php/php-src/pull/10141

The official ZTS Docker images also include these flags.