### PR TITLE
Add snappy extension

### DIFF
--- a/config/ext.json
+++ b/config/ext.json
@@ -328,6 +328,7 @@
     "snappy": {
         "type": "external",
         "source": "ext-snappy",
+        "cpp-extension": true,
         "arg-type": "custom",
         "lib-depends": [
             "snappy"

--- a/config/ext.json
+++ b/config/ext.json
@@ -325,6 +325,17 @@
             "libxml2"
         ]
     },
+    "snappy": {
+        "type": "external",
+        "source": "ext-snappy",
+        "arg-type": "custom",
+        "lib-depends": [
+            "snappy"
+        ],
+        "ext-suggest": [
+            "apcu"
+        ]
+    },
     "snmp": {
         "type": "builtin",
         "arg-type": "with",

--- a/config/lib.json
+++ b/config/lib.json
@@ -522,6 +522,9 @@
             "snappy.h",
             "snappy-stubs-internal.h",
             "snappy-stubs-public.h"
+        ],
+        "lib-depends": [
+            "zlib"
         ]
     }
 }

--- a/config/lib.json
+++ b/config/lib.json
@@ -510,5 +510,18 @@
             "zstd.h",
             "zstd_errors.h"
         ]
+    },
+    "snappy": {
+        "source": "snappy",
+        "static-libs-unix": [
+            "libsnappy.a"
+        ],
+        "headers-unix": [
+            "snappy-c.h",
+            "snappy-sinksource.h",
+            "snappy.h",
+            "snappy-stubs-internal.h",
+            "snappy-stubs-public.h"
+        ]
     }
 }

--- a/config/lib.json
+++ b/config/lib.json
@@ -445,6 +445,22 @@
             "ncurses"
         ]
     },
+    "snappy": {
+        "source": "snappy",
+        "static-libs-unix": [
+            "libsnappy.a"
+        ],
+        "headers-unix": [
+            "snappy-c.h",
+            "snappy-sinksource.h",
+            "snappy.h",
+            "snappy-stubs-internal.h",
+            "snappy-stubs-public.h"
+        ],
+        "lib-depends": [
+            "zlib"
+        ]
+    },
     "sqlite": {
         "source": "sqlite",
         "static-libs-unix": [
@@ -509,22 +525,6 @@
         "headers-windows": [
             "zstd.h",
             "zstd_errors.h"
-        ]
-    },
-    "snappy": {
-        "source": "snappy",
-        "static-libs-unix": [
-            "libsnappy.a"
-        ],
-        "headers-unix": [
-            "snappy-c.h",
-            "snappy-sinksource.h",
-            "snappy.h",
-            "snappy-stubs-internal.h",
-            "snappy-stubs-public.h"
-        ],
-        "lib-depends": [
-            "zlib"
         ]
     }
 }

--- a/config/source.json
+++ b/config/source.json
@@ -80,6 +80,16 @@
             "path": "LICENSE"
         }
     },
