### PR TITLE
Rework doctor command

### DIFF
--- a/src/SPC/doctor/CheckListHandler.php
+++ b/src/SPC/doctor/CheckListHandler.php
@@ -7,105 +7,62 @@ namespace SPC\doctor;
 use SPC\exception\FileSystemException;
 use SPC\exception\RuntimeException;
 use SPC\store\FileSystem;
-use Symfony\Component\Console\Helper\QuestionHelper;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
 
-class CheckListHandler
+final class CheckListHandler
 {
     /** @var AsCheckItem[] */
     private array $check_list = [];
 
     private array $fix_map = [];
 
+    public function __construct() {}
+
     /**
+     * @return array<AsCheckItem>
      * @throws \ReflectionException
+     * @throws RuntimeException
      * @throws FileSystemException
-     * @throws RuntimeException
      */
-    public function __construct(private readonly InputInterface $input, private readonly OutputInterface $output, bool $include_manual = false)
+    public function runChecks(bool $include_manual = false): array
     {
-        $this->loadCheckList($include_manual);
+        return $this->loadCheckList($include_manual);
     }
 
     /**
      * @throws RuntimeException
      */
-    public function runSingleCheck(string $item_name, int $fix_policy = FIX_POLICY_DIE): void
+    public function emitFix(OutputInterface $output, CheckResult $result): void
     {
-        foreach ($this->check_list as $item) {
-            if ($item->item_name === $item_name) {
-                $this->check_list = [$item];
-                break;
-            }
-        }
-        $this->runCheck($fix_policy);
-    }
+        pcntl_signal(SIGINT, function () use ($output) {
+            $output->writeln('<error>You cancelled fix</error>');
+        });
 
-    /**
-     * @throws RuntimeException
-     */
-    public function runCheck(int $fix_policy = FIX_POLICY_DIE): void
-    {
-        foreach ($this->check_list as $item) {
-            if ($item->limit_os !== null && $item->limit_os !== PHP_OS_FAMILY) {
-                continue;
-            }
-            $this->output->write('Checking <comment>' . $item->item_name . '</comment> ... ');
-            $result = call_user_func($item->callback);
-            if ($result === null) {
-                $this->output->writeln('skipped');
-            } elseif ($result instanceof CheckResult) {
-                if ($result->isOK()) {
-                    $this->output->writeln($result->getMessage() ?? 'ok');
-                    continue;
-                }
-                // Failed
-                $this->output->writeln('<error>' . $result->getMessage() . '</error>');
-                switch ($fix_policy) {
-                    case FIX_POLICY_DIE:
-                        throw new RuntimeException('Some check items can not be fixed !');
-                    case FIX_POLICY_PROMPT:
-                        if ($result->getFixItem() !== '') {
-                            $helper = new QuestionHelper();
-                            $question = new ConfirmationQuestion('Do you want to fix it? [Y/n] ', true);
-                            if ($helper->ask($this->input, $this->output, $question)) {
-                                $this->emitFix($result);
-                            } else {
-                                throw new RuntimeException('You cancelled fix');
-                            }
-                        } else {
-                            throw new RuntimeException('Some check items can not be fixed !');
-                        }
-                        break;
-                    case FIX_POLICY_AUTOFIX:
-                        if ($result->getFixItem() !== '') {
-                            $this->output->writeln('Automatically fixing ' . $result->getFixItem() . ' ...');
-                            $this->emitFix($result);
-                        } else {
-                            throw new RuntimeException('Some check items can not be fixed !');
-                        }
-                        break;
-                }
-            }
+        $fix_result = call_user_func($this->fix_map[$result->getFixItem()], ...$result->getFixParams());
+        pcntl_signal(SIGINT, SIG_IGN);
+
+        if ($fix_result) {
+            $output->writeln('<info>Fix done</info>');
+        } else {
+            $output->writeln('<error>Fix failed</error>');
+            throw new RuntimeException('Some check item are not fixed');
         }
     }
 
     /**
      * Load Doctor check item list
      *
+     * @return array<AsCheckItem>
      * @throws \ReflectionException
      * @throws RuntimeException
      * @throws FileSystemException
      */
-    private function loadCheckList(bool $include_manual = false): void
+    private function loadCheckList(bool $include_manual = false): array
     {
         foreach (FileSystem::getClassesPsr4(__DIR__ . '/item', 'SPC\\doctor\\item') as $class) {
             $ref = new \ReflectionClass($class);
             foreach ($ref->getMethods() as $method) {
-                $attr = $method->getAttributes();
-                foreach ($attr as $a) {
+                foreach ($method->getAttributes() as $a) {
                     if (is_a($a->getName(), AsCheckItem::class, true)) {
                         /** @var AsCheckItem $instance */
                         $instance = $a->newInstance();
@@ -126,26 +83,10 @@ class CheckListHandler
                 }
             }
         }
-        // sort check list by level
-        usort($this->check_list, fn ($a, $b) => $a->level > $b->level ? -1 : ($a->level == $b->level ? 0 : 1));
-    }
 
-    /**
-     * @throws RuntimeException
-     */
-    private function emitFix(CheckResult $result): void
-    {
-        pcntl_signal(SIGINT, function () {
-            $this->output->writeln('<error>You cancelled fix</error>');
-        });
-        $fix = $this->fix_map[$result->getFixItem()];
-        $fix_result = call_user_func($fix, ...$result->getFixParams());
-        pcntl_signal(SIGINT, SIG_IGN);
-        if ($fix_result) {
-            $this->output->writeln('<info>Fix done</info>');
-        } else {
-            $this->output->writeln('<error>Fix failed</error>');
-            throw new RuntimeException('Some check item are not fixed');
-        }
+        // sort check list by level
+        usort($this->check_list, fn (AsCheckItem $a, AsCheckItem $b) => $a->level > $b->level ? -1 : ($a->level == $b->level ? 0 : 1));
+
+        return $this->check_list;
     }
 }

--- a/tests/SPC/doctor/CheckListHandlerTest.php
+++ b/tests/SPC/doctor/CheckListHandlerTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\Tests\doctor;
+
+use PHPUnit\Framework\TestCase;
+use SPC\doctor\CheckListHandler;
+
+/**
+ * @internal
+ */
+final class CheckListHandlerTest extends TestCase
+{
+    public function testRunChecksReturnsListOfCheck(): void
+    {
+        $list = new CheckListHandler();
+
+        $this->assertCount(6, $list->runChecks());
+    }
+}


### PR DESCRIPTION
The execution class should not contain command-related stuff (there is still an output call, but it may we reworked later on).

```shell
stloyd@MacBook-Pro-2 static-php-cli % bin/spc doctor
     _        _   _                 _           
 ___| |_ __ _| |_(_) ___      _ __ | |__  _ __  
/ __| __/ _` | __| |/ __|____| '_ \| '_ \| '_ \ 
\__ \ || (_| | |_| | (_|_____| |_) | | | | |_) |
|___/\__\__,_|\__|_|\___|    | .__/|_| |_| .__/   v2.0-rc6
                             |_|         |_|    
Checking if current OS are supported ... Darwin x86_64, supported
Checking if homebrew has installed ... ok
Checking if necessary tools are installed ... ok
Doctor check complete !
```