### PR TITLE
fix: throw if the PHP version doesn't exist

### DIFF
--- a/src/SPC/store/source/PhpSource.php
+++ b/src/SPC/store/source/PhpSource.php
@@ -35,6 +35,10 @@ class PhpSource extends CustomSourceBase
     {
         // 查找最新的小版本号
         $info = json_decode(Downloader::curlExec(url: "https://www.php.net/releases/index.php?json&version={$major_version}"), true);
+        if (!isset($info['version'])) {
+            throw new DownloaderException("Version {$major_version} not found.");
+        }
+
         $version = $info['version'];
 
         // 从官网直接下载


### PR DESCRIPTION
Prevents errors like that when the PHP version (ex: 8.3). Isn't available:

```
[15:15:44] [WARN] PHP Warning: Undefined array key "version" in /home/runner/work/frankenphp/frankenphp/static-php-cli/src/SPC/store/source/PhpSource.php on 38
curl: (22) The requested URL returned error: 404
[15:15:44] [ERRO] Command run failed with code[22]: curl -sfSL -o "/home/runner/work/frankenphp/frankenphp/static-php-cli/downloads/php-.tar.gz"   "https://www.php.net/distributions/php-.tar.gz"
```