### PR TITLE
rhel support & ldap support

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -214,7 +214,7 @@ If you are familiar with this project, you are also welcome to initiate a pull r
 
 The basic principles for contributing are as follows:
 
-- This project uses php-cs-fixer and phpstan as code formatting tools. Before contributing, please run `composer analyze` and `composer cs-fix` on the updated code.
+- This project uses php-cs-fixer and phpstan as code formatting tools. Before contributing, please run `composer analyse` and `composer cs-fix` on the updated code.
 - If other open source libraries are involved, the corresponding licenses should be provided. 
     Also, configuration files should be sorted using the command `sort-config` after modification.
     For more information about sorting commands, see the documentation.

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "illuminate/collections",
-            "version": "v10.23.1",
+            "version": "v10.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
-                "reference": "72c3cc6d44416db499d2ad11b8b27ae22e60a661"
+                "reference": "939a975daa8a5f77974ffa6a24067f5e947683f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/collections/zipball/72c3cc6d44416db499d2ad11b8b27ae22e60a661",
-                "reference": "72c3cc6d44416db499d2ad11b8b27ae22e60a661",
+                "url": "https://api.github.com/repos/illuminate/collections/zipball/939a975daa8a5f77974ffa6a24067f5e947683f4",
+                "reference": "939a975daa8a5f77974ffa6a24067f5e947683f4",
                 "shasum": ""
             },
             "require": {
@@ -59,11 +59,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2023-09-07T14:13:46+00:00"
+            "time": "2023-09-18T18:32:31+00:00"
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v10.23.1",
+            "version": "v10.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
@@ -109,7 +109,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v10.23.1",
+            "version": "v10.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -157,7 +157,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v10.23.1",
+            "version": "v10.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -203,16 +203,16 @@
         },
         {
             "name": "laravel/prompts",
-            "version": "v0.1.7",
+            "version": "v0.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/prompts.git",
-                "reference": "554e7d855a22e87942753d68e23b327ad79b2070"
+                "reference": "68dcc65babf92e1fb43cba0b3f78fc3d8002709c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/prompts/zipball/554e7d855a22e87942753d68e23b327ad79b2070",
-                "reference": "554e7d855a22e87942753d68e23b327ad79b2070",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/68dcc65babf92e1fb43cba0b3f78fc3d8002709c",
+                "reference": "68dcc65babf92e1fb43cba0b3f78fc3d8002709c",
                 "shasum": ""
             },
             "require": {
@@ -245,9 +245,9 @@
             ],
             "support": {
                 "issues": "https://github.com/laravel/prompts/issues",
-                "source": "https://github.com/laravel/prompts/tree/v0.1.7"
+                "source": "https://github.com/laravel/prompts/tree/v0.1.8"
             },
