### PR TITLE
Add GH action to build library artifacts

### DIFF
--- a/.github/workflows/build-libraries.yml
+++ b/.github/workflows/build-libraries.yml
@@ -1,0 +1,130 @@
+name: Build Library Dependency Artifacts
+
+on:
+    release:
+        types:
+            - published
+    workflow_dispatch:
+
+jobs:
+    build-release-artifacts:
+        name: "Build Library Dependency Artifacts"
+        runs-on: ${{ matrix.operating-system }}
+        strategy:
+            fail-fast: false
+            matrix:
+                php-version:
+                    - "8.1"
+                operating-system:
+                    - "ubuntu-latest"
+                    - "macos-latest"
+                library:
+                    # Commented out libraries are not yet supported
+                    - brotli
+                    - bzip2
+                    - curl
+                    - freetype
+                    #- glfw
+                    - gmp
+                    - icu
+                    - imagemagick
+                    - libavif
+                    - libevent
+                    #- libffi
+                    - libiconv
+                    - libjpeg
+                    #- libmcrypt
+                    #- libmemcached
+                    - libpng
+                    - libsodium
+                    - libssh2
+                    - libwebp
+                    - libxml2
+                    - libxslt
+                    - libyaml
+                    - libzip
+                    - mcrypt
+                    - ncurses
+                    - nghttp2
+                    - onig
+                    - openssl
+                    #- pkg-config
+                    - postgresql
+                    #- pthreads4w
+                    - readline
+                    - snappy
+                    - sqlite
+                    - xz
+                    - zlib
+                    - zstd
+
+        steps:
+            - name: "Checkout"
+              uses: "actions/checkout@v4"
+
+            - name: "Install PHP"
+              uses: "shivammathur/setup-php@v2"
+              with:
+                  coverage: none
+                  tools: composer:v2
+                  php-version: "${{ matrix.php-version }}"
+                  ini-values: memory_limit=-1
+
+            - name: "Get Composer Cache Directory"
+              id: composer-cache
+              run: |
+                  echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+            - name: "Cache Composer dependencies"
+              uses: "actions/cache@v3"
+              with:
+                  path: "${{ steps.composer-cache.outputs.dir }}"
+                  key: "php-${{ matrix.php-version }}-locked-composer-${{ hashFiles('**/composer.lock') }}"
+                  restore-keys: |
+                      php-${{ matrix.php-version }}-locked-composer-
+
+            - name: "Install locked dependencies"
+              run: "composer install --no-interaction --no-progress"
+
+            # Cache downloaded source
+            - name: OS type
+              id: os-type
+              run: |
+                  OS=""
+                  if [ "${{ matrix.operating-system }}" = "ubuntu-latest" ]; then
+                      OS="linux-x86_64"
+                  elif [ "${{ matrix.operating-system }}" = "macos-latest" ]; then
+                      OS="macos-x86_64"
+                  fi
+                  echo "OS=$OS" >> $GITHUB_ENV
+
+            - id: cache-download
+              uses: actions/cache@v3
+              with:
+                  path: downloads
+                  key: php-${{ matrix.php-version }}-dependencies
+
+            # If there's no dependencies cache, fetch sources
+            - if: steps.cache-download.outputs.cache-hit != 'true'
+              name: "Download sources"
+              run: bin/spc download --with-php=${{ matrix.php-version }} --all
+
+            - name: "Build library: ${{ matrix.library }}"
+              run: |
+                  SPC_USE_SUDO=yes bin/spc doctor --auto-fix
+                  bin/spc build:libs ${{ matrix.library }}
+
+            - name: Upload binaries to release
+              uses: softprops/action-gh-release@v1
+              if: ${{startsWith(github.ref, 'refs/tags/') }}
+              with:
+                  files: ${{ env.filename }}
+
+            - name: "Upload Artifact"
+              uses: actions/upload-artifact@v3
+              with:
+                  name: php-${{ matrix.php-version }}-${{ matrix.library }}-${{ env.OS }}
+                  path: |
+                      buildroot/include/
+                      buildroot/lib/
+                  if-no-files-found: error

--- a/.github/workflows/build-libraries.yml
+++ b/.github/workflows/build-libraries.yml
@@ -62,31 +62,6 @@ jobs:
             - name: "Checkout"
               uses: "actions/checkout@v4"
 
