### PR TITLE
add extension ardillo support

### DIFF
--- a/config/ext.json
+++ b/config/ext.json
@@ -3,6 +3,14 @@
         "type": "external",
         "source": "apcu"
     },
+    "ardillo": {
+        "type": "external",
+        "source": "ardillo",
+        "arg-type": "enable",
+        "lib-depends": [
+            "libui-ng"
+        ]
+    },
     "bcmath": {
         "type": "builtin"
     },

--- a/config/lib.json
+++ b/config/lib.json
@@ -294,6 +294,17 @@
             "zlib"
         ]
     },
+    "libui-ng": {
+        "source": "ardillo",
+        "static-libs-unix": [
+            "libui.a",
+            "libcmocka.a"
+        ],
+        "frameworks": [
+            "CoreFoundation",
+            "AppKit"
+        ]
+    },
     "libuv": {
         "source": "libuv",
         "static-libs-unix": [

--- a/config/source.json
+++ b/config/source.json
@@ -16,6 +16,15 @@
             "path": "LICENSE"
         }
     },
+    "ardillo": {
+        "type": "git",
+        "rev": "master",
+        "url": "https://github.com/ardillo-php/ext.git",
+        "license": {
+            "type": "text",
+            "text": "NO LICENSE FILE"
+        }
+    },
     "brotli": {
         "type": "ghtar",
         "repo": "google/brotli",

--- a/src/SPC/builder/extension/ardillo.php
+++ b/src/SPC/builder/extension/ardillo.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\extension;
+
+use SPC\builder\Extension;
+use SPC\store\FileSystem;
+use SPC\util\CustomExt;
+
+#[CustomExt('ardillo')]
+class ardillo extends Extension
+{
+    public function patchBeforeBuildconf(): bool
+    {
+        if (!is_dir(SOURCE_PATH . '/php-src/ext/ardillo')) {
+            FileSystem::copyDir(SOURCE_PATH . '/ardillo', SOURCE_PATH . '/php-src/ext/ardillo');
+        }
+        FileSystem::replaceFileStr(
+            SOURCE_PATH . '/php-src/ext/ardillo/config.m4',
+            'ARDILLO_CFLAGS="-Wl,--verbose -I$ARDILLO_DIR/libui-ng"',
+            'ARDILLO_CFLAGS="-Wl,--verbose -I$ARDILLO_DIR/../../../../buildroot/include"'
+        );
+        FileSystem::replaceFileStr(
+            SOURCE_PATH . '/php-src/ext/ardillo/config.m4',
+            'UI_LIB="-L$CURRENT_DIR/libui-ng/build/meson-out -Wl,-Bstatic -lui"',
+            'UI_LIB="-L$CURRENT_DIR/../../buildroot/lib -Wl,-Bstatic -lui"'
+        );
+        return true;
+    }
+}

--- a/src/SPC/builder/macos/library/libui_ng.php
+++ b/src/SPC/builder/macos/library/libui_ng.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\macos\library;
+
+/**
+ * is a template library class for unix
+ */
+class libui_ng extends MacOSLibraryBase
+{
+    use \SPC\builder\unix\library\libui_ng;
+
+    public const NAME = 'libui-ng';
+}

--- a/src/SPC/builder/unix/library/libui_ng.php
+++ b/src/SPC/builder/unix/library/libui_ng.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\unix\library;
+
+trait libui_ng
+{
+    public function build(): void
+    {
+        shell()->cd(SOURCE_PATH . '/ardillo/libui-ng')
+            ->exec('meson setup --default-library=static --prefix=' . BUILD_ROOT_PATH . ' build')
+            ->exec('ninja -C build install');
+    }
+}

--- a/src/SPC/doctor/item/LinuxToolCheckList.php
+++ b/src/SPC/doctor/item/LinuxToolCheckList.php
@@ -21,7 +21,7 @@ class LinuxToolCheckList
         'tar', 'unzip', 'gzip',
         'bzip2', 'cmake', 'gcc',
         'g++', 'patch', 'binutils-gold',
-        'libtoolize',
+        'libtoolize', 'meson',
     ];
 
     public const TOOLS_DEBIAN = [
@@ -29,7 +29,7 @@ class LinuxToolCheckList
         'git', 'autoconf', 'automake',
         'tar', 'unzip', 'gzip',
         'bzip2', 'cmake', 'patch',
-        'xz', 'libtoolize',
+        'xz', 'libtoolize', 'meson',
     ];
 
     public const TOOLS_RHEL = [
@@ -37,7 +37,7 @@ class LinuxToolCheckList
         'git', 'autoconf', 'automake',
         'tar', 'unzip', 'gzip', 'gcc',
         'bzip2', 'cmake', 'patch',
-        'xz',
+        'xz', 'meson',
     ];
 
     /** @noinspection PhpUnused */

--- a/src/SPC/doctor/item/MacOSToolCheckList.php
+++ b/src/SPC/doctor/item/MacOSToolCheckList.php
@@ -31,6 +31,7 @@ class MacOSToolCheckList
         'gzip',
         'bzip2',
         'cmake',
+        'meson',
     ];
 
     #[AsCheckItem('if homebrew has installed', limit_os: 'Darwin', level: 998)]

--- a/src/SPC/doctor/item/OSCheckList.php
+++ b/src/SPC/doctor/item/OSCheckList.php
@@ -21,6 +21,6 @@ class OSCheckList
         }
         $distro = PHP_OS_FAMILY === 'Linux' ? (' ' . SystemUtil::getOSRelease()['dist']) : '';
         $known_distro = PHP_OS_FAMILY === 'Linux' && in_array(SystemUtil::getOSRelease()['dist'], SystemUtil::getSupportedDistros());
-        return CheckResult::ok(PHP_OS_FAMILY . ' ' . php_uname('m') . $distro . ', supported' . ($known_distro ? '' : ' (but not tested on this distro)'));
+        return CheckResult::ok(PHP_OS_FAMILY . ' ' . php_uname('m') . $distro . ', supported' . ($known_distro && PHP_OS_FAMILY === 'Linux' ? '' : ' (but not tested on this distro)'));
     }
 }

--- a/src/globals/test-extensions.php
+++ b/src/globals/test-extensions.php
@@ -13,7 +13,8 @@ declare(strict_types=1);
 
 // If you want to test your added extensions and libs, add below (comma separated, example `bcmath,openssl`).
 $extensions = match (PHP_OS_FAMILY) {
-    'Linux', 'Darwin' => '',
+    'Linux' => '',
+    'Darwin' => 'ardillo',
     'Windows' => 'mbstring,openssl',
 };
 
@@ -27,7 +28,7 @@ $with_libs = match (PHP_OS_FAMILY) {
 // You can use `common`, `bulk`, `minimal` or `none`.
 // note: combination is only available for *nix platform. Windows must use `none` combination
 $base_combination = match (PHP_OS_FAMILY) {
-    'Linux', 'Darwin' => 'bulk',
+    'Linux', 'Darwin' => 'common',
     'Windows' => 'none',
 };
 


### PR DESCRIPTION
## What does this PR do?

Fix #317 . 

It is currently only tested on macOS, and the support is not perfect (for example, clicking the menu bar will delete it, but I am not sure if it is a problem with libui itself).

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [ ] If it's a extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [ ] If you changed the behavior of static-php-cli, add docs in [static-php/static-php-cli-docs](https://github.com/static-php/static-php-cli-docs) .
- [x] If you updated `config/xxxx.json` content, run `bin/spc dev:sort-config xxx`.
