### PR TITLE
Sanity check extensions by inline their test code

### DIFF
--- a/src/globals/tests/dom.php
+++ b/src/globals/tests/dom.php
@@ -4,5 +4,5 @@ declare(strict_types=1);
 
 assert(class_exists('\\DOMDocument'));
 $doc = new DOMDocument();
-$doc->loadHtml("<html><head><meta charset=\"UTF-8\"><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"></head><body id='app'>Hello</body></html>");
+$doc->loadHtml('<html><head><meta charset="UTF-8"><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"></head><body id="app">Hello</body></html>');
 assert($doc->getElementById('app')->nodeValue === 'Hello');


### PR DESCRIPTION
```shell
stloyd@MacBook-Pro-2 spc-test % ./spc build gd --build-cli
     _        _   _                 _
 ___| |_ __ _| |_(_) ___      _ __ | |__  _ __
/ __| __/ _` | __| |/ __|____| '_ \| '_ \| '_ \
\__ \ || (_| | |_| | (_|_____| |_) | | | | |_) |
|___/\__\__,_|\__|_|\___|    | .__/|_| |_| .__/   v2.0-rc6
                             |_|         |_|
[11:45:50] [INFO] [EXEC] sysctl -n hw.ncpu
[11:45:50] [INFO] Build target: cli
[11:45:50] [INFO] Enabled extensions: zlib, gd
[11:45:50] [INFO] Required libraries: zlib, libpng
[11:45:50] [WARN] some extensions will be enabled due to dependencies: zlib
[11:45:52] [NOTI] lib [pkg-config] already built
[11:45:52] [NOTI] lib [zlib] already built
[11:45:52] [NOTI] lib [libpng] already built
[11:45:52] [INFO] enabling gd without library libavif
[11:45:52] [INFO] enabling gd without library libwebp
[11:45:52] [INFO] enabling gd without library libjpeg
[11:45:52] [INFO] enabling gd without library freetype
[11:45:52] [INFO] Entering dir: /Users/stloyd/Documents/spc-test/source/php-src
[11:45:52] [INFO] [EXEC] ./buildconf --force
[11:45:58] [INFO] Entering dir: /Users/stloyd/Documents/spc-test/source/php-src
[11:45:58] [INFO] Using configure: --with-zlib --enable-gd
(...)
[11:46:54] [INFO] cleaning up
[11:46:54] [INFO] Entering dir: /Users/stloyd/Documents/spc-test/source/php-src
[11:46:54] [INFO] [EXEC] make clean
[11:46:55] [INFO] building cli
[11:46:55] [INFO] Entering dir: /Users/stloyd/Documents/spc-test/source/php-src
[11:46:55] [INFO] [EXEC] make -j10 EXTRA_CFLAGS='-g -Os' EXTRA_LIBS='/Users/stloyd/Documents/spc-test/buildroot/lib/libpng16.a /Users/stloyd/Documents/spc-test/buildroot/lib/libz.a -lresolv' cli
[11:49:18] [INFO] [EXEC] dsymutil -f sapi/cli/php
[11:49:19] [INFO] [EXEC] strip sapi/cli/php
[11:49:19] [INFO] Deploying cli file
[11:49:19] [INFO] [EXEC] cp '/Users/stloyd/Documents/spc-test/source/php-src/sapi/cli/php' '/Users/stloyd/Documents/spc-test/buildroot/bin/'
[11:49:19] [INFO] running cli sanity check
[11:49:19] [INFO] [EXEC] /Users/stloyd/Documents/spc-test/buildroot/bin/php -r "echo \"hello\";"
[11:49:19] [INFO] [EXEC] /Users/stloyd/Documents/spc-test/buildroot/bin/php -r "assert(function_exists('gzcompress'));"
[11:49:19] [INFO] [EXEC] /Users/stloyd/Documents/spc-test/buildroot/bin/php -r "assert(function_exists('gd_info'));\$info = gd_info();assert(\$info['PNG Support'] ?? false);assert(\$info['GIF Create Support'] ?? false);assert(\$info['GIF Read Support'] ?? false);"
[11:49:19] [INFO] Build complete, used 209.285 s !
[11:49:19] [INFO] Static php binary path: /Users/stloyd/Documents/spc-test/buildroot/bin/php
[11:49:19] [INFO] License path: /Users/stloyd/Documents/spc-test/buildroot/license/
```

----

Alternative for #180
Fixes https://github.com/crazywhalecc/static-php-cli/issues/124