-            - name: "Install PHP"
-              uses: "shivammathur/setup-php@v2"
-              with:
-                  coverage: none
-                  tools: composer:v2
-                  php-version: "${{ matrix.php-version }}"
-                  ini-values: memory_limit=-1
-
-            - name: "Get Composer Cache Directory"
-              id: composer-cache
-              run: |
-                  echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-            - name: "Cache Composer dependencies"
-              uses: "actions/cache@v3"
-              with:
-                  path: "${{ steps.composer-cache.outputs.dir }}"
-                  key: "php-${{ matrix.php-version }}-locked-composer-${{ hashFiles('**/composer.lock') }}"
-                  restore-keys: |
-                      php-${{ matrix.php-version }}-locked-composer-
-
-            - name: "Install locked dependencies"
-              run: "composer install --no-interaction --no-progress"
-
-            # Cache downloaded source
             - name: OS type
               id: os-type
               run: |
@@ -98,6 +73,19 @@ jobs:
                   fi
                   echo "OS=$OS" >> $GITHUB_ENV
 
+            - name: Download SPC bin artifact
+              id: download-spc-artifact
+              uses: dawidd6/action-download-artifact@v2
+              with:
+                  branch: main
+                  workflow: release-build.yml
+                  name: "spc-${{ env.OS }}"
+
+            - name: Validate SPC bin
+              run: |
+                  chmod +x spc
+                  ./spc --version
+
             - id: cache-download
               uses: actions/cache@v3
               with:
@@ -107,18 +95,12 @@ jobs:
             # If there's no dependencies cache, fetch sources
             - if: steps.cache-download.outputs.cache-hit != 'true'
               name: "Download sources"
-              run: bin/spc download --with-php=${{ matrix.php-version }} --all
+              run: ./spc download --with-php=${{ matrix.php-version }} --all
 
             - name: "Build library: ${{ matrix.library }}"
               run: |
-                  SPC_USE_SUDO=yes bin/spc doctor --auto-fix
-                  bin/spc build:libs ${{ matrix.library }} --include-suggested
-
-            - name: Upload binaries to release
-              uses: softprops/action-gh-release@v1
-              if: ${{startsWith(github.ref, 'refs/tags/') }}
-              with:
-                  files: ${{ env.filename }}
+                  SPC_USE_SUDO=yes ./spc doctor --auto-fix
+                  ./spc build:libs ${{ matrix.library }} --include-suggested
 
             - name: "Upload Artifact"
               uses: actions/upload-artifact@v3

--- a/.github/workflows/build-libraries.yml
+++ b/.github/workflows/build-libraries.yml
@@ -112,7 +112,7 @@ jobs:
             - name: "Build library: ${{ matrix.library }}"
               run: |
                   SPC_USE_SUDO=yes bin/spc doctor --auto-fix
-                  bin/spc build:libs ${{ matrix.library }}
+                  bin/spc build:libs ${{ matrix.library }} --include-suggested
 
             - name: Upload binaries to release
               uses: softprops/action-gh-release@v1

--- a/.github/workflows/build-linux-x86_64.yml
+++ b/.github/workflows/build-linux-x86_64.yml
@@ -49,7 +49,7 @@ jobs:
 
       # If there's no Composer cache, install dependencies
       - if: steps.cache-composer-deps.outputs.cache-hit != 'true'
-        run: composer update --no-dev --classmap-authoritative
+        run: composer install --no-dev --classmap-authoritative
 
       # Cache downloaded source
       - id: cache-download

--- a/.github/workflows/build-macos-x86_64.yml
+++ b/.github/workflows/build-macos-x86_64.yml
@@ -54,7 +54,7 @@ jobs:
 
       # If there's no Composer cache, install dependencies
       - if: steps.cache-composer-deps.outputs.cache-hit != 'true'
-        run: composer update --no-dev --classmap-authoritative
+        run: composer install --no-dev --classmap-authoritative
 
       # Cache downloaded source
       - id: cache-download

--- a/.github/workflows/download-cache.yml
+++ b/.github/workflows/download-cache.yml
@@ -27,7 +27,7 @@ jobs:
 
       # If there's no Composer cache, install dependencies
       - if: steps.cache-composer-deps.outputs.cache-hit != 'true'
-        run: composer update --no-dev
+        run: composer install --no-dev
 
       # If there's no dependencies cache, fetch sources, with or without debug
       - if: steps.cache-download.outputs.cache-hit != 'true'

--- a/src/SPC/builder/BuilderBase.php
+++ b/src/SPC/builder/BuilderBase.php
@@ -53,7 +53,7 @@ abstract class BuilderBase
         }
 
         // if no libs specified, compile all supported libs
-        if ($libraries === [] && $this->isLibsOnly()) {
+        if ($libraries === [] && $this->libs_only) {
             $libraries = array_keys($support_lib_list);
         }
 
@@ -215,14 +215,6 @@ abstract class BuilderBase
         }
         logger()->info('Using configure: ' . implode(' ', $ret));
         return implode(' ', $ret);