-            "time": "2023-09-12T11:09:22+00:00"
+            "time": "2023-09-19T15:33:56+00:00"
         },
         {
             "name": "psr/container",
@@ -2240,16 +2240,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.26.1",
+            "version": "v3.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "d023ba6684055f6ea1da1352d8a02baca0426983"
+                "reference": "113e09fea3d2306319ffaa2423fe3de768b28cff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/d023ba6684055f6ea1da1352d8a02baca0426983",
-                "reference": "d023ba6684055f6ea1da1352d8a02baca0426983",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/113e09fea3d2306319ffaa2423fe3de768b28cff",
+                "reference": "113e09fea3d2306319ffaa2423fe3de768b28cff",
                 "shasum": ""
             },
             "require": {
@@ -2323,7 +2323,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.26.1"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.28.0"
             },
             "funding": [
                 {
@@ -2331,7 +2331,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-08T19:09:07+00:00"
+            "time": "2023-09-22T20:43:40+00:00"
         },
         {
             "name": "humbug/box",
@@ -2872,37 +2872,37 @@
         },
         {
             "name": "nunomaduro/collision",
-            "version": "v7.8.1",
+            "version": "v7.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/collision.git",
-                "reference": "61553ad3260845d7e3e49121b7074619233d361b"
+                "reference": "296d0cf9fe462837ac0da8a568b56fc026b132da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/61553ad3260845d7e3e49121b7074619233d361b",
-                "reference": "61553ad3260845d7e3e49121b7074619233d361b",
+                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/296d0cf9fe462837ac0da8a568b56fc026b132da",
+                "reference": "296d0cf9fe462837ac0da8a568b56fc026b132da",
                 "shasum": ""
             },
             "require": {
                 "filp/whoops": "^2.15.3",
                 "nunomaduro/termwind": "^1.15.1",
                 "php": "^8.1.0",
-                "symfony/console": "^6.3.2"
+                "symfony/console": "^6.3.4"
             },
             "require-dev": {
-                "brianium/paratest": "^7.2.4",
-                "laravel/framework": "^10.17.1",
-                "laravel/pint": "^1.10.5",
-                "laravel/sail": "^1.23.1",
-                "laravel/sanctum": "^3.2.5",
-                "laravel/tinker": "^2.8.1",
+                "brianium/paratest": "^7.2.7",
+                "laravel/framework": "^10.23.1",
+                "laravel/pint": "^1.13.1",
+                "laravel/sail": "^1.25.0",
+                "laravel/sanctum": "^3.3.1",
+                "laravel/tinker": "^2.8.2",
                 "nunomaduro/larastan": "^2.6.4",
-                "orchestra/testbench-core": "^8.5.9",
-                "pestphp/pest": "^2.12.1",
-                "phpunit/phpunit": "^10.3.1",
+                "orchestra/testbench-core": "^8.11.0",
+                "pestphp/pest": "^2.19.1",
+                "phpunit/phpunit": "^10.3.5",
                 "sebastian/environment": "^6.0.1",
-                "spatie/laravel-ignition": "^2.2.0"
+                "spatie/laravel-ignition": "^2.3.0"
             },
             "type": "library",
             "extra": {
@@ -2961,7 +2961,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2023-08-07T08:03:21+00:00"
+            "time": "2023-09-19T10:45:09+00:00"
         },
         {
             "name": "nunomaduro/termwind",
@@ -3397,16 +3397,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.24.0",
+            "version": "1.24.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "3510b0a6274cc42f7219367cb3abfc123ffa09d6"
+                "reference": "9f854d275c2dbf84915a5c0ec9a2d17d2cd86b01"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/3510b0a6274cc42f7219367cb3abfc123ffa09d6",
-                "reference": "3510b0a6274cc42f7219367cb3abfc123ffa09d6",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/9f854d275c2dbf84915a5c0ec9a2d17d2cd86b01",
+                "reference": "9f854d275c2dbf84915a5c0ec9a2d17d2cd86b01",
                 "shasum": ""
             },
             "require": {
@@ -3438,22 +3438,22 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.24.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.24.1"
             },
-            "time": "2023-09-07T20:46:32+00:00"
+            "time": "2023-09-18T12:18:02+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.34",
+            "version": "1.10.35",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "7f806b6f1403e6914c778140e2ba07c293cb4901"
+                "reference": "e730e5facb75ffe09dfb229795e8c01a459f26c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/7f806b6f1403e6914c778140e2ba07c293cb4901",
-                "reference": "7f806b6f1403e6914c778140e2ba07c293cb4901",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e730e5facb75ffe09dfb229795e8c01a459f26c3",
+                "reference": "e730e5facb75ffe09dfb229795e8c01a459f26c3",
                 "shasum": ""
             },
             "require": {
@@ -3502,20 +3502,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-13T09:49:47+00:00"
+            "time": "2023-09-19T15:27:56+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.1.5",
+            "version": "10.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "1df504e42a88044c27a90136910f0b3fe9e91939"
+                "reference": "56f33548fe522c8d82da7ff3824b42829d324364"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/1df504e42a88044c27a90136910f0b3fe9e91939",
-                "reference": "1df504e42a88044c27a90136910f0b3fe9e91939",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/56f33548fe522c8d82da7ff3824b42829d324364",
+                "reference": "56f33548fe522c8d82da7ff3824b42829d324364",
                 "shasum": ""
             },
             "require": {
@@ -3572,7 +3572,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.5"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.6"
             },
             "funding": [
                 {
@@ -3580,7 +3580,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-12T14:37:22+00:00"
+            "time": "2023-09-19T04:59:03+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3827,16 +3827,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.3.4",
+            "version": "10.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b8d59476f19115c9774b3b447f78131781c6c32b"
+                "reference": "747c3b2038f1139e3dcd9886a3f5a948648b7503"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b8d59476f19115c9774b3b447f78131781c6c32b",
-                "reference": "b8d59476f19115c9774b3b447f78131781c6c32b",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/747c3b2038f1139e3dcd9886a3f5a948648b7503",
+                "reference": "747c3b2038f1139e3dcd9886a3f5a948648b7503",
                 "shasum": ""
             },
             "require": {
@@ -3860,7 +3860,7 @@
                 "sebastian/comparator": "^5.0",
                 "sebastian/diff": "^5.0",
                 "sebastian/environment": "^6.0",
-                "sebastian/exporter": "^5.0",
+                "sebastian/exporter": "^5.1",
                 "sebastian/global-state": "^6.0.1",
                 "sebastian/object-enumerator": "^5.0",
                 "sebastian/recursion-context": "^5.0",
@@ -3908,7 +3908,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.3.4"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.3.5"
             },
             "funding": [
                 {
@@ -3924,7 +3924,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-12T14:42:28+00:00"
+            "time": "2023-09-19T05:42:37+00:00"
         },
         {
             "name": "psr/event-dispatcher",
@@ -4411,16 +4411,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "5.0.1",
+            "version": "5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "32ff03d078fed1279c4ec9a407d08c5e9febb480"
+                "reference": "c3fa8483f9539b190f7cd4bfc4a07631dd1df344"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/32ff03d078fed1279c4ec9a407d08c5e9febb480",
-                "reference": "32ff03d078fed1279c4ec9a407d08c5e9febb480",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/c3fa8483f9539b190f7cd4bfc4a07631dd1df344",
+                "reference": "c3fa8483f9539b190f7cd4bfc4a07631dd1df344",
                 "shasum": ""
             },
             "require": {
@@ -4477,7 +4477,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/5.0.1"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.0"
             },
             "funding": [
                 {
@@ -4485,7 +4485,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-08T04:46:58+00:00"
+            "time": "2023-09-18T07:15:37+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -5946,5 +5946,5 @@
         "ext-pcntl": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/config/ext.json
+++ b/config/ext.json
@@ -153,9 +153,15 @@
     },
     "ldap": {
         "type": "builtin",
-        "arg-type": "with",
+        "arg-type": "with-prefix",
         "lib-depends": [
             "ldap"
+        ],
+        "lib-suggests": [
+            "openssl"
+        ],
+        "ext-suggests": [
+            "openssl"
         ]
     },
     "mbregex": {

--- a/config/ext.json
+++ b/config/ext.json
@@ -158,10 +158,14 @@
             "ldap"
         ],
         "lib-suggests": [
-            "openssl"
+            "openssl",
+            "zlib",
+            "gmp",
+            "libsodium"
         ],
         "ext-suggests": [
-            "openssl"
+            "openssl",
+            "zlib"
         ]
     },
     "mbregex": {

--- a/config/ext.json
+++ b/config/ext.json
@@ -158,14 +158,11 @@
             "ldap"
         ],
         "lib-suggests": [
-            "openssl",
-            "zlib",
             "gmp",
             "libsodium"
         ],
         "ext-suggests": [
-            "openssl",
-            "zlib"
+            "openssl"
         ]
     },
     "mbregex": {
@@ -239,6 +236,9 @@
         "arg-type": "with",
         "lib-depends": [
             "openssl"
+        ],
+        "ext-depends": [
+            "zlib"
         ]
     },
     "pcntl": {

--- a/config/lib.json
+++ b/config/lib.json
@@ -144,6 +144,11 @@
         "static-libs-unix": [
             "liblber.a",
             "libldap.a"
+        ],
+        "lib-suggests": [
+            "openssl",
+            "gmp",
+            "libsodium"
         ]
     },
     "libavif": {

--- a/config/lib.json
+++ b/config/lib.json
@@ -139,6 +139,13 @@
             "libxml2"
         ]
     },
