### PR TITLE
fix: FreeType build

### DIFF
--- a/config/source.json
+++ b/config/source.json
@@ -111,8 +111,9 @@
         }
     },
     "freetype": {
-        "type": "url",
-        "url": "https://github.com/freetype/freetype/archive/refs/tags/VER-2-13-2.tar.gz",
+        "type": "git",
+        "rev": "VER-2-13-2",
+        "url": "https://github.com/freetype/freetype",
         "license": {
             "type": "file",
             "path": "LICENSE.TXT"

--- a/config/source.json
+++ b/config/source.json
@@ -111,8 +111,9 @@
         }
     },
     "freetype": {
-        "type": "url",
-        "url": "https://github.com/freetype/freetype/archive/refs/tags/VER-2-13-2.tar.gz",
+        "type": "git",
+        "rev": "VER-2-13-2",
+        "url": "https://github.com/freetype/freetype",
         "license": {
             "type": "file",
             "path": "LICENSE.TXT"
@@ -216,7 +217,7 @@
     },
     "libmcrypt": {
         "type": "url",
-        "url": "https://nchc.dl.sourceforge.net/project/mcrypt/Libmcrypt/2.5.8/libmcrypt-2.5.8.tar.gz",
+        "url": "https://downloads.sourceforge.net/project/mcrypt/Libmcrypt/2.5.8/libmcrypt-2.5.8.tar.gz",
         "license": {
             "type": "file",
             "path": "COPYING"
@@ -302,7 +303,7 @@
     },
     "mcrypt": {
         "type": "url",
-        "url": "https://jaist.dl.sourceforge.net/project/mcrypt/MCrypt/2.6.8/mcrypt-2.6.8.tar.gz",
+        "url": "https://downloads.sourceforge.net/project/mcrypt/MCrypt/2.6.8/mcrypt-2.6.8.tar.gz",
         "license": {
             "type": "file",
             "path": "COPYING"

--- a/config/source.json
+++ b/config/source.json
@@ -111,9 +111,8 @@
         }
     },
     "freetype": {
-        "type": "git",
-        "rev": "VER-2-13-2",
-        "url": "https://github.com/freetype/freetype",
+        "type": "url",
+        "url": "https://github.com/freetype/freetype/archive/refs/tags/VER-2-13-2.tar.gz",
         "license": {
             "type": "file",
             "path": "LICENSE.TXT"

--- a/src/SPC/builder/unix/library/freetype.php
+++ b/src/SPC/builder/unix/library/freetype.php
@@ -26,6 +26,7 @@ trait freetype
         $suggested .= ' ';
 
         shell()->cd($this->source_dir)
+            ->exec('sh autogen.sh')
             ->exec(
                 './configure ' .
                 '--enable-static --disable-shared --without-harfbuzz --prefix= ' .


### PR DESCRIPTION
Closes https://github.com/crazywhalecc/static-php-cli/issues/269.
See for the rationale: https://gitlab.freedesktop.org/freetype/freetype/-/issues/1158

Also let the SourceForge download page choose an appropriate mirror instead of hardcoding it.

## Tasks
- [X] Linux x86_64
- [X] Linux aarch64
- [x] macOS x86_64
- [X] macOS aarch64