### PR TITLE
Another way to run docker in spc binary

### DIFF
--- a/bin/spc
+++ b/bin/spc
@@ -6,9 +6,43 @@ use SPC\exception\ExceptionHandler;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-// 防止 Micro 打包状态下不支持中文的显示（虽然这个项目目前好像没输出过中文？）
-if (PHP_OS_FAMILY === 'Windows' && Phar::running()) {
-    exec('CHCP 65001');
+// check if we need to run in docker
+if (in_array('--docker', $_SERVER['argv'] ?? [], true)) {
+    // Remove fake option used in pre-built binary
+    $key = array_search('--docker', $_SERVER['argv']);
+    array_splice($_SERVER['argv'], $key, 1);
+    putenv('SPC_USE_DOCKER=yes');
+}
+if (getenv('SPC_USE_DOCKER') === 'yes') {
+    echo "We are in docker mode !\n";
+    // Remove first argument as it point this file
+    array_shift($_SERVER['argv']);
+
+    // mark that we are running in docker
+    putenv('SPC_USE_DOCKER=in');
+
+    // only support linux
+    if (PHP_OS_FAMILY !== 'Linux') {
+        echo 'Docker mode is only supported on Linux!' . PHP_EOL;
+        exit(1);
+    }
+
+    if (Phar::running() !== '') {
+        $exec = Phar::running(false) . ' export-docker-sh | sh -s -- ' . implode(' ', $_SERVER['argv']);
+        $result = passthru($exec, $exit_code);
+        if ($exit_code !== 0) {
+            echo "Phar running docker with error\n";
+            exit($exit_code);
+        }
+    } else {
+        $exec = __DIR__ . '/spc-alpine-docker';
+        $result = pcntl_exec($exec, $_SERVER['argv']);
+    }
+    if ($result === false) {
+        echo 'Failed to run docker mode!' . PHP_EOL;
+        exit(1);
+    }
+    exit(0);
 }
 
 try {

--- a/bin/spc-alpine-docker
+++ b/bin/spc-alpine-docker
@@ -49,6 +49,20 @@ else
     SPC_USE_MIRROR="RUN echo 'Using original repo'"
 fi
 
+# Detect init source from where
+if [ "$SPC_CALL_FROM_PHAR" != "" ]; then
+    INIT_SOURCE=""
+    SPC_EXECUTABLE="./spc"
+    SPC_SOURCE="-v $SPC_CALL_FROM_PHAR:/app/spc"
+else
+    INIT_SOURCE="ADD ./src /app/src
+COPY ./composer.* /app/
+ADD ./bin /app/bin
+RUN composer install --no-dev"
+    SPC_EXECUTABLE="bin/spc"
+    SPC_SOURCE="-v $(pwd)/src:/app/src"
+fi
+
 # Detect docker env is setup
 if ! $DOCKER_EXECUTABLE images | grep -q cwcc-spc-$SPC_USE_ARCH; then
     echo "Docker container does not exist. Building docker image ..."
@@ -93,10 +107,7 @@ RUN apk update; \
   ln -s /usr/bin/php82 /usr/bin/php
 
 WORKDIR /app
-ADD ./src /app/src
-COPY ./composer.* /app/
-ADD ./bin /app/bin
-RUN composer install --no-dev --classmap-authoritative
+$INIT_SOURCE
 EOF
 fi
 
@@ -109,4 +120,4 @@ fi
 
 # Run docker
 # shellcheck disable=SC2068
-$DOCKER_EXECUTABLE run --rm $INTERACT -e SPC_FIX_DEPLOY_ROOT="$(pwd)" -v "$(pwd)"/config:/app/config -v "$(pwd)"/src:/app/src -v "$(pwd)"/buildroot:/app/buildroot -v "$(pwd)"/source:/app/source -v "$(pwd)"/downloads:/app/downloads cwcc-spc-$SPC_USE_ARCH bin/spc $@
+$DOCKER_EXECUTABLE run --rm $INTERACT -e SPC_FIX_DEPLOY_ROOT="$(pwd)" $SPC_SOURCE -v "$(pwd)"/buildroot:/app/buildroot -v "$(pwd)"/source:/app/source -v "$(pwd)"/downloads:/app/downloads cwcc-spc-$SPC_USE_ARCH $SPC_EXECUTABLE $@

--- a/box.json
+++ b/box.json
@@ -12,6 +12,9 @@
     "vendor/symfony",
     "vendor/zhamao"
   ],
+  "files": [
+    "bin/spc-alpine-docker"
+  ],
   "git-commit-short": "git_commit_short",
   "metadata": "ConsoleApplication::VERSION",
   "output": "spc.phar"

--- a/src/SPC/ConsoleApplication.php
+++ b/src/SPC/ConsoleApplication.php
@@ -12,6 +12,7 @@ use SPC\command\dev\SortConfigCommand;
 use SPC\command\DoctorCommand;
 use SPC\command\DownloadCommand;
 use SPC\command\DumpLicenseCommand;
+use SPC\command\ExportDockerShCommand;
 use SPC\command\ExtractCommand;
 use SPC\command\MicroCombineCommand;
 use Symfony\Component\Console\Application;
@@ -27,7 +28,8 @@ final class ConsoleApplication extends Application
 
     public function __construct()
     {
-        parent::__construct('static-php-cli', self::VERSION);
+        $name = !empty(getenv('SPC_FIX_DEPLOY_ROOT')) ? 'static-php-cli (Docker)' : 'static-php-cli';
+        parent::__construct($name, self::VERSION);
 
         global $argv;
 
@@ -43,6 +45,7 @@ final class ConsoleApplication extends Application
                 new DumpLicenseCommand(),
                 new ExtractCommand(),
                 new MicroCombineCommand(),
+                new ExportDockerShCommand(),
 
                 // Dev commands
                 new AllExtCommand(),

--- a/src/SPC/command/ExportDockerShCommand.php
+++ b/src/SPC/command/ExportDockerShCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand('export-docker-sh', 'Export spc-alpine-docker file')]
+class ExportDockerShCommand extends BaseCommand
+{
+    public function configure()
+    {
+        $this->no_motd = true;
+    }
+
+    public function handle(): int
+    {
+        $file = file_get_contents(ROOT_DIR . '/bin/spc-alpine-docker');
+        if (\Phar::running() !== '') {
+            $file = str_replace('$SPC_CALL_FROM_PHAR', \Phar::running(false), $file);
+        }
+        echo $file;
+        return static::SUCCESS;
+    }
+}

--- a/src/globals/defines.php
+++ b/src/globals/defines.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use ZM\Logger\ConsoleLogger;
 
 define('WORKING_DIR', getcwd());
-const ROOT_DIR = __DIR__ . '/../..';
+define('ROOT_DIR', Phar::running() !== '' ? Phar::running() : (__DIR__ . '/../..'));
 
 // CLI start time
 define('START_TIME', microtime(true));


### PR DESCRIPTION
Related PR: #197.

pros:

1. When docker has already built, we can always use the latest `spc` binary in docker.
2. We can always use the latest `src` directory in docker if we are using source mode.
3. Zero file modification.

cons:

1. If we call `--docker --help` in binary or phar mode, we will get non-color help message for `symfony/console`.
2. Additional command.