+    "ldap": {
+        "source": "ldap",
+        "static-libs-unix": [
+            "liblber.a",
+            "libldap.a"
+        ]
+    },
     "libavif": {
         "source": "libavif",
         "static-libs-unix": [

--- a/config/source.json
+++ b/config/source.json
@@ -46,7 +46,6 @@
         "type": "filelist",
         "url": "https://www.openldap.org/software/download/OpenLDAP/openldap-release/",
         "regex": "/href=\"(?<file>openldap-(?<version>[^\"]+)\\.tgz)\"/",
-        "path": "php-src/ext/ldap",
         "license": {
             "type": "file",
             "path": "LICENSE"

--- a/config/source.json
+++ b/config/source.json
@@ -42,6 +42,16 @@
             "path": "COPYING"
         }
     },
+    "ldap": {
+        "type": "filelist",
+        "url": "https://www.openldap.org/software/download/OpenLDAP/openldap-release/",
+        "regex": "/href=\"(?<file>openldap-(?<version>[^\"]+)\\.tgz)\"/",
+        "path": "php-src/ext/ldap",
+        "license": {
+            "type": "file",
+            "path": "LICENSE"
+        }
+    },
     "ext-event": {
         "type": "url",
         "url": "https://bitbucket.org/osmanov/pecl-event/get/3.0.8.tar.gz",

--- a/config/source.json
+++ b/config/source.json
@@ -42,15 +42,6 @@
             "path": "COPYING"
         }
     },