-    }
-
-    /**
-     * Get libs only mode.
-     */
-    public function isLibsOnly(): bool
-    {
-        return $this->libs_only;
     }
 
     /**

--- a/src/SPC/builder/BuilderBase.php
+++ b/src/SPC/builder/BuilderBase.php
@@ -38,7 +38,7 @@ abstract class BuilderBase
      * @throws RuntimeException
      * @throws WrongUsageException
      */
-    public function buildLibs(array $libraries): void
+    public function buildLibs(array $libraries, bool $includeSuggested = false): void
     {
         // search all supported libs
         $support_lib_list = [];
@@ -63,7 +63,7 @@ abstract class BuilderBase
         }
 
         // append dependencies
-        $libraries = DependencyUtil::getLibsByDeps($libraries);
+        $libraries = DependencyUtil::getLibsByDeps($libraries, $includeSuggested);
 
         // add lib object for builder
         foreach ($libraries as $library) {

--- a/src/SPC/command/BuildLibsCommand.php
+++ b/src/SPC/command/BuildLibsCommand.php
@@ -21,6 +21,7 @@ class BuildLibsCommand extends BuildCommand
         $this->addOption('clean', null, null, 'Clean old download cache and source before fetch');
         $this->addOption('all', 'A', null, 'Build all libs that static-php-cli needed');
         $this->addOption('rebuild', 'r', null, 'Delete old build and rebuild');
+        $this->addOption('include-suggested', 'I', null, 'Build all library dependencies along with suggested ones');
     }
 
     public function initialize(InputInterface $input, OutputInterface $output): void
@@ -60,7 +61,7 @@ class BuildLibsCommand extends BuildCommand
             // 只编译 library 的情况下，标记
             $builder->setLibsOnly();
             // 编译和检查库完整
-            $builder->buildLibs($libraries);
+            $builder->buildLibs($libraries, $this->getOption('include-suggested'));
 
             $time = round(microtime(true) - START_TIME, 3);
             logger()->info('Build libs complete, used ' . $time . ' s !');

--- a/src/SPC/util/DependencyUtil.php
+++ b/src/SPC/util/DependencyUtil.php
@@ -71,7 +71,7 @@ class DependencyUtil
      * @throws RuntimeException
      * @throws WrongUsageException
      */
-    public static function getLibsByDeps(array $libs): array
+    public static function getLibsByDeps(array $libs, bool $includeSuggested = false): array
     {
         $sorted = [];
         $visited = [];
@@ -92,7 +92,7 @@ class DependencyUtil
             }
         }
         foreach ($sorted_suggests as $suggest) {
-            if (in_array($suggest, $sorted)) {
+            if (in_array($suggest, $sorted, true) || $includeSuggested) {
                 $final[] = $suggest;
             }
         }


### PR DESCRIPTION
Generated artifacts can be downloaded & re-used instead of built locally.

Example of `curl` library pre-build for osx: https://github.com/stloyd/static-php-build/actions/runs/6198320093

Extracted locally to `buildroot` dir:
```shell
stloyd@MacBook-Pro-2 static-php-cli % bin/spc build curl --build-micro    
     _        _   _                 _           
 ___| |_ __ _| |_(_) ___      _ __ | |__  _ __  
/ __| __/ _` | __| |/ __|____| '_ \| '_ \| '_ \ 
\__ \ || (_| | |_| | (_|_____| |_) | | | | |_) |
|___/\__\__,_|\__|_|\___|    | .__/|_| |_| .__/   v2.0-rc6
                             |_|         |_|    
[13:30:27] [INFO] [EXEC] sysctl -n hw.ncpu
[13:30:27] [INFO] Build target: micro
[13:30:27] [INFO] Enabled extensions: curl
[13:30:27] [INFO] Required libraries: zlib, openssl, curl
[13:30:29] [NOTI] lib [zlib] already built
[13:30:29] [NOTI] lib [openssl] already built
[13:30:29] [NOTI] lib [curl] already built
[13:30:29] [INFO] patching before-configure for curl checks
[13:30:29] [INFO] Extension [curl] patched before buildconf
[13:30:29] [INFO] Entering dir: /Users/stloyd/Documents/static-php-cli/source/php-src
[13:30:29] [INFO] [EXEC] ./buildconf --force
[13:30:35] [INFO] Extension [curl] patched before configure
[13:30:35] [INFO] Entering dir: /Users/stloyd/Documents/static-php-cli/source/php-src
[13:30:35] [INFO] Using configure: --with-curl
(...)
```