### PR TITLE
feat: add support for libphp and the embed SAPI

### DIFF
--- a/src/SPC/builder/BuilderBase.php
+++ b/src/SPC/builder/BuilderBase.php
@@ -252,6 +252,9 @@ abstract class BuilderBase
         if (($type & BUILD_TARGET_FPM) === BUILD_TARGET_FPM) {
             $ls[] = 'fpm';
         }
+        if (($type & BUILD_TARGET_EMBED) === BUILD_TARGET_EMBED) {
+            $ls[] = 'embed';
+        }
         return implode(', ', $ls);
     }
 

--- a/src/SPC/command/BuildCliCommand.php
+++ b/src/SPC/command/BuildCliCommand.php
@@ -25,7 +25,8 @@ class BuildCliCommand extends BuildCommand
         $this->addOption('build-micro', null, null, 'build micro');
         $this->addOption('build-cli', null, null, 'build cli');
         $this->addOption('build-fpm', null, null, 'build fpm');
-        $this->addOption('build-all', null, null, 'build cli, micro, fpm');
+        $this->addOption('build-embed', null, null, 'build embed');
+        $this->addOption('build-all', null, null, 'build cli, micro, fpm, embed');
         $this->addOption('no-strip', null, null, 'build without strip, in order to debug and load external extensions');
         $this->addOption('enable-zts', null, null, 'enable ZTS support');
         $this->addOption('with-hardcoded-ini', 'I', InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Patch PHP source code, inject hardcoded INI');
@@ -43,13 +44,15 @@ class BuildCliCommand extends BuildCommand
         $rule = $rule | ($this->getOption('build-cli') ? BUILD_TARGET_CLI : BUILD_TARGET_NONE);
         $rule = $rule | ($this->getOption('build-micro') ? BUILD_TARGET_MICRO : BUILD_TARGET_NONE);
         $rule = $rule | ($this->getOption('build-fpm') ? BUILD_TARGET_FPM : BUILD_TARGET_NONE);
+        $rule = $rule | ($this->getOption('build-embed') ? BUILD_TARGET_EMBED : BUILD_TARGET_NONE);
         $rule = $rule | ($this->getOption('build-all') ? BUILD_TARGET_ALL : BUILD_TARGET_NONE);
         if ($rule === BUILD_TARGET_NONE) {
             $this->output->writeln('<error>Please add at least one build target!</error>');
             $this->output->writeln("<comment>\t--build-cli\tBuild php-cli SAPI</comment>");
             $this->output->writeln("<comment>\t--build-micro\tBuild phpmicro SAPI</comment>");
             $this->output->writeln("<comment>\t--build-fpm\tBuild php-fpm SAPI</comment>");
-            $this->output->writeln("<comment>\t--build-all\tBuild all SAPI: cli, micro, fpm</comment>");
+            $this->output->writeln("<comment>\t--build-embed\tBuild embed SAPI/libphp</comment>");
+            $this->output->writeln("<comment>\t--build-all\tBuild all SAPI: cli, micro, fpm, embed</comment>");
             return static::FAILURE;
         }
         try {

--- a/src/globals/defines.php
+++ b/src/globals/defines.php
@@ -43,7 +43,8 @@ const BUILD_TARGET_NONE = 0;    // no target
 const BUILD_TARGET_CLI = 1;     // build cli
 const BUILD_TARGET_MICRO = 2;   // build micro
 const BUILD_TARGET_FPM = 4;     // build fpm
-const BUILD_TARGET_ALL = 7;     // build all
+const BUILD_TARGET_EMBED = 8;   // build embed
+const BUILD_TARGET_ALL = 15;    // build all
 
 // doctor error fix policy
 const FIX_POLICY_DIE = 1;       // die directly


### PR DESCRIPTION
This patch enables the creation of static `libphp` builds thanks to a new `--with-embed` flag.

`libphp` can be used to create static programs using [the embed SAPI](https://github.com/php/php-src/tree/master/sapi/embed) as well as programs using other SAPIs such as [FrankenPHP](https://frankenphp.dev) (the reason why I'm working on this: https://github.com/dunglas/frankenphp/pull/198), NGINX Unit and various other projects.

## Downloads

Currently, I have not updated GitHub Actions workflows to build `libphp`, however, this could be interesting to distribute a pre-compiled version of `libphp` to speed up builds of FrankenPHP and of other projects depending on it. This will require to zip the `buildroot/` directory, or at least all the `.a` libraries and the headers.

This can be done in a subsequent PR if relevant.

## Known issue on macOS

The static library works perfectly well on Linux, but only a limited subset of extensions are currently supported on macOS. Basically, all extensions that depend on third-party static libraries (e.g. curl or pdo_sqlite) fail to be built properly.

Building `libphp.a` works but a weird linking error occurs when linking it with the final program (in my case, FrankenPHP):

> ld: warning: ignoring file /static-php-cli/buildroot/lib/libphp.a, building for macOS-arm64 but attempting to link with file built for macOS-arm64

This may be related [to the linker used to build .`a` libraries (the GNU linker must not be used) or to the use of the `-mmacosx-version-min` flag](https://developer.apple.com/forums/thread/694062), but I didn't manage to find the exact reason yet. If anyone with Apple-specific knowledge has a better clue of what's going on, I would be happy to get some help!