### PR TITLE
Add FreeBSD support

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -8,10 +8,12 @@ Compile a purely static php-cli binary file with various extensions to make PHP 
 
 <img width="600" alt="2023-05-02 15 53 13" src="https://user-images.githubusercontent.com/20330940/235610282-23e58d68-bd35-4092-8465-171cff2d5ba8.png">
 
-You can also use the micro binary file to combine php binary and php source code into one for distribution!
-This feature is provided by [dixyes/phpmicro](https://github.com/dixyes/phpmicro). (micro SAPI)
+You can also use the micro binary file to combine php binary and php source code into one for distribution! (micro SAPI)
 
 <img width="600" alt="2023-05-02 15 52 33" src="https://user-images.githubusercontent.com/20330940/235610318-2ef4e3f1-278b-4ca4-99f4-b38120efc395.png">
+
+> This SAPI feature is from the [Fork](https://github.com/crazywhalecc/phpmicro) of [dixyes/phpmicro](https://github.com/dixyes/phpmicro).
+
 
 [![Version](https://img.shields.io/badge/Version-2.0--rc5-pink.svg?style=flat-square)]()
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)]()

--- a/README-en.md
+++ b/README-en.md
@@ -34,6 +34,7 @@ Here is the architecture support status, where `CI` represents support for GitHu
 | macOS   | CI, Local | Local     |
 | Linux   | CI, Local | CI, Local |
 | Windows |           |           |
+| FreeBSD | Local     | Local     |
 
 > macOS-arm64 is not supported for GitHub Actions, if you are going to build on arm, you can build it manually on your own machine.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Build single static PHP binary, with PHP project together, with popular extensio
 
 <img width="600" alt="截屏2023-05-02 15 52 33" src="https://user-images.githubusercontent.com/20330940/235610318-2ef4e3f1-278b-4ca4-99f4-b38120efc395.png">
 
-> 该 SAPI 源自 [dixyes/phpmicro](https://github.com/dixyes/phpmicro) 的 [Fork 仓库](https://github.com/dixyes/phpmicro)。
+> 该 SAPI 源自 [dixyes/phpmicro](https://github.com/dixyes/phpmicro) 的 [Fork 仓库](https://github.com/crazywhalecc/phpmicro)。
 
 [![Version](https://img.shields.io/badge/Version-2.0--rc5-pink.svg?style=flat-square)]()
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)]()

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ Build single static PHP binary, with PHP project together, with popular extensio
 
 <img width="600" alt="截屏2023-05-02 15 53 13" src="https://user-images.githubusercontent.com/20330940/235610282-23e58d68-bd35-4092-8465-171cff2d5ba8.png">
 
-同时可以使用 micro 二进制文件，将 PHP 源码和 PHP 二进制构建为一个文件分发！（由 [dixyes/phpmicro](https://github.com/dixyes/phpmicro) 提供支持）（micro SAPI）
+同时可以使用 micro 二进制文件，将 PHP 源码和 PHP 二进制构建为一个文件分发！（micro SAPI）
 
 <img width="600" alt="截屏2023-05-02 15 52 33" src="https://user-images.githubusercontent.com/20330940/235610318-2ef4e3f1-278b-4ca4-99f4-b38120efc395.png">
+
+> 该 SAPI 源自 [dixyes/phpmicro](https://github.com/dixyes/phpmicro) 的 [Fork 仓库](https://github.com/dixyes/phpmicro)。
 
 [![Version](https://img.shields.io/badge/Version-2.0--rc5-pink.svg?style=flat-square)]()
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)]()

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Build single static PHP binary, with PHP project together, with popular extensio
 | macOS   | CI, Local | Local     |
 | Linux   | CI, Local | CI, Local |
 | Windows |           |           |
+| FreeBSD | Local     | Local     |
 
 > macOS-arm64 因 GitHub 暂未提供 arm runner，如果要构建 arm 二进制，可以使用手动构建。
 

--- a/src/SPC/builder/BuilderProvider.php
+++ b/src/SPC/builder/BuilderProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SPC\builder;
 
+use SPC\builder\freebsd\BSDBuilder;
 use SPC\builder\linux\LinuxBuilder;
 use SPC\builder\macos\MacOSBuilder;
 use SPC\exception\FileSystemException;
@@ -31,6 +32,7 @@ class BuilderProvider
             // ),
             'Darwin' => new MacOSBuilder($input->getOptions()),
             'Linux' => new LinuxBuilder($input->getOptions()),
+            'BSD' => new BSDBuilder($input->getOptions()),
             default => throw new WrongUsageException('Current OS "' . PHP_OS_FAMILY . '" is not supported yet'),
         };
     }

--- a/src/SPC/builder/Extension.php
+++ b/src/SPC/builder/Extension.php
@@ -46,6 +46,7 @@ class Extension
                 break;
             case 'Darwin':
             case 'Linux':
+            case 'BSD':
                 $arg .= $this->getUnixConfigureArg();
                 break;
         }

--- a/src/SPC/builder/freebsd/BSDBuilder.php
+++ b/src/SPC/builder/freebsd/BSDBuilder.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\freebsd;
+
+use SPC\builder\BuilderBase;
+use SPC\builder\traits\UnixBuilderTrait;
+use SPC\exception\FileSystemException;
+use SPC\exception\RuntimeException;
+use SPC\exception\WrongUsageException;
+use SPC\store\FileSystem;
+use SPC\store\SourcePatcher;
+
+class BSDBuilder extends BuilderBase
+{
+    /** Unix compatible builder methods */
+    use UnixBuilderTrait;
+
+    /** @var bool Micro patch phar flag */
+    private bool $phar_patched = false;
+
+    /**
+     * @throws RuntimeException
+     * @throws WrongUsageException
+     * @throws FileSystemException
+     */
+    public function __construct(array $options = [])
+    {
+        $this->options = $options;
+
+        // ---------- set necessary options ----------
+        // set C Compiler (default: clang)
+        $this->setOptionIfNotExist('cc', 'clang');
+        // set C++ Composer (default: clang++)
+        $this->setOptionIfNotExist('cxx', 'clang++');
+        // set arch (default: current)
+        $this->setOptionIfNotExist('arch', php_uname('m'));
+        $this->setOptionIfNotExist('gnu-arch', arch2gnu($this->getOption('arch')));
+
+        // ---------- set necessary compile environments ----------
+        // concurrency
+        $this->concurrency = SystemUtil::getCpuCount();
+        // cflags
+        $this->arch_c_flags = SystemUtil::getArchCFlags($this->getOption('arch'));
+        $this->arch_cxx_flags = SystemUtil::getArchCFlags($this->getOption('arch'));
+        // cmake toolchain
+        $this->cmake_toolchain_file = SystemUtil::makeCmakeToolchainFile('BSD', $this->getOption('arch'), $this->arch_c_flags);
+        // configure environment
+        $this->configure_env = SystemUtil::makeEnvVarString([
+            'PKG_CONFIG' => BUILD_ROOT_PATH . '/bin/pkg-config',
+            'PKG_CONFIG_PATH' => BUILD_LIB_PATH . '/pkgconfig/',
+            'CC' => $this->getOption('cc'),
+            'CXX' => $this->getOption('cxx'),
+            'CFLAGS' => "{$this->arch_c_flags} -Wimplicit-function-declaration -Os",
+            'LIBS' => '-ldl -lpthread',
+            'PATH' => BUILD_ROOT_PATH . '/bin:' . getenv('PATH'),
+        ]);
+
+        // create pkgconfig and include dir (some libs cannot create them automatically)
+        f_mkdir(BUILD_LIB_PATH . '/pkgconfig', recursive: true);
+        f_mkdir(BUILD_INCLUDE_PATH, recursive: true);
+    }
+
+    /**
+     * Just start to build statically linked php binary
+     *
+     * @param  int                 $build_target build target
+     * @throws FileSystemException
+     * @throws RuntimeException
+     * @throws WrongUsageException
+     */
+    public function buildPHP(int $build_target = BUILD_TARGET_NONE): void
+    {
+        // ---------- Update extra-libs ----------
+        $extra_libs = $this->getOption('extra-libs', '');
+        // add libc++, some extensions or libraries need it (C++ cannot be linked statically)
+        $extra_libs .= (empty($extra_libs) ? '' : ' ') . ($this->hasCppExtension() ? '-lc++ ' : '');
+        if (!$this->getOption('bloat', false)) {
+            $extra_libs .= (empty($extra_libs) ? '' : ' ') . implode(' ', $this->getAllStaticLibFiles());
+        } else {
+            logger()->info('bloat linking');
+            $extra_libs .= (empty($extra_libs) ? '' : ' ') . implode(' ', array_map(fn ($x) => "-Wl,-force_load,{$x}", array_filter($this->getAllStaticLibFiles())));
+        }
+        $this->setOption('extra-libs', $extra_libs);
+
+        SourcePatcher::patchBeforeBuildconf($this);
+
+        shell()->cd(SOURCE_PATH . '/php-src')->exec('./buildconf --force');
+
+        SourcePatcher::patchBeforeConfigure($this);
+
+        $json_74 = $this->getPHPVersionID() < 80000 ? '--enable-json ' : '';
+        $zts = $this->getOption('enable-zts', false) ? '--enable-zts --disable-zend-signals ' : '';
+
+        $enableCli = ($build_target & BUILD_TARGET_CLI) === BUILD_TARGET_CLI;
+        $enableFpm = ($build_target & BUILD_TARGET_FPM) === BUILD_TARGET_FPM;
+        $enableMicro = ($build_target & BUILD_TARGET_MICRO) === BUILD_TARGET_MICRO;
+        $enableEmbed = ($build_target & BUILD_TARGET_EMBED) === BUILD_TARGET_EMBED;
+
+        shell()->cd(SOURCE_PATH . '/php-src')
+            ->exec(
+                './configure ' .
+                '--prefix= ' .
+                '--with-valgrind=no ' .     // Not detect memory leak
+                '--enable-shared=no ' .
+                '--enable-static=yes ' .
+                "CFLAGS='{$this->arch_c_flags} -Werror=unknown-warning-option' " .
+                '--disable-all ' .
+                '--disable-cgi ' .
+                '--disable-phpdbg ' .
+                ($enableCli ? '--enable-cli ' : '--disable-cli ') .
+                ($enableFpm ? '--enable-fpm ' : '--disable-fpm ') .
+                ($enableEmbed ? '--enable-embed=static ' : '--disable-embed ') .
+                ($enableMicro ? '--enable-micro ' : '--disable-micro ') .
+                $json_74 .
+                $zts .
+                $this->makeExtensionArgs() . ' ' .
+                $this->configure_env
+            );
+
+        SourcePatcher::patchBeforeMake($this);
+
+        $this->cleanMake();
+
+        if ($enableCli) {
+            logger()->info('building cli');
+            $this->buildCli();
+        }
+        if ($enableFpm) {
+            logger()->info('building fpm');
+            $this->buildFpm();
+        }
+        if ($enableMicro) {
+            logger()->info('building micro');
+            $this->buildMicro();
+        }
+        if ($enableEmbed) {
+            logger()->info('building embed');
+            if ($enableMicro) {
+                FileSystem::replaceFileStr(SOURCE_PATH . '/php-src/Makefile', 'OVERALL_TARGET =', 'OVERALL_TARGET = libphp.la');
+            }
+            $this->buildEmbed();
+        }
+
+        if (php_uname('m') === $this->getOption('arch')) {
+            $this->sanityCheck($build_target);
+        }
+    }
+
+    /**
+     * Build cli sapi
+     *
+     * @throws RuntimeException
+     * @throws FileSystemException
+     */
+    public function buildCli(): void
+    {
+        $vars = SystemUtil::makeEnvVarString([
+            'EXTRA_CFLAGS' => '-g -Os', // with debug information, but optimize for size
+            'EXTRA_LIBS' => "{$this->getOption('extra-libs')} /usr/lib/libm.a",
+        ]);
+
+        $shell = shell()->cd(SOURCE_PATH . '/php-src');
+        $shell->exec('sed -ie "s|//lib|/lib|g" Makefile');
+        $shell->exec("make -j{$this->concurrency} {$vars} cli");
+        if (!$this->getOption('no-strip', false)) {
+            $shell->exec('strip sapi/cli/php');
+        }
+        $this->deployBinary(BUILD_TARGET_CLI);
+    }
+
+    /**
+     * Build phpmicro sapi
+     *
+     * @throws FileSystemException|RuntimeException
+     */
+    public function buildMicro(): void
+    {
+        if ($this->getPHPVersionID() < 80000) {
+            throw new RuntimeException('phpmicro only support PHP >= 8.0!');
+        }
+        if ($this->getExt('phar')) {
+            $this->phar_patched = true;
+            SourcePatcher::patchMicro(['phar']);
+        }
+
+        $enable_fake_cli = $this->getOption('with-micro-fake-cli', false) ? ' -DPHP_MICRO_FAKE_CLI' : '';
+        $vars = [
+            // with debug information, optimize for size, remove identifiers, patch fake cli for micro
+            'EXTRA_CFLAGS' => '-g -Os' . $enable_fake_cli,
+            // link resolv library (macOS needs it)
+            'EXTRA_LIBS' => "{$this->getOption('extra-libs')} /usr/lib/libm.a",
+        ];
+        if (!$this->getOption('no-strip', false)) {
+            shell()->cd(SOURCE_PATH . '/php-src/sapi/micro')->exec('strip --strip-all micro.sfx');
+        }
+        $vars = SystemUtil::makeEnvVarString($vars);
+
+        shell()->cd(SOURCE_PATH . '/php-src')
+            ->exec("make -j{$this->concurrency} {$vars} micro");
+        $this->deployBinary(BUILD_TARGET_MICRO);
+
+        if ($this->phar_patched) {
+            SourcePatcher::patchMicro(['phar'], true);
+        }
+    }
+
+    /**
+     * Build fpm sapi
+     *
+     * @throws RuntimeException
+     * @throws FileSystemException
+     */
+    public function buildFpm(): void
+    {
+        $vars = SystemUtil::makeEnvVarString([
+            'EXTRA_CFLAGS' => '-g -Os', // with debug information, but optimize for size
+            'EXTRA_LIBS' => "{$this->getOption('extra-libs')} /usr/lib/libm.a", // link resolv library (macOS needs it)
+        ]);
+
+        $shell = shell()->cd(SOURCE_PATH . '/php-src');
+        $shell->exec("make -j{$this->concurrency} {$vars} fpm");
+        if (!$this->getOption('no-strip', false)) {
+            $shell->exec('strip sapi/fpm/php-fpm');
+        }
+        $this->deployBinary(BUILD_TARGET_FPM);
+    }
+
+    public function buildEmbed(): void
+    {
+        $vars = SystemUtil::makeEnvVarString([
+            'EXTRA_CFLAGS' => '-g -Os', // with debug information, but optimize for size
+            'EXTRA_LIBS' => "{$this->getOption('extra-libs')} /usr/lib/libm.a", // link resolv library (macOS needs it)
+        ]);
+
+        shell()
+            ->cd(SOURCE_PATH . '/php-src')
+            ->exec('make INSTALL_ROOT=' . BUILD_ROOT_PATH . " -j{$this->concurrency} {$vars} install")
+            // Workaround for https://github.com/php/php-src/issues/12082
+            ->exec('rm -Rf ' . BUILD_ROOT_PATH . '/lib/php-o')
+            ->exec('mkdir ' . BUILD_ROOT_PATH . '/lib/php-o')
+            ->cd(BUILD_ROOT_PATH . '/lib/php-o')
+            ->exec('ar x ' . BUILD_ROOT_PATH . '/lib/libphp.a')
+            ->exec('rm ' . BUILD_ROOT_PATH . '/lib/libphp.a')
+            ->exec('ar rcs ' . BUILD_ROOT_PATH . '/lib/libphp.a *.o')
+            ->exec('rm -Rf ' . BUILD_ROOT_PATH . '/lib/php-o');
+    }
+}

--- a/src/SPC/builder/freebsd/BSDBuilder.php
+++ b/src/SPC/builder/freebsd/BSDBuilder.php
@@ -192,13 +192,14 @@ class BSDBuilder extends BuilderBase
             // link resolv library (macOS needs it)
             'EXTRA_LIBS' => "{$this->getOption('extra-libs')} /usr/lib/libm.a",
         ];
-        if (!$this->getOption('no-strip', false)) {
-            shell()->cd(SOURCE_PATH . '/php-src/sapi/micro')->exec('strip --strip-all micro.sfx');
-        }
         $vars = SystemUtil::makeEnvVarString($vars);
 
         shell()->cd(SOURCE_PATH . '/php-src')
             ->exec("make -j{$this->concurrency} {$vars} micro");
+
+        if (!$this->getOption('no-strip', false)) {
+            shell()->cd(SOURCE_PATH . '/php-src/sapi/micro')->exec('strip --strip-all micro.sfx');
+        }
         $this->deployBinary(BUILD_TARGET_MICRO);
 
         if ($this->phar_patched) {

--- a/src/SPC/builder/freebsd/SystemUtil.php
+++ b/src/SPC/builder/freebsd/SystemUtil.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\freebsd;
+
+use SPC\builder\traits\UnixSystemUtilTrait;
+use SPC\exception\RuntimeException;
+use SPC\exception\WrongUsageException;
+
+class SystemUtil
+{
+    /** Unix System Util Compatible */
+    use UnixSystemUtilTrait;
+
+    /**
+     * Get Logic CPU Count for macOS
+     *
+     * @throws RuntimeException
+     */
+    public static function getCpuCount(): int
+    {
+        [$ret, $output] = shell()->execWithResult('sysctl -n hw.ncpu');
+        if ($ret !== 0) {
+            throw new RuntimeException('Failed to get cpu count');
+        }
+
+        return (int) $output[0];
+    }
+
+    /**
+     * Get Target Arch CFlags
+     *
+     * @param  string              $arch Arch Name
+     * @return string              return Arch CFlags string
+     * @throws WrongUsageException
+     */
+    public static function getArchCFlags(string $arch): string
+    {
+        return match ($arch) {
+            'amd64', 'x86_64' => '--target=x86_64-unknown-freebsd',
+            'arm64','aarch64' => '--target=aarch-unknown-freebsd',
+            default => throw new WrongUsageException('unsupported arch: ' . $arch),
+        };
+    }
+}

--- a/src/SPC/builder/freebsd/library/BSDLibraryBase.php
+++ b/src/SPC/builder/freebsd/library/BSDLibraryBase.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\freebsd\library;
+
+use SPC\builder\BuilderBase;
+use SPC\builder\freebsd\BSDBuilder;
+use SPC\builder\LibraryBase;
+use SPC\builder\traits\UnixLibraryTrait;
+
+abstract class BSDLibraryBase extends LibraryBase
+{
+    use UnixLibraryTrait;
+
+    protected array $headers;
+
+    public function __construct(protected BSDBuilder $builder)
+    {
+        parent::__construct();
+    }
+
+    public function getBuilder(): BuilderBase
+    {
+        return $this->builder;
+    }
+}

--- a/src/SPC/builder/freebsd/library/bzip2.php
+++ b/src/SPC/builder/freebsd/library/bzip2.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\freebsd\library;
+
+class bzip2 extends BSDLibraryBase
+{
+    use \SPC\builder\unix\library\bzip2;
+
+    public const NAME = 'bzip2';
+}

--- a/src/SPC/builder/freebsd/library/curl.php
+++ b/src/SPC/builder/freebsd/library/curl.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\freebsd\library;
+
+class curl extends BSDLibraryBase
+{
+    use \SPC\builder\unix\library\curl;
+
+    public const NAME = 'curl';
+
+    public function getStaticLibFiles(string $style = 'autoconf', bool $recursive = true): string
+    {
+        $libs = parent::getStaticLibFiles($style, $recursive);
+        if ($this->builder->getLib('openssl')) {
+            $this->builder->setOption('extra-libs', $this->builder->getOption('extra-libs') . ' /usr/lib/libpthread.a /usr/lib/libdl.a');
+        }
+        return $libs;
+    }
+}

--- a/src/SPC/builder/freebsd/library/onig.php
+++ b/src/SPC/builder/freebsd/library/onig.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\freebsd\library;
+
+class onig extends BSDLibraryBase
+{
+    use \SPC\builder\unix\library\onig;
+
+    public const NAME = 'onig';
+}

--- a/src/SPC/builder/freebsd/library/openssl.php
+++ b/src/SPC/builder/freebsd/library/openssl.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright (c) 2022 Yun Dou <dixyes@gmail.com>
+ *
+ * lwmbs is licensed under Mulan PSL v2. You can use this
+ * software according to the terms and conditions of the
+ * Mulan PSL v2. You may obtain a copy of Mulan PSL v2 at:
+ *
+ * http://license.coscl.org.cn/MulanPSL2
+ *
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *
+ * See the Mulan PSL v2 for more details.
+ */
+
+declare(strict_types=1);
+
+namespace SPC\builder\freebsd\library;
+
+use SPC\builder\macos\library\MacOSLibraryBase;
+use SPC\exception\FileSystemException;
+use SPC\exception\RuntimeException;
+use SPC\exception\WrongUsageException;
+
+class openssl extends BSDLibraryBase
+{
+    public const NAME = 'openssl';
+
+    /**
+     * @throws FileSystemException
+     * @throws RuntimeException
+     * @throws WrongUsageException
+     */
+    protected function build(): void
+    {
+        [$lib,,$destdir] = SEPARATED_PATH;
+
+        // lib:zlib
+        $extra = '';
+        $ex_lib = '';
+        $zlib = $this->builder->getLib('zlib');
+        if ($zlib instanceof MacOSLibraryBase) {
+            $extra = 'zlib';
+            $ex_lib = trim($zlib->getStaticLibFiles() . ' ' . $ex_lib);
+        }
+
+        shell()->cd($this->source_dir)
+            ->exec(
+                "{$this->builder->configure_env} ./Configure no-shared {$extra} " .
+                '--prefix=/ ' . // use prefix=/
+                "--libdir={$lib} " .
+                '--openssldir=/etc/ssl ' .
+                'BSD-' . arch2gnu($this->builder->getOption('arch'))
+            )
+            ->exec('make clean')
+            ->exec("make -j{$this->builder->concurrency} CNF_EX_LIBS=\"{$ex_lib}\"")
+            ->exec("make install_sw DESTDIR={$destdir}");
+        $this->patchPkgconfPrefix(['libssl.pc', 'openssl.pc', 'libcrypto.pc']);
+    }
+}

--- a/src/SPC/builder/freebsd/library/pkgconfig.php
+++ b/src/SPC/builder/freebsd/library/pkgconfig.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\freebsd\library;
+
+/**
+ * gmp is a template library class for unix
+ */
+class pkgconfig extends BSDLibraryBase
+{
+    use \SPC\builder\unix\library\pkgconfig;
+
+    public const NAME = 'pkg-config';
+}

--- a/src/SPC/builder/freebsd/library/zlib.php
+++ b/src/SPC/builder/freebsd/library/zlib.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\freebsd\library;
+
+class zlib extends BSDLibraryBase
+{
+    use \SPC\builder\unix\library\zlib;
+
+    public const NAME = 'zlib';
+}

--- a/src/SPC/doctor/item/BSDToolCheckList.php
+++ b/src/SPC/doctor/item/BSDToolCheckList.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\doctor\item;
+
+use SPC\builder\traits\UnixSystemUtilTrait;
+use SPC\doctor\AsCheckItem;
+use SPC\doctor\AsFixItem;
+use SPC\doctor\CheckResult;
+use SPC\exception\RuntimeException;
+
+class BSDToolCheckList
+{
+    use UnixSystemUtilTrait;
+
+    /** @var string[] FreeBSD */
+    public const REQUIRED_COMMANDS = [
+        'curl',
+        'make',
+        'bison',
+        'flex',
+        'pkg-config',
+        'git',
+        'autoconf',
+        'automake',
+        'tar',
+        'unzip',
+        'xz',
+        'gzip',
+        'bzip2',
+        'cmake',
+    ];
+
+    #[AsCheckItem('if necessary tools are installed', limit_os: 'BSD')]
+    public function checkCliTools(): ?CheckResult
+    {
+        $missing = [];
+        foreach (self::REQUIRED_COMMANDS as $cmd) {
+            if ($this->findCommand($cmd) === null) {
+                $missing[] = $cmd;
+            }
+        }
+        if (!empty($missing)) {
+            return CheckResult::fail('missing system commands: ' . implode(', ', $missing), 'build-tools-bsd', [$missing]);
+        }
+        return CheckResult::ok();
+    }
+
+    #[AsFixItem('build-tools-bsd')]
+    public function fixBuildTools(array $missing): bool
+    {
+        if (get_current_user() !== 'root') {
+            $prefix = 'sudo ';
+            logger()->warning('Current user is not root, using sudo for running command');
+        } else {
+            $prefix = '';
+        }
+        try {
+            shell(true)->exec("ASSUME_ALWAYS_YES=yes {$prefix} pkg install -y " . implode(' ', $missing));
+        } catch (RuntimeException) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/SPC/doctor/item/OSCheckList.php
+++ b/src/SPC/doctor/item/OSCheckList.php
@@ -15,7 +15,7 @@ class OSCheckList
     #[AsCheckItem('if current OS are supported', level: 999)]
     public function checkOS(): ?CheckResult
     {
-        if (!in_array(PHP_OS_FAMILY, ['Darwin', 'Linux'])) {
+        if (!in_array(PHP_OS_FAMILY, ['Darwin', 'Linux', 'BSD'])) {
             return CheckResult::fail('Current OS is not supported');
         }
         return CheckResult::ok(PHP_OS_FAMILY . ' ' . php_uname('m') . ', supported');

--- a/src/SPC/store/Config.php
+++ b/src/SPC/store/Config.php
@@ -54,6 +54,7 @@ class Config
                 'Windows' => ['-windows', '-win', ''],
                 'Darwin' => ['-macos', '-unix', ''],
                 'Linux' => ['-linux', '-unix', ''],
+                'BSD' => ['-freebsd', '-bsd', '-unix', ''],
                 default => throw new WrongUsageException('OS ' . PHP_OS_FAMILY . ' is not supported'),
             };
             foreach ($m_key as $v) {
@@ -98,6 +99,7 @@ class Config
                 'Windows' => ['-windows', '-win', ''],
                 'Darwin' => ['-macos', '-unix', ''],
                 'Linux' => ['-linux', '-unix', ''],
+                'BSD' => ['-freebsd', '-bsd', '-unix', ''],
                 default => throw new WrongUsageException('OS ' . PHP_OS_FAMILY . ' is not supported'),
             };
             foreach ($m_key as $v) {

--- a/src/SPC/store/FileSystem.php
+++ b/src/SPC/store/FileSystem.php
@@ -132,6 +132,7 @@ class FileSystem
                 break;
             case 'Linux':
             case 'Darwin':
+            case 'BSD':
                 f_passthru('cp -r "' . $src_path . '" "' . $dst_path . '"');
                 break;
         }
@@ -154,7 +155,7 @@ class FileSystem
         if ($move_path !== null) {
             $move_path = SOURCE_PATH . '/' . $move_path;
         }
-        logger()->info("extracting {$name} source");
+        logger()->info("extracting {$name} source to " . ($move_path ?? SOURCE_PATH . "/{$name}") . ' ...');
         try {
             $target = $move_path ?? (SOURCE_PATH . "/{$name}");
             // Git source, just move

--- a/src/SPC/store/FileSystem.php
+++ b/src/SPC/store/FileSystem.php
@@ -163,7 +163,7 @@ class FileSystem
                 self::emitSourceExtractHook($name);
                 return;
             }
-            if (PHP_OS_FAMILY === 'Darwin' || PHP_OS_FAMILY === 'Linux') {
+            if (in_array(PHP_OS_FAMILY, ['Darwin', 'Linux', 'BSD'])) {
                 if (f_mkdir(directory: $target, recursive: true) !== true) {
                     throw new FileSystemException('create ' . $name . 'source dir failed');
                 }

--- a/src/SPC/store/SourceExtractor.php
+++ b/src/SPC/store/SourceExtractor.php
@@ -59,9 +59,12 @@ class SourceExtractor
             }
 
             // check source dir exist
-            $check = $lock[$source]['move_path'] === null ? SOURCE_PATH . '/' . $source : SOURCE_PATH . '/' . $lock[$source]['move_path'];
+            $check = $lock[$source]['move_path'] === null ? (SOURCE_PATH . '/' . $source) : (SOURCE_PATH . '/' . $lock[$source]['move_path']);
             if (!is_dir($check)) {
+                logger()->debug('Extracting source [' . $source . '] to ' . $check . ' ...');
                 FileSystem::extractSource($source, DOWNLOAD_PATH . '/' . ($lock[$source]['filename'] ?? $lock[$source]['dirname']), $lock[$source]['move_path']);
+            } else {
+                logger()->debug('Source [' . $source . '] already extracted in ' . $check . ', skip !');
             }
         }
     }

--- a/src/globals/functions.php
+++ b/src/globals/functions.php
@@ -60,6 +60,7 @@ function osfamily2dir(): string
         'Windows', 'WINNT', 'Cygwin' => 'windows',
         'Darwin' => 'macos',
         'Linux' => 'linux',
+        'BSD' => 'freebsd',
         default => throw new WrongUsageException('Not support os: ' . PHP_OS_FAMILY),
     };
 }

--- a/tests/SPC/doctor/CheckListHandlerTest.php
+++ b/tests/SPC/doctor/CheckListHandlerTest.php
@@ -16,6 +16,7 @@ final class CheckListHandlerTest extends TestCase
     {
         $list = new CheckListHandler();
 
-        $this->assertCount(6, $list->runChecks());
+        $id = $list->runChecks();
+        $this->assertCount(7, $id);
     }
 }


### PR DESCRIPTION
If we just implement a standalone php binary in FreeBSD, it is very simple (I only took 2 hours to implement). FreeBSD support is now available with only a few modifications.

The current compilation result is not statically linked, but only `libc.so`, `librt.so`, etc. included by FreeBSD by default are linked. Tested (compiled from 13, run on 12) it's perfect.

I also tried compiling a fully static binary using `-all-static`, and the result of compiling it was very strange: `file php` showed `dynamically linked`, and running it or `ldd php` showed a segfault. Maybe it has something to do with `clang/llvm` and the underlying ELF parsing mode of FreeBSD, but there is very, very little information about this on the Internet.

Documentation PR: https://github.com/crazywhalecc/static-php-cli-docs/pull/2