### PR TITLE
add static-php-cli.version ini for php-src

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -154,4 +154,4 @@ jobs:
         run: bin/spc download --for-extensions="$(php src/globals/test-extensions.php extensions)" --with-php=${{ matrix.php }} --debug
 
       - name: "Run Build Tests (build)"
-        run: bin/spc build $(php src/globals/test-extensions.php cmd) --build-cli --build-micro --build-fpm --debug
+        run: bin/spc build "$(php src/globals/test-extensions.php extensions)" $(php src/globals/test-extensions.php libs_cmd) --build-cli --build-micro --build-fpm --debug

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,6 +115,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
+          - macos-14
       fail-fast: false
     steps:
       - name: "Checkout"

--- a/src/SPC/ConsoleApplication.php
+++ b/src/SPC/ConsoleApplication.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Command\ListCommand;
  */
 final class ConsoleApplication extends Application
 {
-    public const VERSION = '2.1.0-beta.1';
+    public const VERSION = '2.1.0-beta.2';
 
     public function __construct()
     {

--- a/src/SPC/command/BuildCliCommand.php
+++ b/src/SPC/command/BuildCliCommand.php
@@ -104,6 +104,9 @@ class BuildCliCommand extends BuildCommand
                 SourcePatcher::patchHardcodedINI($custom_ini);
             }
 
+            // add static-php-cli.version to main.c, in order to debug php failure more easily
+            SourcePatcher::patchSPCVersionToPHP($this->getApplication()->getVersion());
+
             // start to build
             $builder->buildPHP($rule);
 

--- a/src/SPC/store/SourcePatcher.php
+++ b/src/SPC/store/SourcePatcher.php
@@ -296,4 +296,20 @@ class SourcePatcher
         $lines[$line_num + 1] = "\t" . '"$(LINK)" /nologo $(PHP_GLOBAL_OBJS_RESP) $(CLI_GLOBAL_OBJS_RESP) $(STATIC_EXT_OBJS_RESP) $(STATIC_EXT_LIBS) $(ASM_OBJS) $(LIBS) $(LIBS_CLI) $(BUILD_DIR)\php.exe.res /out:$(BUILD_DIR)\php.exe $(LDFLAGS) $(LDFLAGS_CLI) /ltcg /nodefaultlib:msvcrt /nodefaultlib:msvcrtd /ignore:4286';
         FileSystem::writeFile(SOURCE_PATH . '/php-src/Makefile', implode("\r\n", $lines));
     }
+
+    /**
+     * Add additional `static-php-cli.version` ini value for PHP source.
+     *
+     * @throws FileSystemException
+     */
+    public static function patchSPCVersionToPHP(string $version = 'unknown'): void
+    {
+        // detect patch
+        $file = FileSystem::readFile(SOURCE_PATH . '/php-src/main/main.c');
+        if (!str_contains($file, 'static-php-cli.version')) {
+            logger()->debug('Inserting static-php-cli.version to php-src');
+            $file = str_replace('PHP_INI_BEGIN()', "PHP_INI_BEGIN()\n\tPHP_INI_ENTRY(\"static-php-cli.version\",\t\"{$version}\",\tPHP_INI_ALL,\tNULL)", $file);
+            FileSystem::writeFile(SOURCE_PATH . '/php-src/main/main.c', $file);
+        }
+    }
 }

--- a/src/globals/test-extensions.php
+++ b/src/globals/test-extensions.php
@@ -69,6 +69,7 @@ if (PHP_OS_FAMILY === 'Windows') {
 echo match ($argv[1]) {
     'extensions' => $final_extensions,
     'libs' => $final_libs,
+    'libs_cmd' => ($final_libs === '' ? '' : (' --with-libs="' . $final_libs . '"')),
     'cmd' => $final_extensions_cmd . ($final_libs === '' ? '' : (' --with-libs="' . $final_libs . '"')),
     default => '',
 };


### PR DESCRIPTION
## What does this PR do?

Fix #325 

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [X] If it's a extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [X] If you changed the behavior of static-php-cli, add docs in [static-php/static-php-cli-docs](https://github.com/static-php/static-php-cli-docs) .
- [X] If you updated `config/xxxx.json` content, run `bin/spc dev:sort-config xxx`.
