### PR TITLE
Replace file based extension tests with inline ones

### DIFF
--- a/config/ext.json
+++ b/config/ext.json
@@ -4,17 +4,30 @@
         "source": "apcu"
     },
     "bcmath": {
-        "type": "builtin"
+        "type": "builtin",
+        "test": [
+            "assert(function_exists('bcscale'));"
+        ]
     },
     "bz2": {
         "type": "builtin",
         "arg-type": "with-prefix",
         "lib-depends": [
             "bzip2"
+        ],
+        "test": [
+            "$str = 'This is bz2 extension test';",
+            "assert(function_exists('bzdecompress'));",
+            "assert(function_exists('bzcompress'));",
+            "assert(bzdecompress(bzcompress($str, 9)) === $str);"
         ]
     },
     "calendar": {
-        "type": "builtin"
+        "type": "builtin",
+        "test": [
+            "assert(function_exists('cal_info'));",
+            "assert(is_array(cal_info(0)));"
+        ]
     },
     "ctype": {
         "type": "builtin"
@@ -24,6 +37,9 @@
         "arg-type": "with",
         "lib-depends": [
             "curl"
+        ],
+        "test": [
+            "assert(function_exists('curl_init'));"
         ]
     },
     "dba": {
@@ -37,6 +53,12 @@
         "lib-depends": [
             "libxml2",
             "zlib"
+        ],
+        "test": [
+            "assert(class_exists('\\DOMDocument'));",
+            "$doc = new DOMDocument();",
+            "$doc->loadHtml('<html><head><meta charset=\"UTF-8\"><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"></head><body id='app'>Hello</body></html>');",
+            "assert($doc->getElementById('app')->nodeValue === 'Hello');"
         ]
     },
     "event": {
@@ -67,7 +89,10 @@
         "type": "builtin"
     },
     "filter": {
-        "type": "builtin"
+        "type": "builtin",
+        "test": [
+            "assert(function_exists('filter_var'));"
+        ]
     },
     "ftp": {
         "type": "builtin",
@@ -91,6 +116,12 @@
             "libwebp",
             "libjpeg",
             "freetype"
+        ],
+        "test": [
+            "assert(function_exists('gd_info'));",
+            "assert(gd_info()['PNG Support'] ?? false);",
+            "assert(gd_info()['GIF Create Support'] ?? false);",
+            "assert(gd_info()['GIF Read Support'] ?? false);"
         ]
     },
     "gettext": {
@@ -149,6 +180,9 @@
         "cpp-extension": true,
         "lib-depends": [
             "icu"
+        ],
+        "test": [
+            "assert(class_exists(NumberFormatter::class));"
         ]
     },
     "ldap": {
@@ -309,6 +343,9 @@
         "arg-type": "custom",
         "ext-suggests": [
             "session"
+        ],
+        "test": [
+            "assert(class_exists('\\Redis'));"
         ]
     },
     "session": {
@@ -484,6 +521,9 @@
         "arg-type-windows": "enable",
         "lib-depends": [
             "libzip"
+        ],
+        "test": [
+            "assert(class_exists('\\ZipArchive'));"
         ]
     },
     "zlib": {
@@ -492,6 +532,9 @@
         "arg-type-windows": "enable",
         "lib-depends": [
             "zlib"
+        ],
+        "test": [
+            "assert(function_exists('gzcompress'));"
         ]
     },
     "zstd": {

--- a/src/SPC/builder/Extension.php
+++ b/src/SPC/builder/Extension.php
@@ -124,6 +124,14 @@ class Extension
         return $this->name;
     }
 
