### PR TITLE
fix: ExceptionHandler:: must not be accessed before initialization

### DIFF
--- a/src/SPC/exception/ExceptionHandler.php
+++ b/src/SPC/exception/ExceptionHandler.php
@@ -6,7 +6,7 @@ namespace SPC\exception;
 
 class ExceptionHandler
 {
-    protected mixed $whoops;
+    protected mixed $whoops = null;
 
     private static ?ExceptionHandler $obj = null;
 


### PR DESCRIPTION
Found while working on #142.