### PR TITLE
fix libtool missing bug for freetype

### DIFF
--- a/bin/spc-alpine-docker
+++ b/bin/spc-alpine-docker
@@ -73,6 +73,7 @@ RUN apk update; \
         git \
         jq \
         libgcc \
+        libtool \
         libstdc++ \
         linux-headers \
         m4 \

--- a/config/ext.json
+++ b/config/ext.json
@@ -228,7 +228,8 @@
         ]
     },
     "opcache": {
-        "type": "builtin"
+        "type": "builtin",
+        "arg-type": "custom"
     },
     "openssl": {
         "type": "builtin",

--- a/src/SPC/builder/extension/opcache.php
+++ b/src/SPC/builder/extension/opcache.php
@@ -5,11 +5,25 @@ declare(strict_types=1);
 namespace SPC\builder\extension;
 
 use SPC\builder\Extension;
+use SPC\exception\RuntimeException;
+use SPC\exception\WrongUsageException;
 use SPC\util\CustomExt;
 
 #[CustomExt('opcache')]
 class opcache extends Extension
 {
+    /**
+     * @throws WrongUsageException
+     * @throws RuntimeException
+     */
+    public function getUnixConfigureArg(): string
+    {
+        if ($this->builder->getPHPVersionID() < 80000) {
+            throw new WrongUsageException('Statically compiled PHP with Zend Opcache only available for PHP >= 8.0 !');
+        }
+        return '--enable-opcache';
+    }
+
     public function getDistName(): string
     {
         return 'Zend Opcache';

--- a/src/SPC/doctor/item/LinuxToolCheckList.php
+++ b/src/SPC/doctor/item/LinuxToolCheckList.php
@@ -21,6 +21,7 @@ class LinuxToolCheckList
         'tar', 'unzip', 'gzip',
         'bzip2', 'cmake', 'gcc',
         'g++', 'patch', 'binutils-gold',
+        'libtoolize',
     ];
 
     public const TOOLS_DEBIAN = [
@@ -102,7 +103,8 @@ class LinuxToolCheckList
         try {
             $is_debian = in_array($distro['dist'], ['debian', 'ubuntu']);
             $to_install = $is_debian ? str_replace('xz', 'xz-utils', $missing) : $missing;
-            $to_install = $is_debian ? str_replace('libtoolize', 'libtool', $to_install) : $to_install;
+            // debian, alpine libtool -> libtoolize
+            $to_install = str_replace('libtoolize', 'libtool', $to_install);
             shell(true)->exec($prefix . $install_cmd . ' ' . implode(' ', $to_install));
         } catch (RuntimeException) {
             return false;


### PR DESCRIPTION
## What does this PR do?

- Add missing `libtool` for doctor and docker (freetype use `libtoolize`)
- Refactor build command starting log
- Add limitation for opcache extension when compiling with 7.x

Fix #282