+    /**
+     * @return string[]
+     */
+    public function getTests(): array
+    {
+        return Config::getExt($this->name, 'test', []);
+    }
+
     public function getWindowsConfigureArg(): string
     {
         return '';

--- a/src/SPC/builder/traits/UnixBuilderTrait.php
+++ b/src/SPC/builder/traits/UnixBuilderTrait.php
@@ -72,8 +72,10 @@ trait UnixBuilderTrait
                 if ($ret !== 0) {
                     throw new RuntimeException('extension ' . $ext->getName() . ' failed compile check');
                 }
-                if (file_exists(ROOT_DIR . '/src/globals/tests/' . $ext->getName() . '.php')) {
-                    [$ret] = shell()->execWithResult(BUILD_ROOT_PATH . '/bin/php ' . ROOT_DIR . '/src/globals/tests/' . $ext->getName() . '.php');
+
+                $tests = $ext->getTests();
+                if ($tests !== []) {
+                    [$ret] = shell()->execWithResult(BUILD_ROOT_PATH . '/bin/php -r "' . implode('', $tests) . '"');
                     if ($ret !== 0) {
                         throw new RuntimeException('extension ' . $ext->getName() . ' failed sanity check');
                     }

--- a/src/globals/tests/bcmath.php
+++ b/src/globals/tests/bcmath.php
@@ -1,5 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-assert(function_exists('bcscale'));

--- a/src/globals/tests/bz2.php
+++ b/src/globals/tests/bz2.php
@@ -1,8 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-$str = 'This is bz2 extension test';
-assert(function_exists('bzdecompress'));
-assert(function_exists('bzcompress'));
-assert(bzdecompress(bzcompress($str, 9)) === $str);

--- a/src/globals/tests/calendar.php
+++ b/src/globals/tests/calendar.php
@@ -1,6 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-assert(function_exists('cal_info'));
-assert(is_array(cal_info(0)));

--- a/src/globals/tests/curl.php
+++ b/src/globals/tests/curl.php
@@ -1,5 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-assert(function_exists('curl_init'));

--- a/src/globals/tests/dom.php
+++ b/src/globals/tests/dom.php
@@ -1,8 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-assert(class_exists('\\DOMDocument'));
-$doc = new DOMDocument();
-$doc->loadHtml("<html><head><meta charset=\"UTF-8\"><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"></head><body id='app'>Hello</body></html>");
-assert($doc->getElementById('app')->nodeValue === 'Hello');

--- a/src/globals/tests/filter.php
+++ b/src/globals/tests/filter.php
@@ -1,5 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-assert(function_exists('filter_var'));

--- a/src/globals/tests/gd.php
+++ b/src/globals/tests/gd.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-assert(function_exists('gd_info'));
-$info = gd_info();
-assert($info['PNG Support'] ?? false);
-assert($info['GIF Create Support'] ?? false);
-assert($info['GIF Read Support'] ?? false);

--- a/src/globals/tests/intl.php
+++ b/src/globals/tests/intl.php
@@ -1,5 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-assert(class_exists(NumberFormatter::class));

--- a/src/globals/tests/redis.php
+++ b/src/globals/tests/redis.php
@@ -1,5 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-assert(class_exists('\\Redis'));

--- a/src/globals/tests/zip.php
+++ b/src/globals/tests/zip.php
@@ -1,5 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-assert(class_exists('\\ZipArchive'));

--- a/src/globals/tests/zlib.php
+++ b/src/globals/tests/zlib.php
@@ -1,5 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-assert(function_exists('gzcompress'));


### PR DESCRIPTION
This change simplifies testing of extensions against custom build PHP binaries, also inside the phar!

```shell
stloyd@MacBook-Pro-2 spc-test % ./spc build curl,dom --build-cli
     _        _   _                 _
 ___| |_ __ _| |_(_) ___      _ __ | |__  _ __
/ __| __/ _` | __| |/ __|____| '_ \| '_ \| '_ \
\__ \ || (_| | |_| | (_|_____| |_) | | | | |_) |
|___/\__\__,_|\__|_|\___|    | .__/|_| |_| .__/   v2.0-rc6
                             |_|         |_|
[17:28:32] [INFO] [EXEC] sysctl -n hw.ncpu
[17:28:32] [INFO] Build target: cli
[17:28:32] [INFO] Enabled extensions: curl, dom
[17:28:32] [INFO] Required libraries: zlib, openssl, curl, libiconv, libxml2
(...)
[17:31:01] [INFO] [EXEC] make -j10 EXTRA_CFLAGS='-g -Os' EXTRA_LIBS=' -liconv -framework CoreFoundation -framework SystemConfiguration  /Users/stloyd/Documents/spc-test/buildroot/lib/libxml2.a /Users/stloyd/Documents/spc-test/buildroot/lib/libiconv.a /Users/stloyd/Documents/spc-test/buildroot/lib/libcharset.a /Users/stloyd/Documents/spc-test/buildroot/lib/libcurl.a /Users/stloyd/Documents/spc-test/buildroot/lib/libssl.a /Users/stloyd/Documents/spc-test/buildroot/lib/libcrypto.a /Users/stloyd/Documents/spc-test/buildroot/lib/libz.a -lresolv' cli
[17:33:29] [INFO] [EXEC] dsymutil -f sapi/cli/php
[17:33:30] [INFO] [EXEC] strip sapi/cli/php
[17:33:30] [INFO] Deploying cli file
[17:33:30] [INFO] [EXEC] cp '/Users/stloyd/Documents/spc-test/source/php-src/sapi/cli/php' '/Users/stloyd/Documents/spc-test/buildroot/bin/'
[17:33:30] [INFO] running cli sanity check
[17:33:30] [INFO] [EXEC] /Users/stloyd/Documents/spc-test/buildroot/bin/php -r "echo \"hello\";"
[17:33:31] [INFO] [EXEC] /Users/stloyd/Documents/spc-test/buildroot/bin/php -r "assert(function_exists('curl_init'));"
[17:33:32] [INFO] [EXEC] /Users/stloyd/Documents/spc-test/buildroot/bin/php -r "assert(class_exists('\DOMDocument'));$doc = new DOMDocument();$doc->loadHtml('<html><head><meta charset="UTF-8"><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"></head><body id='app'>Hello</body></html>');assert($doc->getElementById('app')->nodeValue === 'Hello');"
[17:33:32] [INFO] Build complete, used 299.775 s !
[17:33:32] [INFO] Static php binary path: /Users/stloyd/Documents/spc-test/buildroot/bin/php
[17:33:32] [INFO] License path: /Users/stloyd/Documents/spc-test/buildroot/license/
```