### PR TITLE
fix: curl dependency on openssl

### DIFF
--- a/config/lib.json
+++ b/config/lib.json
@@ -42,14 +42,14 @@
             "curl"
         ],
         "lib-depends-unix": [
+            "openssl",
             "zlib"
         ],
         "lib-suggests": [
             "libssh2",
             "brotli",
             "nghttp2",
-            "zstd",
-            "openssl"
+            "zstd"
         ],
         "lib-suggests-windows": [
             "zlib",


### PR DESCRIPTION
Without that, the build fails, at least on macOS.