-    "ldap": {
-        "type": "filelist",
-        "url": "https://www.openldap.org/software/download/OpenLDAP/openldap-release/",
-        "regex": "/href=\"(?<file>openldap-(?<version>[^\"]+)\\.tgz)\"/",
-        "license": {
-            "type": "file",
-            "path": "LICENSE"
-        }
-    },
     "ext-event": {
         "type": "url",
         "url": "https://bitbucket.org/osmanov/pecl-event/get/3.0.8.tar.gz",
@@ -157,6 +148,15 @@
         "url": "https://pecl.php.net/get/inotify",
         "path": "php-src/ext/inotify",
         "filename": "inotify.tgz",
+        "license": {
+            "type": "file",
+            "path": "LICENSE"
+        }
+    },
+    "ldap": {
+        "type": "filelist",
+        "url": "https://www.openldap.org/software/download/OpenLDAP/openldap-release/",
+        "regex": "/href=\"(?<file>openldap-(?<version>[^\"]+)\\.tgz)\"/",
         "license": {
             "type": "file",
             "path": "LICENSE"

--- a/src/SPC/builder/linux/LinuxBuilder.php
+++ b/src/SPC/builder/linux/LinuxBuilder.php
@@ -52,7 +52,7 @@ class LinuxBuilder extends BuilderBase
 
         // ---------- set necessary compile environments ----------
         // set libc
-        $this->libc = 'musl'; // SystemUtil::selectLibc($this->cc);
+        $this->libc = $this->getOption('cc', 'gcc') === 'musl-gcc' ? 'musl_wrapper' : 'musl'; // SystemUtil::selectLibc($this->cc);
         // concurrency
         $this->concurrency = SystemUtil::getCpuCount();
         // cflags

--- a/src/SPC/builder/linux/SystemUtil.php
+++ b/src/SPC/builder/linux/SystemUtil.php
@@ -121,7 +121,7 @@ class SystemUtil
 
     public static function checkCCFlag(string $flag, string $cc): string
     {
-        [$ret] = shell()->execWithResult("echo | {$cc} -E -x c - {$flag}");
+        [$ret] = shell()->execWithResult("echo | {$cc} -E -x c - {$flag} 2>/dev/null");
         if ($ret != 0) {
             return '';
         }

--- a/src/SPC/builder/linux/library/ldap.php
+++ b/src/SPC/builder/linux/library/ldap.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\linux\library;
+
+class ldap extends LinuxLibraryBase
+{
+    use \SPC\builder\unix\library\ldap;
+
+    public const NAME = 'ldap';
+}

--- a/src/SPC/builder/macos/library/ldap.php
+++ b/src/SPC/builder/macos/library/ldap.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\macos\library;
+
+class ldap extends MacOSLibraryBase
+{
+    use \SPC\builder\unix\library\ldap;
+
+    public const NAME = 'ldap';
+}

--- a/src/SPC/builder/traits/UnixBuilderTrait.php
+++ b/src/SPC/builder/traits/UnixBuilderTrait.php
@@ -153,4 +153,26 @@ trait UnixBuilderTrait
             "-DCMAKE_INSTALL_INCLUDEDIR={$include} " .
             "-DCMAKE_TOOLCHAIN_FILE={$this->cmake_toolchain_file}";
     }
+
+    /**
+     * Generate configure flags
+     */
+    public function makeAutoconfFlags(int $flag = AUTOCONF_ALL): string
+    {
+        $extra = '';
+        // TODO: add auto pkg-config support
+        if (($flag & AUTOCONF_LIBS) === AUTOCONF_LIBS) {
+            $extra .= 'LIBS="' . BUILD_LIB_PATH . '" ';
+        }
+        if (($flag & AUTOCONF_CFLAGS) === AUTOCONF_CFLAGS) {
+            $extra .= 'CFLAGS="-I' . BUILD_INCLUDE_PATH . '" ';
+        }
+        if (($flag & AUTOCONF_CPPFLAGS) === AUTOCONF_CPPFLAGS) {
+            $extra .= 'CPPFLAGS="-I' . BUILD_INCLUDE_PATH . '" ';
+        }
+        if (($flag & AUTOCONF_LDFLAGS) === AUTOCONF_LDFLAGS) {
+            $extra .= 'LDFLAGS="-L' . BUILD_LIB_PATH . '" ';
+        }
+        return $extra;
+    }
 }

--- a/src/SPC/builder/unix/library/curl.php
+++ b/src/SPC/builder/unix/library/curl.php
@@ -39,8 +39,8 @@ trait curl
         } else {
             $extra .= '-DUSE_NGHTTP2=OFF ';
         }
-        // TODO: ldap is not supported yet
-        $extra .= '-DCURL_DISABLE_LDAP=ON ';
+        // lib:ldap
+        $extra .= $this->builder->getLib('ldap') ? '-DCURL_DISABLE_LDAP=OFF ' : '-DCURL_DISABLE_LDAP=ON ';
         // lib:zstd
         $extra .= $this->builder->getLib('zstd') ? '-DCURL_ZSTD=ON ' : '-DCURL_ZSTD=OFF ';
         // lib:idn2

