### PR TITLE
Patch for PHP >= 8.4

### DIFF
--- a/src/SPC/builder/windows/WindowsBuilder.php
+++ b/src/SPC/builder/windows/WindowsBuilder.php
@@ -150,6 +150,8 @@ class WindowsBuilder extends BuilderBase
         $makefile = FileSystem::readFile(SOURCE_PATH . '\php-src\Makefile');
         if ($this->getPHPVersionID() >= 80200 && str_contains($makefile, 'FIBER_ASM_ARCH')) {
             $makefile .= "\r\n" . '$(MICRO_SFX): $(BUILD_DIR)\Zend\jump_$(FIBER_ASM_ARCH)_ms_pe_masm.obj $(BUILD_DIR)\Zend\make_$(FIBER_ASM_ARCH)_ms_pe_masm.obj' . "\r\n\r\n";
+        } elseif ($this->getPHPVersionID() >= 84000 && str_contains($makefile, 'FIBER_ASM_ABI')) {
+            $makefile .= "\r\n" . '$(MICRO_SFX): $(BUILD_DIR)\Zend\jump_$(FIBER_ASM_ABI).obj $(BUILD_DIR)\Zend\make_$(FIBER_ASM_ABI).obj' . "\r\n\r\n";
         }
         FileSystem::writeFile(SOURCE_PATH . '\php-src\Makefile', $makefile);
 

--- a/src/SPC/builder/windows/WindowsBuilder.php
+++ b/src/SPC/builder/windows/WindowsBuilder.php
@@ -150,7 +150,7 @@ class WindowsBuilder extends BuilderBase
         $makefile = FileSystem::readFile(SOURCE_PATH . '\php-src\Makefile');
         if ($this->getPHPVersionID() >= 80200 && str_contains($makefile, 'FIBER_ASM_ARCH')) {
             $makefile .= "\r\n" . '$(MICRO_SFX): $(BUILD_DIR)\Zend\jump_$(FIBER_ASM_ARCH)_ms_pe_masm.obj $(BUILD_DIR)\Zend\make_$(FIBER_ASM_ARCH)_ms_pe_masm.obj' . "\r\n\r\n";
-        } elseif ($this->getPHPVersionID() >= 84000 && str_contains($makefile, 'FIBER_ASM_ABI')) {
+        } elseif ($this->getPHPVersionID() >= 80400 && str_contains($makefile, 'FIBER_ASM_ABI')) {
             $makefile .= "\r\n" . '$(MICRO_SFX): $(BUILD_DIR)\Zend\jump_$(FIBER_ASM_ABI).obj $(BUILD_DIR)\Zend\make_$(FIBER_ASM_ABI).obj' . "\r\n\r\n";
         }
         FileSystem::writeFile(SOURCE_PATH . '\php-src\Makefile', $makefile);


### PR DESCRIPTION
## What does this PR do?

Hello, I've removed the FIBER_ASM_ARCH in favor of the FIBER_ASM_ABI in PHP 8.4 Windows build system. This fixes the build for PHP >= 8.4 if this patch is still needed here. Thanks.

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [x] If it's a extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [x] If you changed the behavior of static-php-cli, add docs in [static-php/static-php-cli-docs](https://github.com/static-php/static-php-cli-docs) .
- [x] If you updated `config/xxxx.json` content, run `bin/spc dev:sort-config xxx`.