+    "ext-snappy": {
+        "type": "git",
+        "path": "php-src/ext/snappy",
+        "rev": "master",
+        "url": "https://github.com/kjdev/php-ext-snappy",
+        "license": {
+            "type": "file",
+            "path": "LICENSE"
+        }
+    },
     "ext-ssh2": {
         "type": "url",
         "url": "https://pecl.php.net/get/ssh2",
@@ -396,6 +406,16 @@
         "path": "php-src/ext/redis",
         "rev": "5.3.7",
         "url": "https://github.com/phpredis/phpredis",
+        "license": {
+            "type": "file",
+            "path": "COPYING"
+        }
+    },
+    "snappy": {
+        "type": "git",
+        "repo": "google/snappy",
+        "rev": "main",
+        "url": "https://github.com/google/snappy",
         "license": {
             "type": "file",
             "path": "COPYING"

--- a/src/SPC/builder/extension/snappy.php
+++ b/src/SPC/builder/extension/snappy.php
@@ -21,7 +21,7 @@ class snappy extends Extension
         FileSystem::replaceFileRegex(
             SOURCE_PATH . '/php-src/configure',
             '/-lsnappy/',
-            $this->getLibFilesString() . $this->builder instanceof MacOSBuilder ? ' -lc++' : ' -lstdc++'
+            $this->getLibFilesString() . ($this->builder instanceof MacOSBuilder ? ' -lc++' : ' -lstdc++')
         );
         return true;
     }

--- a/src/SPC/builder/extension/snappy.php
+++ b/src/SPC/builder/extension/snappy.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\extension;
+
+use SPC\builder\Extension;
+use SPC\util\CustomExt;
+
+#[CustomExt('snappy')]
+class snappy extends Extension
+{
+    public function getUnixConfigureArg(): string
+    {
+        return '--enable-snappy --with-snappy-includedir="' . BUILD_ROOT_PATH . '"';
+    }
+}

--- a/src/SPC/builder/extension/snappy.php
+++ b/src/SPC/builder/extension/snappy.php
@@ -5,11 +5,27 @@ declare(strict_types=1);
 namespace SPC\builder\extension;
 
 use SPC\builder\Extension;
+use SPC\builder\macos\MacOSBuilder;
+use SPC\exception\FileSystemException;
+use SPC\store\FileSystem;
 use SPC\util\CustomExt;
 
 #[CustomExt('snappy')]
 class snappy extends Extension
 {
+    /**
+     * @throws FileSystemException
+     */
+    public function patchBeforeConfigure(): bool
+    {
+        FileSystem::replaceFileRegex(
+            SOURCE_PATH . '/php-src/configure',
+            '/-lsnappy/',
+            $this->getLibFilesString() . $this->builder instanceof MacOSBuilder ? ' -lc++' : ' -lstdc++'
+        );
+        return true;
+    }
+
     public function getUnixConfigureArg(): string
     {
         return '--enable-snappy --with-snappy-includedir="' . BUILD_ROOT_PATH . '"';

--- a/src/SPC/builder/linux/library/snappy.php
+++ b/src/SPC/builder/linux/library/snappy.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\linux\library;
+
+class snappy extends LinuxLibraryBase
+{
+    use \SPC\builder\unix\library\snappy;
+
+    public const NAME = 'snappy';
+}

--- a/src/SPC/builder/macos/library/snappy.php
+++ b/src/SPC/builder/macos/library/snappy.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\macos\library;
+
+class snappy extends MacOSLibraryBase
+{
+    use \SPC\builder\unix\library\snappy;
+
+    public const NAME = 'snappy';
+}

--- a/src/SPC/builder/unix/library/snappy.php
+++ b/src/SPC/builder/unix/library/snappy.php
@@ -21,12 +21,14 @@ trait snappy
         shell()->cd($this->source_dir . '/cmake/build')
             ->exec(
                 "{$this->builder->configure_env} cmake " .
-                "{$this->builder->makeCmakeArgs()} " .
+                "-DCMAKE_TOOLCHAIN_FILE={$this->builder->cmake_toolchain_file} " .
+                '-DCMAKE_BUILD_TYPE=Release ' .
+                '-DCMAKE_INSTALL_PREFIX=' . escapeshellarg(BUILD_ROOT_PATH) . ' ' .
                 '-DSNAPPY_BUILD_TESTS=OFF ' .
                 '-DSNAPPY_BUILD_BENCHMARKS=OFF ' .
                 '../..'
             )
             ->exec("cmake --build . -j {$this->builder->concurrency}")
-            ->exec('make install DESTDIR=' . BUILD_ROOT_PATH);
+            ->exec('make install');
     }
 }

--- a/src/SPC/builder/unix/library/snappy.php
+++ b/src/SPC/builder/unix/library/snappy.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\unix\library;
+
+use SPC\exception\FileSystemException;
+use SPC\exception\RuntimeException;
+use SPC\store\FileSystem;
+
+trait snappy
+{
+    /**
+     * @throws RuntimeException
+     * @throws FileSystemException
+     */
+    protected function build(): void
+    {
+        FileSystem::resetDir($this->source_dir . '/cmake/build');
+
+        shell()->cd($this->source_dir . '/cmake/build')
+            ->exec(
+                "{$this->builder->configure_env} cmake " .
+                "{$this->builder->makeCmakeArgs()} " .
+                '-DSNAPPY_BUILD_TESTS=OFF ' .
+                '-DSNAPPY_BUILD_BENCHMARKS=OFF ' .
+                '../..'
+            )
+            ->exec("cmake --build . -j {$this->builder->concurrency}")
+            ->exec('make install DESTDIR=' . BUILD_ROOT_PATH);
+    }
+}


### PR DESCRIPTION
This PR tries to introduce a new PHP extension: https://github.com/kjdev/php-ext-snappy for http://google.github.io/snappy/

Currently, I have a problem with linking the library with an extension (the bundled one is older and is not compiling at all on OSX).

---
Latest library linking error:

<details>
<code>
Configuring extensions
checking for io.h... no
checking for strtoll... yes
checking for atoll... yes
checking whether to build with LIBXML support... no
checking for OpenSSL support... no
checking for Kerberos support... no
checking whether to use system default cipher list instead of hardcoded value... no
checking for PCRE library to use... bundled
checking whether to enable PCRE JIT functionality... yes
checking whether Intel CET is enabled... no
checking whether to enable the SQLite3 extension... no
checking for ZLIB support... no
checking whether to enable bc style precision math functions... no
checking for BZip2 support... no
checking whether to enable calendar conversion support... no
checking whether to enable ctype functions... no
checking for cURL support... no
checking for QDBM support... no
checking for GDBM support... no
checking for NDBM support... no
checking for TCADB support... no
checking for LMDB support... no
checking for Berkeley DB4 support... no
checking for Berkeley DB3 support... no
checking for Berkeley DB2 support... no
checking for DBMaker support... no
checking for any ODBC driver support... no
checking whether to enable Zend OPcache support... no
checking whether to enable copying PHP CODE pages into HUGE PAGES... yes
checking whether to enable JIT... yes
checking whether to enable pcntl support... no
checking whether to enable PDO support... no
checking for PDO_DBLIB support via FreeTDS... no
checking for Firebird support for PDO... no
checking for MySQL support for PDO... no
checking for the location of libz... no
checking Oracle OCI support for PDO... no
checking for ODBC v3 support for PDO... no
checking for PostgreSQL support for PDO... no
checking for sqlite 3 support for PDO... no
checking for PostgreSQL support... no
checking for phar archive support... no
checking whether to enable POSIX-like functions... no
checking for PSPELL support... no
checking whether arc4random_buf is declared... yes
checking for CommonCrypto/CommonRandom.h... yes
checking for libedit readline replacement... no
checking for readline support... no
checking whether to enable PHP sessions... no
checking for mm support... no
checking whether to enable shmop support... no
checking whether to enable SimpleXML support... no
checking PHP version... 8.2.10
checking whether to enable snappy support... yes
checking for snappy header... /Users/runner/work/static-php-cli/static-php-cli/buildroot/lib
checking searching for libsnappy... found in /Users/runner/work/static-php-cli/static-php-cli/buildroot/lib
checking for snappy_compress in -lsnappy... no
configure: error: could not find usable libsnappy
[13:56:10] [ERRO] Uncaught SPC\exception\RuntimeException: Command run failed with code[1]: cd '/Users/runner/work/static-php-cli/static-php-cli/source/php-src' && ./configure --prefix= --with-valgrind=no --enable-shared=no --enable-static=yes CFLAGS='--target=x86_64-apple-darwin -Werror=unknown-warning-option' --disable-all --disable-cgi --disable-phpdbg --enable-cli --enable-fpm --enable-micro --enable-snappy --with-snappy-includedir="/Users/runner/work/static-php-cli/static-php-cli/buildroot/lib" PKG_CONFIG='/Users/runner/work/static-php-cli/static-php-cli/buildroot/bin/pkg-config' PKG_CONFIG_PATH='/Users/runner/work/static-php-cli/static-php-cli/buildroot/lib/pkgconfig/' CC='clang' CXX='clang++' CFLAGS='--target=x86_64-apple-darwin -Wimplicit-function-declaration -Os' PATH='/Users/runner/work/static-php-cli/static-php-cli/buildroot/bin:/usr/local/lib/ruby/gems/3.0.0/bin:/usr/local/opt/ruby@3.0/bin:/usr/local/opt/pipx_bin:/Users/runner/.cargo/bin:/usr/local/opt/curl/bin:/usr/local/bin:/usr/local/sbin:/Users/runner/bin:/Users/runner/.yarn/bin:/Users/runner/Library/Android/sdk/tools:/Users/runner/Library/Android/sdk/platform-tools:/Library/Frameworks/Python.framework/Versions/Current/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/usr/bin:/bin:/usr/sbin:/sbin:/Users/runner/.dotnet/tools:/Users/runner/.ghcup/bin:/Users/runner/hostedtoolcache/stack/2.11.1/x64' at /Users/runner/work/static-php-cli/static-php-cli/src/globals/functions.php(88)
[13:56:10] [ERRO] #0 /Users/runner/work/static-php-cli/static-php-cli/src/SPC/util/UnixShell.php(44): f_passthru('cd '/Users/runn...')
#1 /Users/runner/work/static-php-cli/static-php-cli/src/SPC/builder/macos/MacOSBuilder.php(155): SPC\util\UnixShell->exec('cd '/Users/runn...')
#2 /Users/runner/work/static-php-cli/static-php-cli/src/SPC/command/BuildCliCommand.php(87): SPC\builder\macos\MacOSBuilder->buildPHP(1)
#3 /Users/runner/work/static-php-cli/static-php-cli/src/SPC/command/BaseCommand.php(83): SPC\command\BuildCliCommand->handle()
#4 /Users/runner/work/static-php-cli/static-php-cli/vendor/symfony/console/Command/Command.php(326): SPC\command\BaseCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#5 /Users/runner/work/static-php-cli/static-php-cli/vendor/symfony/console/Application.php(1063): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#6 /Users/runner/work/static-php-cli/static-php-cli/vendor/symfony/console/Application.php(320): Symfony\Component\Console\Application->doRunCommand(Object(SPC\command\BuildCliCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#7 /Users/runner/work/static-php-cli/static-php-cli/vendor/symfony/console/Application.php(174): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#8 /Users/runner/work/static-php-cli/static-php-cli/bin/spc(15): Symfony\Component\Console\Application->run()
#9 {main}
</code>
</details>

Bundled library error:
<details>
<code>
In file included from /Users/runner/work/static-php-cli/static-php-cli/source/php-src/ext/snappy/snappy/snappy.cc:31:
/Users/runner/work/static-php-cli/static-php-cli/source/php-src/ext/snappy/snappy/snappy.h:212:10: error: unknown type name 'constexpr'
  static constexpr int kBlockLog = 16;
         ^
/Users/runner/work/static-php-cli/static-php-cli/source/php-src/ext/snappy/snappy/snappy.h:213:10: error: unknown type name 'constexpr'
  static constexpr size_t kBlockSize = 1 << kBlockLog;
         ^
/Users/runner/work/static-php-cli/static-php-cli/source/php-src/ext/snappy/snappy/snappy.h:213:26: error: expected ';' after top level declarator
  static constexpr size_t kBlockSize = 1 << kBlockLog;
                         ^
                         ;
/Users/runner/work/static-php-cli/static-php-cli/source/php-src/ext/snappy/snappy/snappy.h:215:10: error: unknown type name 'constexpr'
  static constexpr int kMinHashTableBits = 8;
         ^
/Users/runner/work/static-php-cli/static-php-cli/source/php-src/ext/snappy/snappy/snappy.h:216:10: error: unknown type name 'constexpr'
  static constexpr size_t kMinHashTableSize = 1 << kMinHashTableBits;
         ^
/Users/runner/work/static-php-cli/static-php-cli/source/php-src/ext/snappy/snappy/snappy.h:216:26: error: expected ';' after top level declarator
  static constexpr size_t kMinHashTableSize = 1 << kMinHashTableBits;
                         ^
                         ;
/Users/runner/work/static-php-cli/static-php-cli/source/php-src/ext/snappy/snappy/snappy.h:218:10: error: unknown type name 'constexpr'
  static constexpr int kMaxHashTableBits = 14;
         ^
/Users/runner/work/static-php-cli/static-php-cli/source/php-src/ext/snappy/snappy/snappy.h:219:10: error: unknown type name 'constexpr'
  static constexpr size_t kMaxHashTableSize = 1 << kMaxHashTableBits;
         ^
/Users/runner/work/static-php-cli/static-php-cli/source/php-src/ext/snappy/snappy/snappy.h:219:26: error: expected ';' after top level declarator
  static constexpr size_t kMaxHashTableSize = 1 << kMaxHashTableBits;
                         ^
                         ;
/Users/runner/work/static-php-cli/static-php-cli/source/php-src/ext/snappy/snappy/snappy.cc:92:1: error: unknown type name 'constexpr'
constexpr int kSlopBytes = 64;
^
/Users/runner/work/static-php-cli/static-php-cli/source/php-src/ext/snappy/snappy/snappy.cc:94:17: error: no member named 'char_table' in namespace 'snappy::internal'
using internal::char_table;
      ~~~~~~~~~~^
/Users/runner/work/static-php-cli/static-php-cli/source/php-src/ext/snappy/snappy/snappy.cc:120:8: error: unknown type name 'constexpr'
inline constexpr int16_t MakeEntry(int16_t len, int16_t offset) {
       ^
/Users/runner/work/static-php-cli/static-php-cli/source/php-src/ext/snappy/snappy/snappy.cc:120:1: warning: inline variables are a C++17 extension [-Wc++17-extensions]
inline constexpr int16_t MakeEntry(int16_t len, int16_t offset) {
^
/Users/runner/work/static-php-cli/static-php-cli/source/php-src/ext/snappy/snappy/snappy.cc:120:25: error: expected ';' after top level declarator
inline constexpr int16_t MakeEntry(int16_t len, int16_t offset) {
                        ^
                        ;
/Users/runner/work/static-php-cli/static-php-cli/source/php-src/ext/snappy/snappy/snappy.cc:139:26: error: unknown type name 'size_t'
template <std::size_t N, size_t... Is>
                         ^
/Users/runner/work/static-php-cli/static-php-cli/source/php-src/ext/snappy/snappy/snappy.cc:139:32: warning: variadic templates are a C++11 extension [-Wc++11-extensions]
template <std::size_t N, size_t... Is>
                               ^
/Users/runner/work/static-php-cli/static-php-cli/source/php-src/ext/snappy/snappy/snappy.cc:142:11: error: unknown type name 'size_t'
template <size_t... Is>
          ^
/Users/runner/work/static-php-cli/static-php-cli/source/php-src/ext/snappy/snappy/snappy.cc:142:17: warning: variadic templates are a C++11 extension [-Wc++11-extensions]
template <size_t... Is>
                ^
/Users/runner/work/static-php-cli/static-php-cli/source/php-src/ext/snappy/snappy/snappy.cc:143:40: error: no template named 'index_sequence'
struct make_index_sequence<0, Is...> : index_sequence<Is...> {};
                                       ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
12 warnings and 20 errors generated.
make: *** [ext/snappy/snappy/snappy.lo] Error 1
[14:08:00] [ERRO] Uncaught SPC\exception\RuntimeException: Command run failed with code[2]: cd '/Users/runner/work/static-php-cli/static-php-cli/source/php-src' && make -j3 EXTRA_CFLAGS='-g -Os' EXTRA_LIBS='-lc++   -lresolv' cli at /Users/runner/work/static-php-cli/static-php-cli/src/globals/functions.php(88)
[14:08:00] [ERRO] #0 /Users/runner/work/static-php-cli/static-php-cli/src/SPC/util/UnixShell.php(44): f_passthru('cd '/Users/runn...')
</code>
</details>