--- a/src/SPC/builder/unix/library/ldap.php
+++ b/src/SPC/builder/unix/library/ldap.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\unix\library;
+
+trait ldap
+{
+    protected function build(): void
+    {
+        shell()->cd($this->source_dir)
+            ->exec(
+                $this->builder->configure_env . ' ' .
+                'LDFLAGS="-static"' .
+                ' ./configure ' .
+                '--enable-static ' .
+                '--disable-shared ' .
+                '--disable-slapd ' .
+                '--without-systemd ' .
+                ($this->builder->getLib('openssl') ? '--with-tls=openssl ' : '') .
+                '--prefix='
+            )
+            ->exec('make clean')
+            ->exec('make depend')
+            ->exec("make -j{$this->builder->concurrency}")
+            ->exec('make install DESTDIR=' . BUILD_ROOT_PATH);
+        $this->patchPkgconfPrefix(['ldap.pc', 'lber.pc']);
+    }
+}

--- a/src/SPC/builder/unix/library/ldap.php
+++ b/src/SPC/builder/unix/library/ldap.php
@@ -8,6 +8,13 @@ trait ldap
 {
     protected function build(): void
     {
+        $alt = '';
+        // openssl support
+        $alt .= $this->builder->getLib('openssl') && $this->builder->getExt('zlib') ? '--with-tls=openssl ' : '';
+        // gmp support
+        $alt .= $this->builder->getLib('gmp') ? '--with-mp=gmp ' : '';
+        // libsodium support
+        $alt .= $this->builder->getLib('libsodium') ? '--with-argon2=libsodium ' : '';
         shell()->cd($this->source_dir)
             ->exec(
                 $this->builder->configure_env . ' ' .
@@ -19,9 +26,7 @@ trait ldap
                 '--disable-slurpd ' .
                 '--without-systemd ' .
                 '--without-cyrus-sasl ' .
-                ($this->builder->getLib('openssl') && $this->builder->getExt('zlib') ? '--with-tls=openssl ' : '') .
-                ($this->builder->getLib('gmp') ? '--with-mp=gmp ' : '') .
-                ($this->builder->getLib('libsodium') ? '--with-argon2=libsodium ' : '') .
+                $alt .
                 '--prefix='
             )
             ->exec('make clean')

--- a/src/SPC/builder/unix/library/ldap.php
+++ b/src/SPC/builder/unix/library/ldap.php
@@ -11,13 +11,18 @@ trait ldap
         shell()->cd($this->source_dir)
             ->exec(
                 $this->builder->configure_env . ' ' .
-                'LDFLAGS="-static"' .
+                'CC="musl-gcc -I' . BUILD_INCLUDE_PATH . '" ' .
+                'LDFLAGS="-static -L' . BUILD_LIB_PATH . '" ' .
+                ($this->builder->getLib('openssl') && $this->builder->getExt('zlib') ? 'LIBS="-lssl -lcrypto -lz" ' : '') .
                 ' ./configure ' .
                 '--enable-static ' .
                 '--disable-shared ' .
                 '--disable-slapd ' .
+                '--disable-slurpd ' .
                 '--without-systemd ' .
-                ($this->builder->getLib('openssl') ? '--with-tls=openssl ' : '') .
+                ($this->builder->getLib('openssl') && $this->builder->getExt('zlib') ? '--with-tls=openssl ' : '') .
+                ($this->builder->getLib('gmp') ? '--with-mp=gmp ' : '') .
+                ($this->builder->getLib('libsodium') ? '--with-argon2=libsodium ' : '') .
                 '--prefix='
             )
             ->exec('make clean')

--- a/src/SPC/builder/unix/library/postgresql.php
+++ b/src/SPC/builder/unix/library/postgresql.php
@@ -57,15 +57,14 @@ trait postgresql
                 '--with-ssl=openssl ' .
                 '--with-readline ' .
                 '--with-libxml ' .
+                ($this->builder->getLib('ldap') ? '--with-ldap ' : '--without-ldap ') .
                 ($this->builder->getLib('icu') ? '--with-icu ' : '--without-icu ') .
-                '--without-ldap ' .
                 '--without-libxslt ' .
                 '--without-lz4 ' .
                 '--without-zstd ' .
                 '--without-perl ' .
                 '--without-python ' .
                 '--without-pam ' .
-                '--without-ldap ' .
                 '--without-bonjour ' .
                 '--without-tcl '
             );

--- a/src/SPC/command/BuildCliCommand.php
+++ b/src/SPC/command/BuildCliCommand.php
@@ -41,11 +41,11 @@ class BuildCliCommand extends BuildCommand
         $extensions = array_map('trim', array_filter(explode(',', $this->getArgument('extensions'))));
 
         $rule = BUILD_TARGET_NONE;
-        $rule = $rule | ($this->getOption('build-cli') ? BUILD_TARGET_CLI : BUILD_TARGET_NONE);
-        $rule = $rule | ($this->getOption('build-micro') ? BUILD_TARGET_MICRO : BUILD_TARGET_NONE);
-        $rule = $rule | ($this->getOption('build-fpm') ? BUILD_TARGET_FPM : BUILD_TARGET_NONE);
-        $rule = $rule | ($this->getOption('build-embed') ? BUILD_TARGET_EMBED : BUILD_TARGET_NONE);
-        $rule = $rule | ($this->getOption('build-all') ? BUILD_TARGET_ALL : BUILD_TARGET_NONE);
+        $rule |= ($this->getOption('build-cli') ? BUILD_TARGET_CLI : BUILD_TARGET_NONE);
+        $rule |= ($this->getOption('build-micro') ? BUILD_TARGET_MICRO : BUILD_TARGET_NONE);
+        $rule |= ($this->getOption('build-fpm') ? BUILD_TARGET_FPM : BUILD_TARGET_NONE);
+        $rule |= ($this->getOption('build-embed') ? BUILD_TARGET_EMBED : BUILD_TARGET_NONE);
+        $rule |= ($this->getOption('build-all') ? BUILD_TARGET_ALL : BUILD_TARGET_NONE);
         if ($rule === BUILD_TARGET_NONE) {
             $this->output->writeln('<error>Please add at least one build target!</error>');
             $this->output->writeln("<comment>\t--build-cli\tBuild php-cli SAPI</comment>");

--- a/src/SPC/doctor/item/LinuxMuslCheck.php
+++ b/src/SPC/doctor/item/LinuxMuslCheck.php
@@ -36,13 +36,12 @@ class LinuxMuslCheck
     #[AsFixItem('fix-musl')]
     public function fixMusl(array $distro): bool
     {
-        $rhel_install = 'dnf install tar wget git zip bison flex bzip2 cmake patch && \
-                         wget https://musl.libc.org/releases/musl-1.2.4.tar.gz && tar -zxvf musl-1.2.4.tar.gz && \
+        $rhel_install = 'wget https://musl.libc.org/releases/musl-1.2.4.tar.gz && tar -zxvf musl-1.2.4.tar.gz && \
                          rm -f musl-1.2.4.tar.gz && cd musl-1.2.4 && 
-                         if [[ ! "$PATH" =~ (^|:)"/usr/local/musl/bin"(:|$) ]]; then export PATH="/usr/local/musl/bin:$PATH"
+                         if [[ ! "$PATH" =~ (^|:)"/usr/local/musl/bin"(:|$) ]]; then echo "export PATH=/usr/local/musl/bin:$PATH" >> ~/.bash_profile
                          fi && \
-                         ./configure --disable-shared --enable-wrapper=gcc && \
-                         make -j && make install && cd ..';
+                         ./configure --enable-wrapper=gcc && \
+                         make -j && make install && cd .. && rm -rf musl-1.2.4';
         $install_cmd = match ($distro['dist']) {
             'ubuntu', 'debian' => 'apt-get install musl musl-tools -y',
             'alpine' => 'apk add musl musl-utils musl-dev',

--- a/src/SPC/doctor/item/LinuxMuslCheck.php
+++ b/src/SPC/doctor/item/LinuxMuslCheck.php
@@ -36,11 +36,18 @@ class LinuxMuslCheck
     #[AsFixItem('fix-musl')]
     public function fixMusl(array $distro): bool
     {
+        $rhel_install = 'dnf install tar wget git zip bison flex bzip2 cmake patch && \
+                         wget https://musl.libc.org/releases/musl-1.2.4.tar.gz && tar -zxvf musl-1.2.4.tar.gz && \
+                         rm -f musl-1.2.4.tar.gz && cd musl-1.2.4 && 
+                         if [[ ! "$PATH" =~ (^|:)"/usr/local/musl/bin"(:|$) ]]; then export PATH="/usr/local/musl/bin:$PATH"
+                         fi && \
+                         ./configure --disable-shared --enable-wrapper=gcc && \
+                         make -j && make install && cd ..';
         $install_cmd = match ($distro['dist']) {
             'ubuntu', 'debian' => 'apt-get install musl musl-tools -y',
             'alpine' => 'apk add musl musl-utils musl-dev',
-            'rhel' => 'dnf install tar wget git zip bison flex bzip2 cmake patch && wget https://musl.libc.org/releases/musl-1.2.4.tar.gz && tar -zxvf musl-1.2.4.tar.gz && rm musl-1.2.4.tar.gz && cd musl-1.2.4 && ./configure && make -j && make install && cd ..',
-            'almalinux' => 'dnf install bison flex bzip2 cmake patch && wget https://musl.libc.org/releases/musl-1.2.4.tar.gz && tar -zxvf musl-1.2.4.tar.gz && rm musl-1.2.4.tar.gz && cd musl-1.2.4 && ./configure && make -j && make install && export PATH="/usr/local/musl/bin:$PATH" cd ..',
+            'rhel' => $rhel_install,
+            'almalinux' => $rhel_install,
             default => throw new RuntimeException('Current linux distro does not have an auto-install script for musl packages yet.'),
         };
         $prefix = '';

--- a/src/SPC/doctor/item/LinuxMuslCheck.php
+++ b/src/SPC/doctor/item/LinuxMuslCheck.php
@@ -24,7 +24,7 @@ class LinuxMuslCheck
         // non-exist, need to recognize distro
         $distro = SystemUtil::getOSRelease();
         return match ($distro['dist']) {
-            'ubuntu', 'alpine', 'debian' => CheckResult::fail('musl-libc is not installed on your system', 'fix-musl', [$distro]),
+            'ubuntu', 'alpine', 'debian', 'rhel', 'almalinux' => CheckResult::fail('musl-libc is not installed on your system', 'fix-musl', [$distro]),
             default => CheckResult::fail('musl-libc is not installed on your system'),
         };
     }
@@ -39,7 +39,9 @@ class LinuxMuslCheck
         $install_cmd = match ($distro['dist']) {
             'ubuntu', 'debian' => 'apt-get install musl musl-tools -y',
             'alpine' => 'apk add musl musl-utils musl-dev',
-            default => throw new RuntimeException('Current linux distro is not supported for auto-install musl packages'),
+            'rhel' => 'dnf install tar wget git zip bison flex bzip2 cmake patch && wget https://musl.libc.org/releases/musl-1.2.4.tar.gz && tar -zxvf musl-1.2.4.tar.gz && rm musl-1.2.4.tar.gz && cd musl-1.2.4 && ./configure && make -j && make install && cd ..',
+            'almalinux' => 'dnf install bison flex bzip2 cmake patch && wget https://musl.libc.org/releases/musl-1.2.4.tar.gz && tar -zxvf musl-1.2.4.tar.gz && rm musl-1.2.4.tar.gz && cd musl-1.2.4 && ./configure && make -j && make install && export PATH="/usr/local/musl/bin:$PATH" cd ..',
+            default => throw new RuntimeException('Current linux distro does not have an auto-install script for musl packages yet.'),
         };
         $prefix = '';
         if (get_current_user() !== 'root') {

--- a/src/SPC/doctor/item/LinuxToolCheckList.php
+++ b/src/SPC/doctor/item/LinuxToolCheckList.php
@@ -40,7 +40,7 @@ class LinuxToolCheckList
     ];
 
     /** @noinspection PhpUnused */
-    #[AsCheckItem('if necessary tools are installed', limit_os: 'Linux')]
+    #[AsCheckItem('if necessary tools are installed', limit_os: 'Linux', level: 999)]
     public function checkCliTools(): ?CheckResult
     {
         $distro = SystemUtil::getOSRelease();

--- a/src/SPC/doctor/item/LinuxToolCheckList.php
+++ b/src/SPC/doctor/item/LinuxToolCheckList.php
@@ -16,7 +16,7 @@ class LinuxToolCheckList
     use UnixSystemUtilTrait;
 
     public const TOOLS_ALPINE = [
-        'make', 'bison', 'flex',
+        'perl', 'make', 'bison', 'flex',
         'git', 'autoconf', 'automake',
         'tar', 'unzip', 'gzip',
         'bzip2', 'cmake', 'gcc',
@@ -24,7 +24,7 @@ class LinuxToolCheckList
     ];
 
     public const TOOLS_DEBIAN = [
-        'make', 'bison', 'flex',
+        'perl', 'make', 'bison', 'flex',
         'git', 'autoconf', 'automake',
         'tar', 'unzip', 'gzip',
         'bzip2', 'cmake', 'patch',
@@ -49,7 +49,11 @@ class LinuxToolCheckList
         }
         if (!empty($missing)) {
             return match ($distro['dist']) {
-                'ubuntu', 'alpine', 'debian' => CheckResult::fail(implode(', ', $missing) . ' not installed on your system', 'install-linux-tools', [$distro, $missing]),
+                'ubuntu',
+                'alpine',
+                'rhel',
+                'almalinux',
+                'debian' => CheckResult::fail(implode(', ', $missing) . ' not installed on your system', 'install-linux-tools', [$distro, $missing]),
                 default => CheckResult::fail(implode(', ', $missing) . ' not installed on your system'),
             };
         }
@@ -80,7 +84,9 @@ class LinuxToolCheckList
         $install_cmd = match ($distro['dist']) {
             'ubuntu', 'debian' => 'apt-get install -y',
             'alpine' => 'apk add',
-            default => throw new RuntimeException('Current linux distro is not supported for auto-install musl packages'),
+            'rhel' => 'dnf install -y',
+            'almalinux' => 'dnf install -y',
+            default => throw new RuntimeException('Current linux distro does not have an auto-install script for musl packages yet.'),
         };
         $prefix = '';
         if (get_current_user() !== 'root') {
@@ -88,7 +94,9 @@ class LinuxToolCheckList
             logger()->warning('Current user is not root, using sudo for running command');
         }
         try {
-            shell(true)->exec($prefix . $install_cmd . ' ' . implode(' ', str_replace('xz', 'xz-utils', $missing)));
+            $is_rhel = in_array($distro['dist'], ['rhel', 'almalinux']);
+            $to_install = $is_rhel ? $missing : str_replace('xz', 'xz-utils', $missing);
+            shell(true)->exec($prefix . $install_cmd . ' ' . implode(' ', $to_install));
         } catch (RuntimeException) {
             return false;
         }

--- a/src/SPC/doctor/item/LinuxToolCheckList.php
+++ b/src/SPC/doctor/item/LinuxToolCheckList.php
@@ -36,7 +36,7 @@ class LinuxToolCheckList
         'git', 'autoconf', 'automake',
         'tar', 'unzip', 'gzip', 'gcc',
         'bzip2', 'cmake', 'patch',
-        'xz',
+        'xz', 'wget', // to get musl
     ];
 
     /** @noinspection PhpUnused */

--- a/src/SPC/doctor/item/LinuxToolCheckList.php
+++ b/src/SPC/doctor/item/LinuxToolCheckList.php
@@ -16,7 +16,7 @@ class LinuxToolCheckList
     use UnixSystemUtilTrait;
 
     public const TOOLS_ALPINE = [
-        'perl', 'make', 'bison', 'flex',
+        'make', 'bison', 'flex',
         'git', 'autoconf', 'automake',
         'tar', 'unzip', 'gzip',
         'bzip2', 'cmake', 'gcc',
@@ -24,9 +24,17 @@ class LinuxToolCheckList
     ];
 
     public const TOOLS_DEBIAN = [
-        'perl', 'make', 'bison', 'flex',
+        'make', 'bison', 'flex',
         'git', 'autoconf', 'automake',
         'tar', 'unzip', 'gzip',
+        'bzip2', 'cmake', 'patch',
+        'xz',
+    ];
+
+    public const TOOLS_RHEL = [
+        'perl', 'make', 'bison', 'flex',
+        'git', 'autoconf', 'automake',
+        'tar', 'unzip', 'gzip', 'gcc',
         'bzip2', 'cmake', 'patch',
         'xz',
     ];
@@ -39,6 +47,8 @@ class LinuxToolCheckList
 
         $required = match ($distro['dist']) {
             'alpine' => self::TOOLS_ALPINE,
+            'almalinux' => self::TOOLS_RHEL,
+            'rhel' => self::TOOLS_RHEL,
             default => self::TOOLS_DEBIAN,
         };
         $missing = [];

--- a/src/globals/defines.php
+++ b/src/globals/defines.php
@@ -59,4 +59,11 @@ const PKGCONF_PATCH_INCLUDEDIR = 8;
 const PKGCONF_PATCH_CUSTOM = 16;
 const PKGCONF_PATCH_ALL = 31;
 
+// autoconf flags
+const AUTOCONF_LIBS = 1;
+const AUTOCONF_CFLAGS = 2;
+const AUTOCONF_CPPFLAGS = 4;
+const AUTOCONF_LDFLAGS = 8;
+const AUTOCONF_ALL = 15;
+
 ConsoleLogger::$date_format = 'H:i:s';


### PR DESCRIPTION
I wasn't quite able to get ldap to work when building static-php-cli, but it's trivial on rhel/debian - just run

```
dnf install sqlite-devel openldap-devel
ln -s /usr/lib64/libldap.so /usr/lib/libldap.so && ln -s /usr/lib64/liblber.so /usr/lib/liblber.so
php-src-folder/configure --with-ldap=/usr
```

openldap-devel is called libldap2-dev on debian.

Edit: If you want to add a pipeline for rhel (not required imo) this is the full install script to get things running on rhel.
epel-release is required for most of the things to install, remi only for php 8.2. The default still downloads 8.0 by default, which doesn't work.

```
dnf install epel-release
dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm 
dnf install -y https://rpms.remirepo.net/enterprise/remi-release-9.rpm  
dnf module enable php:remi-8.2
dnf install tar git zip php php-sodium php-zip libsodium wget

cd /opt
git clone https://github.com/crazywhalecc/static-php-cli.git
wget https://musl.libc.org/releases/musl-1.2.4.tar.gz

tar -xzf musl-1.2.4.tar.gz
cd musl-1.2.4.tar.gz
./configure
make -j
make install
cd ../static-php-cli

dnf install bison flex bzip2 cmake patch
dnf install sqlite-devel openldap-devel
ln -s /usr/lib64/libldap.so /usr/lib/libldap.so && ln -s /usr/lib64/liblber.so /usr/lib/liblber.so

php-src-dir/configure --with-ldap=/usr
```