### PR TITLE
fix: use apt-get instead of apt

### DIFF
--- a/src/SPC/doctor/item/LinuxMuslCheck.php
+++ b/src/SPC/doctor/item/LinuxMuslCheck.php
@@ -37,7 +37,7 @@ class LinuxMuslCheck
     public function fixMusl(array $distro): bool
     {
         $install_cmd = match ($distro['dist']) {
-            'ubuntu', 'debian' => 'apt install musl musl-tools -y',
+            'ubuntu', 'debian' => 'apt-get install musl musl-tools -y',
             'alpine' => 'apk add musl musl-utils musl-dev',
             default => throw new RuntimeException('Current linux distro is not supported for auto-install musl packages'),
         };

--- a/src/SPC/doctor/item/LinuxToolCheckList.php
+++ b/src/SPC/doctor/item/LinuxToolCheckList.php
@@ -77,7 +77,7 @@ class LinuxToolCheckList
     public function fixBuildTools(array $distro, array $missing): bool
     {
         $install_cmd = match ($distro['dist']) {
-            'ubuntu', 'debian' => 'apt install -y',
+            'ubuntu', 'debian' => 'apt-get install -y',
             'alpine' => 'apk add',
             default => throw new RuntimeException('Current linux distro is not supported for auto-install musl packages'),
         };


### PR DESCRIPTION
`apt` is not designed to be used in scripts, `apt-get` should be used instead.

This prevents the following warning:

> WARNING: apt does not have a stable CLI interface. Use with caution in scripts.