### PR TITLE
feat: Add package management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ docker/source/
 # default source build root directory
 /buildroot/
 
+# default package root directory
+/pkgroot/
+
 # tools cache files
 .php-cs-fixer.cache
 .phpunit.result.cache

--- a/config/pkg.json
+++ b/config/pkg.json
@@ -1,4 +1,8 @@
 {
+    "musl-toolchain-aarch64-linux": {
+        "type": "url",
+        "url": "https://dl.static-php.dev/static-php-cli/deps/musl-toolchain/aarch64-musl-toolchain.tgz"
+    },
     "musl-toolchain-x86_64-linux": {
         "type": "url",
         "url": "https://dl.static-php.dev/static-php-cli/deps/musl-toolchain/x86_64-musl-toolchain.tgz"

--- a/config/pkg.json
+++ b/config/pkg.json
@@ -1,0 +1,32 @@
+{
+    "upx-x86_64-linux": {
+        "type": "url",
+        "url": "https://github.com/upx/upx/releases/download/v4.2.2/upx-4.2.2-amd64_linux.tar.xz",
+        "extract-files": {
+            "upx": "{pkg_root_path}/bin/upx"
+        }
+    },
+    "upx-aarch64-linux": {
+        "type": "url",
+        "url": "https://github.com/upx/upx/releases/download/v4.2.2/upx-4.2.2-arm64_linux.tar.xz",
+        "extract-files": {
+            "upx": "{pkg_root_path}/bin/upx"
+        }
+    },
+    "nasm-x86_64-win": {
+        "type": "url",
+        "url": "https://www.nasm.us/pub/nasm/releasebuilds/2.16.01/win64/nasm-2.16.01-win64.zip",
+        "extract-files": {
+            "nasm-2.16.01/nasm.exe": "{php_sdk_path}/bin/nasm.exe",
+            "nasm-2.16.01/ndisasm.exe": "{php_sdk_path}/bin/ndisasm.exe"
+        }
+    },
+    "strawberry-perl-x86_64-win": {
+        "type": "url",
+        "url": "https://github.com/StrawberryPerl/Perl-Dist-Strawberry/releases/download/SP_5380_5361/strawberry-perl-5.38.0.1-64bit-portable.zip"
+    },
+    "musl-toolchain-x86_64-linux": {
+        "type": "url",
+        "url": "https://dl.static-php.dev/static-php-cli/deps/musl-toolchain/x86_64-musl-toolchain.tgz"
+    }
+}

--- a/config/pkg.json
+++ b/config/pkg.json
@@ -1,17 +1,7 @@
 {
-    "upx-x86_64-linux": {
+    "musl-toolchain-x86_64-linux": {
         "type": "url",
-        "url": "https://github.com/upx/upx/releases/download/v4.2.2/upx-4.2.2-amd64_linux.tar.xz",
-        "extract-files": {
-            "upx": "{pkg_root_path}/bin/upx"
-        }
-    },
-    "upx-aarch64-linux": {
-        "type": "url",
-        "url": "https://github.com/upx/upx/releases/download/v4.2.2/upx-4.2.2-arm64_linux.tar.xz",
-        "extract-files": {
-            "upx": "{pkg_root_path}/bin/upx"
-        }
+        "url": "https://dl.static-php.dev/static-php-cli/deps/musl-toolchain/x86_64-musl-toolchain.tgz"
     },
     "nasm-x86_64-win": {
         "type": "url",
@@ -25,8 +15,18 @@
         "type": "url",
         "url": "https://github.com/StrawberryPerl/Perl-Dist-Strawberry/releases/download/SP_5380_5361/strawberry-perl-5.38.0.1-64bit-portable.zip"
     },
-    "musl-toolchain-x86_64-linux": {
+    "upx-aarch64-linux": {
         "type": "url",
-        "url": "https://dl.static-php.dev/static-php-cli/deps/musl-toolchain/x86_64-musl-toolchain.tgz"
+        "url": "https://github.com/upx/upx/releases/download/v4.2.2/upx-4.2.2-arm64_linux.tar.xz",
+        "extract-files": {
+            "upx": "{pkg_root_path}/bin/upx"
+        }
+    },
+    "upx-x86_64-linux": {
+        "type": "url",
+        "url": "https://github.com/upx/upx/releases/download/v4.2.2/upx-4.2.2-amd64_linux.tar.xz",
+        "extract-files": {
+            "upx": "{pkg_root_path}/bin/upx"
+        }
     }
 }

--- a/config/pkg.json
+++ b/config/pkg.json
@@ -16,15 +16,17 @@
         "url": "https://github.com/StrawberryPerl/Perl-Dist-Strawberry/releases/download/SP_5380_5361/strawberry-perl-5.38.0.1-64bit-portable.zip"
     },
     "upx-aarch64-linux": {
-        "type": "url",
-        "url": "https://github.com/upx/upx/releases/download/v4.2.2/upx-4.2.2-arm64_linux.tar.xz",
+        "type": "ghrel",
+        "repo": "upx/upx",
+        "match": "upx.+-arm64_linux\\.tar\\.xz",
         "extract-files": {
             "upx": "{pkg_root_path}/bin/upx"
         }
     },
     "upx-x86_64-linux": {
-        "type": "url",
-        "url": "https://github.com/upx/upx/releases/download/v4.2.2/upx-4.2.2-amd64_linux.tar.xz",
+        "type": "ghrel",
+        "repo": "upx/upx",
+        "match": "upx.+-amd64_linux\\.tar\\.xz",
         "extract-files": {
             "upx": "{pkg_root_path}/bin/upx"
         }

--- a/src/SPC/ConsoleApplication.php
+++ b/src/SPC/ConsoleApplication.php
@@ -6,6 +6,7 @@ namespace SPC;
 
 use SPC\command\BuildCliCommand;
 use SPC\command\BuildLibsCommand;
+use SPC\command\DeleteDownloadCommand;
 use SPC\command\dev\AllExtCommand;
 use SPC\command\dev\PhpVerCommand;
 use SPC\command\dev\SortConfigCommand;
@@ -13,6 +14,7 @@ use SPC\command\DoctorCommand;
 use SPC\command\DownloadCommand;
 use SPC\command\DumpLicenseCommand;
 use SPC\command\ExtractCommand;
+use SPC\command\InstallPkgCommand;
 use SPC\command\MicroCombineCommand;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\HelpCommand;
@@ -23,7 +25,7 @@ use Symfony\Component\Console\Command\ListCommand;
  */
 final class ConsoleApplication extends Application
 {
-    public const VERSION = '2.1.0-beta.3';
+    public const VERSION = '2.1.0-beta.4';
 
     public function __construct()
     {
@@ -35,6 +37,8 @@ final class ConsoleApplication extends Application
                 new BuildLibsCommand(),
                 new DoctorCommand(),
                 new DownloadCommand(),
+                new InstallPkgCommand(),
+                new DeleteDownloadCommand(),
                 new DumpLicenseCommand(),
                 new ExtractCommand(),
                 new MicroCombineCommand(),

--- a/src/SPC/builder/BuilderBase.php
+++ b/src/SPC/builder/BuilderBase.php
@@ -9,7 +9,7 @@ use SPC\exception\FileSystemException;
 use SPC\exception\RuntimeException;
 use SPC\exception\WrongUsageException;
 use SPC\store\Config;
-use SPC\store\SourceExtractor;
+use SPC\store\SourceManager;
 use SPC\util\CustomExt;
 
 abstract class BuilderBase
@@ -144,15 +144,15 @@ abstract class BuilderBase
     {
         CustomExt::loadCustomExt();
         $this->emitPatchPoint('before-php-extract');
-        SourceExtractor::initSource(sources: ['php-src']);
+        SourceManager::initSource(sources: ['php-src']);
         $this->emitPatchPoint('after-php-extract');
         if ($this->getPHPVersionID() >= 80000) {
             $this->emitPatchPoint('before-micro-extract');
-            SourceExtractor::initSource(sources: ['micro']);
+            SourceManager::initSource(sources: ['micro']);
             $this->emitPatchPoint('after-micro-extract');
         }
         $this->emitPatchPoint('before-exts-extract');
-        SourceExtractor::initSource(exts: $extensions);
+        SourceManager::initSource(exts: $extensions);
         $this->emitPatchPoint('after-exts-extract');
         foreach ($extensions as $extension) {
             $class = CustomExt::getExtClass($extension);

--- a/src/SPC/builder/unix/UnixBuilderBase.php
+++ b/src/SPC/builder/unix/UnixBuilderBase.php
@@ -11,7 +11,7 @@ use SPC\exception\RuntimeException;
 use SPC\exception\WrongUsageException;
 use SPC\store\Config;
 use SPC\store\FileSystem;
-use SPC\store\SourceExtractor;
+use SPC\store\SourceManager;
 use SPC\util\DependencyUtil;
 
 abstract class UnixBuilderBase extends BuilderBase
@@ -134,7 +134,7 @@ abstract class UnixBuilderBase extends BuilderBase
         $this->emitPatchPoint('before-libs-extract');
 
         // extract sources
-        SourceExtractor::initSource(libs: $sorted_libraries);
+        SourceManager::initSource(libs: $sorted_libraries);
 
         $this->emitPatchPoint('after-libs-extract');
 

--- a/src/SPC/builder/windows/WindowsBuilder.php
+++ b/src/SPC/builder/windows/WindowsBuilder.php
@@ -10,7 +10,7 @@ use SPC\exception\RuntimeException;
 use SPC\exception\WrongUsageException;
 use SPC\store\Config;
 use SPC\store\FileSystem;
-use SPC\store\SourceExtractor;
+use SPC\store\SourceManager;
 use SPC\store\SourcePatcher;
 use SPC\util\DependencyUtil;
 
@@ -211,7 +211,7 @@ class WindowsBuilder extends BuilderBase
         }
 
         // extract sources
-        SourceExtractor::initSource(libs: $sorted_libraries);
+        SourceManager::initSource(libs: $sorted_libraries);
 
         // build all libs
         foreach ($this->libs as $lib) {

--- a/src/SPC/builder/windows/library/openssl.php
+++ b/src/SPC/builder/windows/library/openssl.php
@@ -14,7 +14,8 @@ class openssl extends WindowsLibraryBase
 
     protected function build(): void
     {
-        $perl = file_exists(BUILD_ROOT_PATH . '\perl\perl\bin\perl.exe') ? (BUILD_ROOT_PATH . '\perl\perl\bin\perl.exe') : SystemUtil::findCommand('perl.exe');
+        $perl_path_native = PKG_ROOT_PATH . '\strawberry-perl-' . arch2gnu(php_uname('m')) . '-win\perl\bin\perl.exe';
+        $perl = file_exists($perl_path_native) ? ($perl_path_native) : SystemUtil::findCommand('perl.exe');
         if ($perl === null) {
             throw new RuntimeException('You need to install perl first! (easiest way is using static-php-cli command "doctor")');
         }

--- a/src/SPC/command/BuildCliCommand.php
+++ b/src/SPC/command/BuildCliCommand.php
@@ -58,6 +58,9 @@ class BuildCliCommand extends BuildCommand
             $this->output->writeln("<comment>\t--build-all\tBuild all SAPI: cli, micro, fpm, embed</comment>");
             return static::FAILURE;
         }
+        if ($rule === BUILD_TARGET_ALL) {
+            logger()->warning('--build-all option makes `--no-strip` always true, be aware!');
+        }
         try {
             // create builder
             $builder = BuilderProvider::makeBuilderByInput($this->input);

--- a/src/SPC/command/DeleteDownloadCommand.php
+++ b/src/SPC/command/DeleteDownloadCommand.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\command;
+
+use SPC\exception\DownloaderException;
+use SPC\exception\FileSystemException;
+use SPC\exception\WrongUsageException;
+use SPC\store\FileSystem;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand('del-download', 'Remove locked download source or package using name', ['delete-download', 'del-down'])]
+class DeleteDownloadCommand extends BaseCommand
+{
+    public function configure(): void
+    {
+        $this->addArgument('sources', InputArgument::REQUIRED, 'The sources/packages will be deleted, comma separated');
+        $this->addOption('all', 'A', null, 'Delete all downloaded and locked sources/packages');
+    }
+
+    public function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        if ($input->getOption('all')) {
+            $input->setArgument('sources', '');
+        }
+        parent::initialize($input, $output);
+    }
+
+    /**
+     * @throws FileSystemException
+     */
+    public function handle(): int
+    {
+        try {
+            // get source list that will be downloaded
+            $sources = array_map('trim', array_filter(explode(',', $this->getArgument('sources'))));
+            if (empty($sources)) {
+                logger()->notice('Removing downloads/ directory ...');
+                FileSystem::removeDir(DOWNLOAD_PATH);
+                logger()->info('Removed downloads/ dir!');
+                return static::SUCCESS;
+            }
+            $chosen_sources = $sources;
+            $lock = json_decode(FileSystem::readFile(DOWNLOAD_PATH . '/.lock.json'), true) ?? [];
+
+            foreach ($chosen_sources as $source) {
+                $source = trim($source);
+                if (!isset($lock[$source])) {
+                    logger()->warning("Source/Package [{$source}] not locked or not downloaded, skipped.");
+                    continue;
+                }
+                // remove download file/dir if exists
+                if ($lock[$source]['source_type'] === 'archive') {
+                    if (file_exists($path = FileSystem::convertPath(DOWNLOAD_PATH . '/' . $lock[$source]['filename']))) {
+                        logger()->info('Deleting file ' . $path);
+                        unlink($path);
+                    } else {
+                        logger()->warning("Source/Package [{$source}] file not found, skip deleting file.");
+                    }
+                } else {
+                    if (is_dir($path = FileSystem::convertPath(DOWNLOAD_PATH . '/' . $lock[$source]['dirname']))) {
+                        logger()->info('Deleting dir ' . $path);
+                        FileSystem::removeDir($path);
+                    } else {
+                        logger()->warning("Source/Package [{$source}] directory not found, skip deleting dir.");
+                    }
+                }
+                // remove locked sources
+                unset($lock[$source]);
+            }
+            FileSystem::writeFile(DOWNLOAD_PATH . '/.lock.json', json_encode($lock, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+            logger()->info('Delete success!');
+            return static::SUCCESS;
+        } catch (DownloaderException $e) {
+            logger()->error($e->getMessage());
+            return static::FAILURE;
+        } catch (WrongUsageException $e) {
+            logger()->critical($e->getMessage());
+            return static::FAILURE;
+        }
+    }
+}

--- a/src/SPC/command/ExtractCommand.php
+++ b/src/SPC/command/ExtractCommand.php
@@ -8,11 +8,11 @@ use SPC\builder\traits\UnixSystemUtilTrait;
 use SPC\exception\FileSystemException;
 use SPC\exception\RuntimeException;
 use SPC\exception\WrongUsageException;
-use SPC\store\SourceExtractor;
+use SPC\store\SourceManager;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 
-#[AsCommand('extract', 'Extract required sources')]
+#[AsCommand('extract', 'Extract required sources', ['extract-source'])]
 class ExtractCommand extends BaseCommand
 {
     use UnixSystemUtilTrait;
@@ -34,7 +34,7 @@ class ExtractCommand extends BaseCommand
             $this->output->writeln('<error>sources cannot be empty, at least contain one !</error>');
             return static::FAILURE;
         }
-        SourceExtractor::initSource(sources: $sources);
+        SourceManager::initSource(sources: $sources);
         logger()->info('Extract done !');
         return static::SUCCESS;
     }

--- a/src/SPC/command/InstallPkgCommand.php
+++ b/src/SPC/command/InstallPkgCommand.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\command;
+
+use SPC\builder\traits\UnixSystemUtilTrait;
+use SPC\exception\DownloaderException;
+use SPC\exception\FileSystemException;
+use SPC\exception\WrongUsageException;
+use SPC\store\Config;
+use SPC\store\PackageManager;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand('install-pkg', 'Install additional packages', ['i', 'install-package'])]
+class InstallPkgCommand extends BaseCommand
+{
+    use UnixSystemUtilTrait;
+
+    public function configure(): void
+    {
+        $this->addArgument('packages', InputArgument::REQUIRED, 'The packages will be installed, comma separated');
+        $this->addOption('shallow-clone', null, null, 'Clone shallow');
+        $this->addOption('custom-url', 'U', InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Specify custom source download url, e.g "php-src:https://downloads.php.net/~eric/php-8.3.0beta1.tar.gz"');
+    }
+
+    /**
+     * @throws FileSystemException
+     */
+    public function handle(): int
+    {
+        try {
+            // Use shallow-clone can reduce git resource download
+            if ($this->getOption('shallow-clone')) {
+                define('GIT_SHALLOW_CLONE', true);
+            }
+
+            // Process -U options
+            $custom_urls = [];
+            foreach ($this->input->getOption('custom-url') as $value) {
+                [$pkg_name, $url] = explode(':', $value, 2);
+                $custom_urls[$pkg_name] = $url;
+            }
+
+            $chosen_pkgs = array_map('trim', array_filter(explode(',', $this->getArgument('packages'))));
+
+            // Download them
+            f_mkdir(DOWNLOAD_PATH);
+            $ni = 0;
+            $cnt = count($chosen_pkgs);
+
+            foreach ($chosen_pkgs as $pkg) {
+                ++$ni;
+                if (isset($custom_urls[$pkg])) {
+                    $config = Config::getPkg($pkg);
+                    $new_config = [
+                        'type' => 'url',
+                        'url' => $custom_urls[$pkg],
+                    ];
+                    if (isset($config['extract'])) {
+                        $new_config['extract'] = $config['extract'];
+                    }
+                    if (isset($config['filename'])) {
+                        $new_config['filename'] = $config['filename'];
+                    }
+                    logger()->info("Installing source {$pkg} from custom url [{$ni}/{$cnt}]");
+                    PackageManager::installPackage($pkg, $new_config);
+                } else {
+                    logger()->info("Fetching package {$pkg} [{$ni}/{$cnt}]");
+                    PackageManager::installPackage($pkg, Config::getPkg($pkg));
+                }
+            }
+            $time = round(microtime(true) - START_TIME, 3);
+            logger()->info('Install packages complete, used ' . $time . ' s !');
+            return static::SUCCESS;
+        } catch (DownloaderException $e) {
+            logger()->error($e->getMessage());
+            return static::FAILURE;
+        } catch (WrongUsageException $e) {
+            logger()->critical($e->getMessage());
+            return static::FAILURE;
+        }
+    }
+}

--- a/src/SPC/command/dev/SortConfigCommand.php
+++ b/src/SPC/command/dev/SortConfigCommand.php
@@ -57,6 +57,15 @@ class SortConfigCommand extends BaseCommand
                     return static::FAILURE;
                 }
                 break;
+            case 'pkg':
+                $file = json_decode(FileSystem::readFile(ROOT_DIR . '/config/pkg.json'), true);
+                ConfigValidator::validatePkgs($file);
+                ksort($file);
+                if (!file_put_contents(ROOT_DIR . '/config/pkg.json', json_encode($file, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) . "\n")) {
+                    $this->output->writeln('<error>Write file pkg.json failed!</error>');
+                    return static::FAILURE;
+                }
+                break;
             default:
                 $this->output->writeln("<error>invalid config name: {$name}</error>");
                 return 1;

--- a/src/SPC/doctor/item/LinuxMuslCheck.php
+++ b/src/SPC/doctor/item/LinuxMuslCheck.php
@@ -14,6 +14,7 @@ use SPC\exception\RuntimeException;
 use SPC\exception\WrongUsageException;
 use SPC\store\Downloader;
 use SPC\store\FileSystem;
+use SPC\store\PackageManager;
 
 class LinuxMuslCheck
 {
@@ -84,7 +85,6 @@ class LinuxMuslCheck
 
     /** @noinspection PhpUnused */
     /**
-     * @throws DownloaderException
      * @throws FileSystemException
      * @throws WrongUsageException
      */
@@ -98,15 +98,10 @@ class LinuxMuslCheck
                 logger()->warning('Current user is not root, using sudo for running command');
             }
             $arch = arch2gnu(php_uname('m'));
-            $musl_compile_source = [
-                'type' => 'url',
-                'url' => "https://dl.static-php.dev/static-php-cli/deps/musl-toolchain/{$arch}-musl-toolchain.tgz",
-            ];
-            logger()->info('Downloading ' . $musl_compile_source['url']);
-            Downloader::downloadSource('musl-compile', $musl_compile_source);
-            logger()->info('Extracting musl-cross');
-            FileSystem::extractSource('musl-compile', DOWNLOAD_PATH . "/{$arch}-musl-toolchain.tgz");
-            shell()->exec($prefix . 'cp -rf ' . SOURCE_PATH . '/musl-compile/* /usr/local/musl');
+            PackageManager::installPackage("musl-toolchain-{$arch}-linux");
+            $pkg_root = PKG_ROOT_PATH . "/musl-toolchain-{$arch}-linux";
+            shell()->exec("{$prefix}cp -rf {$pkg_root}/* /usr/local/musl");
+            FileSystem::removeDir($pkg_root);
             return true;
         } catch (RuntimeException) {
             return false;

--- a/src/SPC/store/Config.php
+++ b/src/SPC/store/Config.php
@@ -12,6 +12,8 @@ use SPC\exception\WrongUsageException;
  */
 class Config
 {
+    public static ?array $pkg = null;
+
     public static ?array $source = null;
 
     public static ?array $lib = null;
@@ -29,6 +31,19 @@ class Config
             self::$source = FileSystem::loadConfigArray('source');
         }
         return self::$source[$name] ?? null;
+    }
+
+    /**
+     * Read pkg from pkg.json
+     *
+     * @throws FileSystemException
+     */
+    public static function getPkg(string $name): ?array
+    {
+        if (self::$pkg === null) {
+            self::$pkg = FileSystem::loadConfigArray('pkg');
+        }
+        return self::$pkg[$name] ?? null;
     }
 
     /**

--- a/src/SPC/store/PackageManager.php
+++ b/src/SPC/store/PackageManager.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\store;
+
+use SPC\exception\WrongUsageException;
+
+class PackageManager
+{
+    public static function installPackage(string $pkg_name, ?array $config = null, bool $force = false): void
+    {
+        if ($config === null) {
+            $config = Config::getPkg($pkg_name);
+        }
+        if ($config === null) {
+            $arch = arch2gnu(php_uname('m'));
+            $os = match (PHP_OS_FAMILY) {
+                'Linux' => 'linux',
+                'Windows' => 'win',
+                'BSD' => 'freebsd',
+                'Darwin' => 'macos',
+                default => throw new WrongUsageException('Unsupported OS!'),
+            };
+            $config = Config::getPkg("{$pkg_name}-{$arch}-{$os}");
+        }
+        if ($config === null) {
+            throw new WrongUsageException("Package [{$pkg_name}] does not exist, please check the name and correct it !");
+        }
+
+        // Download package
+        Downloader::downloadPackage($pkg_name, $config, $force);
+        // After download, read lock file name
+        $lock = json_decode(FileSystem::readFile(DOWNLOAD_PATH . '/.lock.json'), true);
+        $filename = DOWNLOAD_PATH . '/' . ($lock[$pkg_name]['filename'] ?? $lock[$pkg_name]['dirname']);
+        $extract = $lock[$pkg_name]['move_path'] === null ? (PKG_ROOT_PATH . '/' . $pkg_name) : $lock[$pkg_name]['move_path'];
+        FileSystem::extractPackage($pkg_name, $filename, $extract);
+
+        // if contains extract-files, we just move this file to destination, and remove extract dir
+        if (is_array($config['extract-files'] ?? null) && is_assoc_array($config['extract-files'])) {
+            foreach ($config['extract-files'] as $file => $target) {
+                $target = FileSystem::convertPath(FileSystem::replacePathVariable($target));
+                if (!is_dir($dir = dirname($target))) {
+                    f_mkdir($dir, 0755, true);
+                }
+                logger()->debug("Moving package [{$pkg_name}] file {$file} to {$target}");
+                rename(FileSystem::convertPath($extract . '/' . $file), $target);
+            }
+            FileSystem::removeDir($extract);
+        }
+    }
+}

--- a/src/SPC/store/SourceManager.php
+++ b/src/SPC/store/SourceManager.php
@@ -8,7 +8,7 @@ use SPC\exception\FileSystemException;
 use SPC\exception\RuntimeException;
 use SPC\exception\WrongUsageException;
 
-class SourceExtractor
+class SourceManager
 {
     /**
      * @throws WrongUsageException
@@ -59,7 +59,7 @@ class SourceExtractor
             }
 
             // check source dir exist
-            $check = $lock[$source]['move_path'] === null ? (SOURCE_PATH . '/' . $source) : (SOURCE_PATH . '/' . $lock[$source]['move_path']);
+            $check = $lock[$source]['move_path'] === null ? (SOURCE_PATH . '/' . $source) : (WORKING_DIR . '/' . $lock[$source]['move_path']);
             if (!is_dir($check)) {
                 logger()->debug('Extracting source [' . $source . '] to ' . $check . ' ...');
                 FileSystem::extractSource($source, DOWNLOAD_PATH . '/' . ($lock[$source]['filename'] ?? $lock[$source]['dirname']), $lock[$source]['move_path']);

--- a/src/SPC/util/ConfigValidator.php
+++ b/src/SPC/util/ConfigValidator.php
@@ -70,4 +70,9 @@ class ConfigValidator
     {
         is_array($data) || throw new ValidationException('ext.json is broken');
     }
+
+    public static function validatePkgs(mixed $data): void
+    {
+        is_array($data) || throw new \_PHPStan_c997ea9ee\Nette\Schema\ValidationException('pkg.json is broken');
+    }
 }

--- a/src/SPC/util/ConfigValidator.php
+++ b/src/SPC/util/ConfigValidator.php
@@ -71,8 +71,11 @@ class ConfigValidator
         is_array($data) || throw new ValidationException('ext.json is broken');
     }
 
+    /**
+     * @throws ValidationException
+     */
     public static function validatePkgs(mixed $data): void
     {
-        is_array($data) || throw new \_PHPStan_c997ea9ee\Nette\Schema\ValidationException('pkg.json is broken');
+        is_array($data) || throw new ValidationException('pkg.json is broken');
     }
 }

--- a/src/globals/defines.php
+++ b/src/globals/defines.php
@@ -14,6 +14,7 @@ define('START_TIME', microtime(true));
 define('BUILD_ROOT_PATH', FileSystem::convertPath(is_string($a = getenv('BUILD_ROOT_PATH')) ? $a : (WORKING_DIR . '/buildroot')));
 define('SOURCE_PATH', FileSystem::convertPath(is_string($a = getenv('SOURCE_PATH')) ? $a : (WORKING_DIR . '/source')));
 define('DOWNLOAD_PATH', FileSystem::convertPath(is_string($a = getenv('DOWNLOAD_PATH')) ? $a : (WORKING_DIR . '/downloads')));
+define('PKG_ROOT_PATH', FileSystem::convertPath(is_string($a = getenv('PKG_ROOT_PATH')) ? $a : (WORKING_DIR . '/pkgroot')));
 define('BUILD_BIN_PATH', FileSystem::convertPath(is_string($a = getenv('INSTALL_BIN_PATH')) ? $a : (BUILD_ROOT_PATH . '/bin')));
 define('BUILD_LIB_PATH', FileSystem::convertPath(is_string($a = getenv('INSTALL_LIB_PATH')) ? $a : (BUILD_ROOT_PATH . '/lib')));
 define('BUILD_INCLUDE_PATH', FileSystem::convertPath(is_string($a = getenv('INSTALL_INCLUDE_PATH')) ? $a : (BUILD_ROOT_PATH . '/include')));


### PR DESCRIPTION
## What does this PR do?

- Add `install-pkg` command: Install binary tools or pre-compiled libraries.
- Add `del-download` command: Delete downloaded sources.
- Change `perl`, `nasm`, `musl-toolchain` to pkg: Treat them as packages.
- Add `PKG_ROOT_PATH` (default `./pkgroot/`): Store binary tools dir.
- Add `upx` package for linux. (`bin/spc install-pkg upx`)
- Prepare for #336 

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [X] If it's a extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [x] If you changed the behavior of static-php-cli, add docs in [static-php/static-php-cli-docs](https://github.com/static-php/static-php-cli-docs) .
- [X] If you updated `config/xxxx.json` content, run `bin/spc dev:sort-config xxx`.
