### PR TITLE
fix: error when source doesn't exist

### DIFF
--- a/src/SPC/store/Downloader.php
+++ b/src/SPC/store/Downloader.php
@@ -253,6 +253,12 @@ class Downloader
             $source = Config::getSource($name);
         }
 
+        if ($source === null) {
+            logger()->warning('Source {name} unknown. Skipping.', ['name' => $name]);
+
+            return;
+        }
+
         // load lock file
         if (!file_exists(DOWNLOAD_PATH . '/.lock.json')) {
             $lock = [];


### PR DESCRIPTION
Currently, the downloader crashes if the source name doesn't exist:

```
[20:12:42] [WARN] PHP Warning: Trying to access array offset on value of type null in /go/static-php-cli/src/SPC/store/Downloader.php on 314
[20:12:42] [ERRO] unknown source type: 
```

This patch prevents the crash and displays a warning instead.