### PR TITLE
Explicitly define application commands

### DIFF
--- a/src/SPC/command/DeployCommand.php
+++ b/src/SPC/command/DeployCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Input\InputOption;
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\text;
 
-#[AsCommand('deploy', 'Deploy static-php-cli self to an .phar application')]
+#[AsCommand('deploy', 'Deploy static-php-cli self to an .phar application', [], true)]
 class DeployCommand extends BaseCommand
 {
     public function configure(): void

--- a/src/SPC/command/dev/SortConfigCommand.php
+++ b/src/SPC/command/dev/SortConfigCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Input\InputArgument;
 /**
  * Modify config file: sort lib, ext, source by name.
  */
-#[AsCommand('dev:sort-config', 'After config edited, sort it by alphabet', ['sort-config'])]
+#[AsCommand('dev:sort-config', 'After config edited, sort it by alphabet', ['sort-config'], true)]
 class SortConfigCommand extends BaseCommand
 {
     public function configure(): void


### PR DESCRIPTION
IMO it's easier to maintain when we have an explicit list of commands, it also allows us to remove hacks with reflection, etc.

To make it easier I have marked the `deploy` & `sort-config` commands as hidden, so those are still not officially visible:
```shell
stloyd@MacBook-Pro-2 static-php-cli % ./spc list
static-php-cli 2.0-rc6

Usage:
  command [options] [arguments]

Options:
  -h, --help            Display help for the given command. When no command is given display help for the list command
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
  -n, --no-interaction  Do not ask any interactive question
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Available commands:
  build            build CLI binary
  doctor           Diagnose whether the current environment can compile normally
  download         [fetch] Download required sources
  dump-license     Dump licenses for required libraries
  extract          Extract required sources
  help             Display help for a command
  list             List commands
 build
  build:libs       Build dependencies
 dev
  dev:extensions   [list-ext] Helper command that lists available extension details
  dev:php-version  [dev:php-ver] Returns version of PHP located source directory
 micro
  micro:combine    Combine micro.sfx and php code together
```