### PR TITLE
fix: linxml build on macOS

### DIFF
--- a/config/lib.json
+++ b/config/lib.json
@@ -279,17 +279,16 @@
             "libxml2"
         ],
         "lib-depends": [
-            "libiconv"
+            "libiconv",
+            "zlib"
         ],
         "lib-suggests": [
             "xz",
-            "zlib",
             "icu"
         ],
         "lib-suggests-windows": [
             "icu",
             "xz",
-            "zlib",
             "pthreads4w"
         ]
     },


### PR DESCRIPTION
On macOS, libxml requires zlib to be built first.