### PR TITLE
fix: setup-runtime portability

### DIFF
--- a/bin/setup-runtime
+++ b/bin/setup-runtime
@@ -52,7 +52,7 @@ china)
 
 esac
 
-if ! command -v curl &> /dev/null && command -v apk &> /dev/null; then
+if ! command -v curl > /dev/null && command -v apk > /dev/null; then
   apk add --no-cache curl
 fi
 


### PR DESCRIPTION
The `&>` syntax doesn't work under some shells (ex: Docker Debian images in sh compatibility mode) and is useless anyway here.