### PR TITLE
Add tidy support

### DIFF
--- a/config/ext.json
+++ b/config/ext.json
@@ -278,11 +278,6 @@
             "sqlite"
         ]
     },
-    "rar": {
-        "type": "external",
-        "source": "rar",
-        "cpp-extension": true
-    },
     "pgsql": {
         "type": "builtin",
         "arg-type": "with-prefix",
@@ -310,6 +305,11 @@
         "lib-depends": [
             "aspell"
         ]
+    },
+    "rar": {
+        "type": "external",
+        "source": "rar",
+        "cpp-extension": true
     },
     "readline": {
         "type": "builtin",
@@ -435,7 +435,7 @@
     },
     "tidy": {
         "type": "builtin",
-        "arg-type": "with",
+        "arg-type": "with-prefix",
         "lib-depends": [
             "tidy"
         ]

--- a/config/lib.json
+++ b/config/lib.json
@@ -483,6 +483,12 @@
             "sqlite3ext.h"
         ]
     },
+    "tidy": {
+        "source": "tidy",
+        "static-libs-unix": [
+            "libtidy.a"
+        ]
+    },
     "xz": {
         "source": "xz",
         "static-libs-unix": [

--- a/config/source.json
+++ b/config/source.json
@@ -51,16 +51,6 @@
             "path": "LICENSE"
         }
     },
-    "rar": {
-        "type": "git",
-        "url": "https://github.com/static-php/php-rar.git",
-        "path": "php-src/ext/rar",
-        "rev": "issue-php82",
-        "license": {
-            "type": "file",
-            "path": "LICENSE"
-        }
-    },
     "ext-glfw": {
         "type": "git",
         "url": "https://github.com/mario-deluna/php-glfw",
@@ -412,6 +402,16 @@
             "path": "LICENSE"
         }
     },
+    "rar": {
+        "type": "git",
+        "url": "https://github.com/static-php/php-rar.git",
+        "path": "php-src/ext/rar",
+        "rev": "issue-php82",
+        "license": {
+            "type": "file",
+            "path": "LICENSE"
+        }
+    },
     "readline": {
         "type": "filelist",
         "url": "https://ftp.gnu.org/pub/gnu/readline/",
@@ -467,6 +467,15 @@
         "license": {
             "type": "file",
             "path": "LICENSE"
+        }
+    },
+    "tidy": {
+        "type": "url",
+        "url": "https://github.com/htacg/tidy-html5/archive/refs/tags/5.8.0.tar.gz",
+        "filename": "tidy-html5.tgz",
+        "license": {
+            "type": "file",
+            "path": "README/LICENSE.md"
         }
     },
     "xlswriter": {

--- a/src/SPC/builder/linux/library/tidy.php
+++ b/src/SPC/builder/linux/library/tidy.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\linux\library;
+
+class tidy extends LinuxLibraryBase
+{
+    use \SPC\builder\unix\library\tidy;
+
+    public const NAME = 'tidy';
+}

--- a/src/SPC/builder/macos/library/tidy.php
+++ b/src/SPC/builder/macos/library/tidy.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\macos\library;
+
+class tidy extends MacOSLibraryBase
+{
+    use \SPC\builder\unix\library\tidy;
+
+    public const NAME = 'tidy';
+}

--- a/src/SPC/builder/unix/library/tidy.php
+++ b/src/SPC/builder/unix/library/tidy.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\unix\library;
+
+use SPC\exception\FileSystemException;
+use SPC\exception\RuntimeException;
+use SPC\store\FileSystem;
+
+trait tidy
+{
+    /**
+     * @throws RuntimeException
+     * @throws FileSystemException
+     */
+    protected function build(): void
+    {
+        FileSystem::resetDir($this->source_dir . '/build-dir');
+        shell()->cd($this->source_dir . '/build-dir')
+            ->exec(
+                'cmake ' .
+                "{$this->builder->makeCmakeArgs()} " .
+                '-DBUILD_SHARED_LIB=OFF ' .
+                '-DSUPPORT_CONSOLE_APP=OFF ' .
+                '..'
+            )
+            ->exec("cmake --build . -j {$this->builder->concurrency}")
+            ->exec('make install DESTDIR=' . BUILD_ROOT_PATH);
+        $this->patchPkgconfPrefix(['tidy.pc']);
+    }
+}

--- a/src/globals/test-extensions.php
+++ b/src/globals/test-extensions.php
@@ -3,6 +3,6 @@
 declare(strict_types=1);
 
 # If you want to test new extensions here, just modify it.
-$extensions = 'rar,zlib,zip';
+$extensions = 'tidy,bcmath,bz2,calendar,ctype,curl,dom,exif,fileinfo,filter,ftp,gd,gmp,iconv,xml,mbstring,mbregex,mysqlnd,openssl,pcntl,pdo,pdo_mysql,pdo_sqlite,phar,posix,redis,session,simplexml,soap,sockets,sqlite3,tokenizer,xmlwriter,xmlreader,zlib,zip';
 
 echo $extensions;


### PR DESCRIPTION
## What does this PR do?

Add tidy extension and libtidy support.

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [X] If it's a extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [ ] If you changed the behavior of static-php-cli, add docs in [static-php/static-php-cli-docs](https://github.com/static-php/static-php-cli-docs) .
- [X] If you updated `config/xxxx.json` content, run `bin/spc dev:sort-config xxx`.

### Tasks
- [ ] Documentation
- [x] Linux x86_64 test
- [x] Linux aarch64 test
- [x] macOS x86_64 test
- [x] macOS aarch64 test
- [x] Comon extension integration test
