### PR TITLE
Allow setting multiple license in extensions, libraries & sources, introduce phpunit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,11 +17,15 @@ composer.lock
 # default source build root directory
 /buildroot/
 
-# php cs fixer cache file
+# tools cache files
 .php-cs-fixer.cache
+.phpunit.result.cache
 
 # exclude self-runtime
 /bin/*
 !/bin/spc
 !/bin/setup-runtime
 !/bin/spc-alpine-docker
+
+# default test directory
+/tests/var/

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -65,5 +65,5 @@ return (new PhpCsFixer\Config())
         'phpdoc_var_without_name' => false,
     ])
     ->setFinder(
-        PhpCsFixer\Finder::create()->in(__DIR__ . '/src')
+        PhpCsFixer\Finder::create()->in([__DIR__ . '/src', __DIR__ . '/tests/SPC'])
     );

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,12 @@
         "zhamao/logger": "^1.0"
     },
     "require-dev": {
-        "nunomaduro/collision": "*",
-        "friendsofphp/php-cs-fixer": "^3.2 != 3.7.0",
-        "phpstan/phpstan": "^1.1",
         "captainhook/captainhook": "^5.10",
-        "captainhook/plugin-composer": "^5.3"
+        "captainhook/plugin-composer": "^5.3",
+        "friendsofphp/php-cs-fixer": "^3.2 != 3.7.0",
+        "nunomaduro/collision": "*",
+        "phpstan/phpstan": "^1.1",
+        "phpunit/phpunit": "^10.3"
     },
     "autoload": {
         "psr-4": {
@@ -32,13 +33,18 @@
             "src/globals/functions.php"
         ]
     },
+    "autoload-dev": {
+        "psr-4": {
+            "SPC\\Tests\\": "tests/SPC"
+        }
+    },
     "bin": [
         "bin/spc"
     ],
     "scripts": {
         "analyse": "phpstan analyse --memory-limit 300M",
         "cs-fix": "php-cs-fixer fix",
-        "test": "bin/phpunit --no-coverage"
+        "test": "vendor/bin/phpunit tests/ --no-coverage"
     },
     "config": {
         "allow-plugins": {

--- a/tests/SPC/util/LicenseDumperTest.php
+++ b/tests/SPC/util/LicenseDumperTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\Tests\util;
+
+use PHPUnit\Framework\TestCase;
+use SPC\store\Config;
+use SPC\util\LicenseDumper;
+
+/**
+ * @internal
+ */
+final class LicenseDumperTest extends TestCase
+{
+    private const DIRECTORY = '../../var/license-dump';
+
+    protected function setUp(): void
+    {
+        @rmdir(self::DIRECTORY);
+    }
+
+    protected function tearDown(): void
+    {
+        array_map('unlink', glob(self::DIRECTORY . '/*.txt'));
+    }
+
+    public function testDumpWithSingleLicense(): void
+    {
+        Config::$lib = [
+            'fake_lib' => [
+                'source' => 'fake_lib',
+            ],
+        ];
+        Config::$source = [
+            'fake_lib' => [
+                'license' => [
+                    'type' => 'text',
+                    'text' => 'license',
+                ],
+            ],
+        ];
+
+        $dumper = new LicenseDumper();
+        $dumper->addLibs(['fake_lib']);
+        $dumper->dump(self::DIRECTORY);
+
+        $this->assertFileExists(self::DIRECTORY . '/lib_fake_lib_0.txt');
+    }
+
+    public function testDumpWithMultipleLicenses(): void
+    {
+        Config::$lib = [
+            'fake_lib' => [
+                'source' => 'fake_lib',
+            ],
+        ];
+        Config::$source = [
+            'fake_lib' => [
+                'license' => [
+                    [
+                        'type' => 'text',
+                        'text' => 'license',
+                    ],
+                    [
+                        'type' => 'text',
+                        'text' => 'license',
+                    ],
+                ],
+            ],
+        ];
+
+        $dumper = new LicenseDumper();
+        $dumper->addLibs(['fake_lib']);
+        $dumper->dump(self::DIRECTORY);
+
+        $this->assertFileExists(self::DIRECTORY . '/lib_fake_lib_0.txt');
+        $this->assertFileExists(self::DIRECTORY . '/lib_fake_lib_1.txt');
+    }
+}


### PR DESCRIPTION
Fixes #110

Example:
```
stloyd@MacBook-Pro-2 static-php-cli % ls -l buildroot/license            
total 16
-rw-r--r--  1 stloyd  staff  1549 Sep  4 14:14 lib_zstd_0.txt
-rw-r--r--  1 stloyd  staff  1549 Sep  4 14:14 lib_zstd_1.txt
```