### PR TITLE
Add curl and ssh2 support for windows

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -20,7 +20,7 @@ static-php-cli（简称 `spc`）有许多特性：
 - :handbag: 构建独立的单文件 PHP 解释器，无需任何依赖
 - :hamburger: 构建 **[phpmicro](https://github.com/dixyes/phpmicro)** 自执行二进制（将 PHP 代码和 PHP 解释器打包为一个文件）
 - :pill: 提供一键检查和修复编译环境的 Doctor 模块
-- :zap: 支持多个系统：`Linux`、`macOS`、`FreeBSD`、[`Windows (WIP)`](https://github.com/crazywhalecc/static-php-cli/pull/301)
+- :zap: 支持多个系统：`Linux`、`macOS`、`FreeBSD`、`Windows`
 - :wrench: 高度自定义的代码 patch 功能
 - :books: 自带编译依赖管理
 - 📦 提供由自身编译的独立 `spc` 二进制（使用 spc 和 [box](https://github.com/box-project/box) 构建）
@@ -47,6 +47,8 @@ static-php-cli（简称 `spc`）有许多特性：
 - [扩展组合 - bulk](https://dl.static-php.dev/static-php-cli/bulk/)：bulk 组合包含了 [50+](https://dl.static-php.dev/static-php-cli/bulk/README.txt) 个扩展，体积为 70MB 左右。
 - [扩展组合 - minimal](https://dl.static-php.dev/static-php-cli/minimal/)：minimal 组合包含了 [5](https://dl.static-php.dev/static-php-cli/minimal/README.txt) 个扩展，体积为 6MB 左右。
 
+对于 Windows 系统，目前支持的扩展较少，故仅提供 SPC 自身运行的最小扩展组合的 `cli` 和 `micro`：[扩展组合 - spc-min](https://dl.static-php.dev/static-php-cli/windows/spc-min/)。
+
 ## 使用 static-php-cli 构建 PHP
 
 ### 编译环境需求
@@ -64,10 +66,24 @@ static-php-cli（简称 `spc`）有许多特性：
 |---------|----------------------|----------------------|
 | macOS   | :octocat: :computer: | :octocat: :computer: |
 | Linux   | :octocat: :computer: | :octocat: :computer: |
-| Windows |                      |                      |
+| Windows | :computer:           |                      |
 | FreeBSD | :computer:           | :computer:           |
 
-目前支持编译的 PHP 版本为：`7.3`，`7.4`，`8.0`，`8.1`，`8.2`，`8.3`。
+当前支持编译的 PHP 版本：
+
+> :warning: 支持，但可能不再提供修复
+> :heavy_check_mark: 支持
+> :x: 不支持
+
+| PHP Version | Status             |
+|-------------|--------------------|
+| 7.2         | :x:                |
+| 7.3         | :warning:          |
+| 7.4         | :warning:          |
+| 8.0         | :heavy_check_mark: |
+| 8.1         | :heavy_check_mark: |
+| 8.2         | :heavy_check_mark: |
+| 8.3         | :heavy_check_mark: |
 
 ### 支持的扩展
 
@@ -107,10 +123,16 @@ curl -o spc https://dl.static-php.dev/static-php-cli/spc-bin/nightly/spc-linux-a
 curl -o spc https://dl.static-php.dev/static-php-cli/spc-bin/nightly/spc-macos-x86_64
 # macOS aarch64 (Apple)
 curl -o spc https://dl.static-php.dev/static-php-cli/spc-bin/nightly/spc-macos-aarch64
+# Windows (x86_64, win10 build 17063 or later)
+curl.exe -o spc.exe https://dl.static-php.dev/static-php-cli/spc-bin/nightly/spc-windows-x64.exe
 
-# add x perm
+# Add execute perm (Linux and macOS only)
 chmod +x ./spc
+
+# Run (Linux and macOS)
 ./spc --version
+# Run (Windows powershell)
+.\spc.exe --version
 ```
 
 自托管 `spc` 由 GitHub Actions 构建，你也可以从 Actions 直接下载：[此处](https://github.com/crazywhalecc/static-php-cli/actions/workflows/release-build.yml)。
@@ -149,16 +171,16 @@ bin/spc --version
 # 拉取所有依赖库
 ./bin/spc download --all
 # 只拉取编译指定扩展需要的所有依赖（推荐）
-./bin/spc download --for-extensions=openssl,pcntl,mbstring,pdo_sqlite
+./bin/spc download --for-extensions="openssl,pcntl,mbstring,pdo_sqlite"
 # 下载编译不同版本的 PHP (--with-php=x.y，推荐 7.3 ~ 8.3)
-./bin/spc download --for-extensions=openssl,curl,mbstring --with-php=8.1
+./bin/spc download --for-extensions="openssl,curl,mbstring" --with-php=8.1
 
 # 构建包含 bcmath,openssl,tokenizer,sqlite3,pdo_sqlite,ftp,curl 扩展的 php-cli 和 micro.sfx
 ./bin/spc build "bcmath,openssl,tokenizer,sqlite3,pdo_sqlite,ftp,curl" --build-cli --build-micro
 # 编译线程安全版本 (--enable-zts)
-./bin/spc build curl,phar --enable-zts --build-cli
+./bin/spc build "curl,phar" --enable-zts --build-cli
 # 编译后使用 UPX 减小可执行文件体积 (--with-upx-pack) (至少压缩至原来的 30~50%)
-./bin/spc build curl,phar --enable-zts --build-cli --with-upx-pack
+./bin/spc build "curl,phar" --enable-zts --build-cli --with-upx-pack
 ```
 
 其中，目前支持构建 cli，micro，fpm 和 embed，使用以下参数的一个或多个来指定编译的 SAPI：
@@ -172,7 +194,7 @@ bin/spc --version
 如果出现了任何错误，可以使用 `--debug` 参数来展示完整的输出日志，以供排查错误：
 
 ```bash
-./bin/spc build openssl,pcntl,mbstring --debug --build-all
+./bin/spc build "openssl,pcntl,mbstring" --debug --build-all
 ./bin/spc download --all --debug
 ```
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -157,6 +157,8 @@ bin/spc --version
 ./bin/spc build "bcmath,openssl,tokenizer,sqlite3,pdo_sqlite,ftp,curl" --build-cli --build-micro
 # 编译线程安全版本 (--enable-zts)
 ./bin/spc build curl,phar --enable-zts --build-cli
+# 编译后使用 UPX 减小可执行文件体积 (--with-upx-pack) (至少压缩至原来的 30~50%)
+./bin/spc build curl,phar --enable-zts --build-cli --with-upx-pack
 ```
 
 其中，目前支持构建 cli，micro，fpm 和 embed，使用以下参数的一个或多个来指定编译的 SAPI：

--- a/README-zh.md
+++ b/README-zh.md
@@ -77,15 +77,15 @@ static-php-cli（简称 `spc`）有许多特性：
 > 
 > :x: 不支持
 
-| PHP Version | Status             |
-|-------------|--------------------|
-| 7.2         | :x:                |
-| 7.3         | :warning:          |
-| 7.4         | :warning:          |
-| 8.0         | :heavy_check_mark: |
-| 8.1         | :heavy_check_mark: |
-| 8.2         | :heavy_check_mark: |
-| 8.3         | :heavy_check_mark: |
+| PHP Version | Status             | Comment                      |
+|-------------|--------------------|------------------------------|
+| 7.2         | :x:                |                              |
+| 7.3         | :warning:          | phpmicro 和许多扩展不支持 7.3、7.4 版本 |
+| 7.4         | :warning:          | phpmicro 和许多扩展不支持 7.3、7.4 版本 |
+| 8.0         | :heavy_check_mark: | PHP 官方已停止 8.0 的维护            |
+| 8.1         | :heavy_check_mark: |                              |
+| 8.2         | :heavy_check_mark: |                              |
+| 8.3         | :heavy_check_mark: |                              |
 
 ### 支持的扩展
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -71,9 +71,9 @@ static-php-cli（简称 `spc`）有许多特性：
 
 当前支持编译的 PHP 版本：
 
-> :warning: 支持，但可能不再提供修复
-> :heavy_check_mark: 支持
-> :x: 不支持
+> - :warning: 支持，但可能不再提供修复
+> - :heavy_check_mark: 支持
+> - :x: 不支持
 
 | PHP Version | Status             |
 |-------------|--------------------|

--- a/README-zh.md
+++ b/README-zh.md
@@ -54,11 +54,11 @@ static-php-cli（简称 `spc`）有许多特性：
 ### 编译环境需求
 
 - PHP >= 8.1（这是 spc 自身需要的版本，不是支持的构建版本）
-- 扩展：`mbstring,pcntl,posix,tokenizer,phar`
+- 扩展：`mbstring,tokenizer,phar`
 - 系统安装了 `curl` 和 `git`
 
 是的，本项目采用 PHP 编写，编译前需要一个 PHP 环境，比较滑稽。
-但本项目默认可通过自身构建的 micro 和 static-php 二进制运行，其他只需要包含 mbstring、pcntl 扩展和 PHP 版本大于等于 8.1 即可。
+但本项目默认可通过自身构建的 micro 和 static-php 二进制运行，其他只需要包含上面提到的扩展和 PHP 版本大于等于 8.1 即可。
 
 下面是架构支持情况，:octocat: 代表支持 GitHub Action 构建，:computer: 代表支持本地构建，空 代表暂不支持。
 
@@ -71,9 +71,11 @@ static-php-cli（简称 `spc`）有许多特性：
 
 当前支持编译的 PHP 版本：
 
-> - :warning: 支持，但可能不再提供修复
-> - :heavy_check_mark: 支持
-> - :x: 不支持
+> :warning: 支持，但可能不再提供修复
+> 
+> :heavy_check_mark: 支持
+> 
+> :x: 不支持
 
 | PHP Version | Status             |
 |-------------|--------------------|

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ Here is the supported OS and arch, where :octocat: represents support for GitHub
 
 Currently supported PHP versions for compilation: 
 
-> :warning: supported but not maintained
-> :heavy_check_mark: supported
-> :x: not supported
+> - :warning: supported but not maintained
+> - :heavy_check_mark: supported
+> - :x: not supported
 
 | PHP Version | Status             |
 |-------------|--------------------|

--- a/README.md
+++ b/README.md
@@ -79,20 +79,21 @@ Here is the supported OS and arch, where :octocat: represents support for GitHub
 
 Currently supported PHP versions for compilation: 
 
-> - :warning: supported but not maintained
-> - :heavy_check_mark: supported
-> - :x: not supported
+> :warning: supported but not maintained
+> 
+> :heavy_check_mark: supported
+> 
+> :x: not supported
 
-| PHP Version | Status             |
-|-------------|--------------------|
-| 7.2         | :x:                |
-| 7.3         | :warning:          |
-| 7.4         | :warning:          |
-| 8.0         | :heavy_check_mark: |
-| 8.1         | :heavy_check_mark: |
-| 8.2         | :heavy_check_mark: |
-| 8.3         | :heavy_check_mark: |
-
+| PHP Version | Status             | Comment                                           |
+|-------------|--------------------|---------------------------------------------------|
+| 7.2         | :x:                |                                                   |
+| 7.3         | :warning:          | phpmicro and some extensions not supported on 7.x |
+| 7.4         | :warning:          | phpmicro and some extensions not supported on 7.x |
+| 8.0         | :heavy_check_mark: | PHP official has stopped maintenance of 8.0       |
+| 8.1         | :heavy_check_mark: |                                                   |
+| 8.2         | :heavy_check_mark: |                                                   |
+| 8.3         | :heavy_check_mark: |                                                   |
 
 ### Supported Extensions
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ Basic usage for building php with some extensions:
 ./bin/spc build bcmath,openssl,tokenizer,sqlite3,pdo_sqlite,ftp,curl --build-cli --build-micro
 # build thread-safe (ZTS) version (--enable-zts)
 ./bin/spc build curl,phar --enable-zts --build-cli
+# build, pack executable with UPX (--with-upx-pack) (reduce binary size for 30~50%)
+./bin/spc build curl,phar --enable-zts --build-cli --with-upx-pack
 ```
 
 Now we support `cli`, `micro`, `fpm` and `embed` SAPI. You can use one or more of the following parameters to specify the compiled SAPI:

--- a/README.md
+++ b/README.md
@@ -53,16 +53,19 @@ which can be downloaded directly according to your needs.
 - [Extension-Combination - bulk](https://dl.static-php.dev/static-php-cli/bulk/): `bulk` contains [50+](https://dl.static-php.dev/static-php-cli/bulk/README.txt) extensions and is about 70MB in size.
 - [Extension-Combination - minimal](https://dl.static-php.dev/static-php-cli/minimal/): `minimal` contains [5](https://dl.static-php.dev/static-php-cli/minimal/README.txt) extensions and is about 6MB in size.
 
+For Windows systems, there are currently fewer extensions supported, 
+so only `cli` and `micro` that run the minimum extension combination of SPC itself are provided: [Extension-Combination - spc-min](https://dl.static-php.dev/static-php-cli/windows/spc-min/).
+
 ## Build
 
 ### Compilation Requirements
 
-- PHP >= 8.1 (This is the version required by spc itself, not the build version)
-- Extension: `mbstring,pcntl,posix,tokenizer,phar`
-- Supported OS with `curl` and `git` installed
-
 You can say I made a PHP builder written in PHP, pretty funny.
-But static-php-cli runtime only requires an environment above PHP 8.1 and `mbstring`, `pcntl` extension.
+But static-php-cli runtime only requires an environment above PHP 8.1 and extensions mentioned below.
+
+- PHP >= 8.1 (This is the version required by spc itself, not the build version)
+- Extension: `mbstring,tokenizer,phar`
+- Supported OS with `curl` and `git` installed
 
 Here is the supported OS and arch, where :octocat: represents support for GitHub Action builds,
 :computer: represents support for local manual builds, and blank represents not currently supported.
@@ -74,7 +77,22 @@ Here is the supported OS and arch, where :octocat: represents support for GitHub
 | Windows | :computer:           |                      |
 | FreeBSD | :computer:           | :computer:           |
 
-Currently supported PHP versions for compilation are: `7.3`, `7.4`, `8.0`, `8.1`, `8.2`, `8.3`.
+Currently supported PHP versions for compilation: 
+
+> :warning: supported but not maintained
+> :heavy_check_mark: supported
+> :x: not supported
+
+| PHP Version | Status             |
+|-------------|--------------------|
+| 7.2         | :x:                |
+| 7.3         | :warning:          |
+| 7.4         | :warning:          |
+| 8.0         | :heavy_check_mark: |
+| 8.1         | :heavy_check_mark: |
+| 8.2         | :heavy_check_mark: |
+| 8.3         | :heavy_check_mark: |
+
 
 ### Supported Extensions
 
@@ -117,10 +135,16 @@ curl -o spc https://dl.static-php.dev/static-php-cli/spc-bin/nightly/spc-linux-a
 curl -o spc https://dl.static-php.dev/static-php-cli/spc-bin/nightly/spc-macos-x86_64
 # macOS aarch64 (Apple)
 curl -o spc https://dl.static-php.dev/static-php-cli/spc-bin/nightly/spc-macos-aarch64
+# Windows (x86_64, win10 build 17063 or later)
+curl.exe -o spc.exe https://dl.static-php.dev/static-php-cli/spc-bin/nightly/spc-windows-x64.exe
 
-# add x perm
+# Add execute perm (Linux and macOS only)
 chmod +x ./spc
+
+# Run (Linux and macOS)
 ./spc --version
+# Run (Windows powershell)
+.\spc.exe --version
 ```
 
 Self-hosted `spc` is built by GitHub Actions, you can also download from Actions artifacts [here](https://github.com/crazywhalecc/static-php-cli/actions/workflows/release-build.yml).
@@ -150,7 +174,7 @@ bin/spc --version
 
 Basic usage for building php with some extensions:
 
-> If you are using the packaged `spc` binary, you need to replace `bin/spc` with `./spc` in the following commands.
+> If you are using the packaged standalone `spc` binary, you need to replace `bin/spc` with `./spc` or `.\spc.exe` in the following commands.
 
 ```bash
 # Check system tool dependencies, auto-fix them if possible
@@ -159,16 +183,16 @@ Basic usage for building php with some extensions:
 # fetch all libraries
 ./bin/spc download --all
 # only fetch necessary sources by needed extensions (recommended)
-./bin/spc download --for-extensions=openssl,pcntl,mbstring,pdo_sqlite
+./bin/spc download --for-extensions="openssl,pcntl,mbstring,pdo_sqlite"
 # download different PHP version (--with-php=x.y, recommend 7.3 ~ 8.3)
-./bin/spc download --for-extensions=openssl,curl,mbstring --with-php=8.1
+./bin/spc download --for-extensions="openssl,curl,mbstring" --with-php=8.1
 
 # with bcmath,openssl,tokenizer,sqlite3,pdo_sqlite,ftp,curl extension, build both CLI and phpmicro SAPI
-./bin/spc build bcmath,openssl,tokenizer,sqlite3,pdo_sqlite,ftp,curl --build-cli --build-micro
+./bin/spc build "bcmath,openssl,tokenizer,sqlite3,pdo_sqlite,ftp,curl" --build-cli --build-micro
 # build thread-safe (ZTS) version (--enable-zts)
-./bin/spc build curl,phar --enable-zts --build-cli
+./bin/spc build "curl,phar" --enable-zts --build-cli
 # build, pack executable with UPX (--with-upx-pack) (reduce binary size for 30~50%)
-./bin/spc build curl,phar --enable-zts --build-cli --with-upx-pack
+./bin/spc build "curl,phar" --enable-zts --build-cli --with-upx-pack
 ```
 
 Now we support `cli`, `micro`, `fpm` and `embed` SAPI. You can use one or more of the following parameters to specify the compiled SAPI:
@@ -182,7 +206,7 @@ Now we support `cli`, `micro`, `fpm` and `embed` SAPI. You can use one or more o
 If anything goes wrong, use `--debug` option to display full terminal output:
 
 ```bash
-./bin/spc build openssl,pcntl,mbstring --debug --build-all
+./bin/spc build "openssl,pcntl,mbstring" --debug --build-all
 ./bin/spc download --all --debug
 ```
 

--- a/config/ext.json
+++ b/config/ext.json
@@ -24,6 +24,10 @@
         "arg-type": "with",
         "lib-depends": [
             "curl"
+        ],
+        "ext-depends-windows": [
+            "zlib",
+            "openssl"
         ]
     },
     "dba": {
@@ -403,8 +407,13 @@
         "type": "external",
         "source": "ext-ssh2",
         "arg-type": "with-prefix",
+        "arg-type-windows": "with",
         "lib-depends": [
             "libssh2"
+        ],
+        "ext-depends-windows": [
+            "openssl",
+            "zlib"
         ]
     },
     "swoole": {

--- a/config/lib.json
+++ b/config/lib.json
@@ -45,19 +45,21 @@
             "openssl",
             "zlib"
         ],
-        "lib-suggests": [
+        "lib-depends-windows": [
+            "openssl",
+            "zlib",
+            "libssh2",
+            "nghttp2"
+        ],
+        "lib-suggests-unix": [
             "libssh2",
             "brotli",
             "nghttp2",
             "zstd"
         ],
         "lib-suggests-windows": [
-            "zlib",
-            "libssh2",
             "brotli",
-            "nghttp2",
-            "zstd",
-            "openssl"
+            "zstd"
         ],
         "frameworks": [
             "CoreFoundation",

--- a/src/SPC/builder/windows/library/curl.php
+++ b/src/SPC/builder/windows/library/curl.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\windows\library;
+
+use SPC\store\FileSystem;
+
+class curl extends WindowsLibraryBase
+{
+    public const NAME = 'curl';
+
+    protected function build(): void
+    {
+        // reset cmake
+        FileSystem::resetDir($this->source_dir . '\build');
+
+        // start build
+        cmd()->cd($this->source_dir)
+            ->execWithWrapper(
+                $this->builder->makeSimpleWrapper('cmake'),
+                '-B build ' .
+                '-A x64 ' .
+                "-DCMAKE_TOOLCHAIN_FILE={$this->builder->cmake_toolchain_file} " .
+                '-DCMAKE_BUILD_TYPE=Release ' .
+                '-DBUILD_SHARED_LIBS=OFF ' .
+                '-DBUILD_STATIC_LIBS=ON ' .
+                '-DBUILD_CURL_EXE=OFF ' .
+                '-DUSE_ZLIB=ON ' .
+                '-DCURL_USE_OPENSSL=ON ' .
+                '-DCURL_USE_LIBLSSH2=ON ' .
+                '-DCMAKE_INSTALL_PREFIX=' . BUILD_ROOT_PATH . ' '
+            )
+            ->execWithWrapper(
+                $this->builder->makeSimpleWrapper('cmake'),
+                "--build build --config Release --target install -j{$this->builder->concurrency}"
+            );
+    }
+}

--- a/src/SPC/builder/windows/library/libssh2.php
+++ b/src/SPC/builder/windows/library/libssh2.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SPC\builder\windows\library;
 
 use SPC\store\FileSystem;

--- a/src/SPC/builder/windows/library/libssh2.php
+++ b/src/SPC/builder/windows/library/libssh2.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace SPC\builder\windows\library;
+
+use SPC\store\FileSystem;
+
+class libssh2 extends WindowsLibraryBase
+{
+    public const NAME = 'libssh2';
+
+    protected function build(): void
+    {
+        $zlib = $this->builder->getLib('zlib') ? 'ON' : 'OFF';
+        // reset cmake
+        FileSystem::resetDir($this->source_dir . '\build');
+
+        // start build
+        cmd()->cd($this->source_dir)
+            ->execWithWrapper(
+                $this->builder->makeSimpleWrapper('cmake'),
+                '-B build ' .
+                '-A x64 ' .
+                "-DCMAKE_TOOLCHAIN_FILE={$this->builder->cmake_toolchain_file} " .
+                '-DCMAKE_BUILD_TYPE=Release ' .
+                '-DBUILD_SHARED_LIBS=OFF ' .
+                '-DBUILD_STATIC_LIBS=ON ' .
+                '-DBUILD_TESTING=OFF ' .
+                "-DENABLE_ZLIB_COMPRESSION={$zlib} " .
+                '-DCMAKE_INSTALL_PREFIX=' . BUILD_ROOT_PATH . ' '
+            )
+            ->execWithWrapper(
+                $this->builder->makeSimpleWrapper('cmake'),
+                "--build build --config Release --target install -j{$this->builder->concurrency}"
+            );
+    }
+}

--- a/src/SPC/builder/windows/library/nghttp2.php
+++ b/src/SPC/builder/windows/library/nghttp2.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SPC\builder\windows\library;
+
+use SPC\store\FileSystem;
+
+class nghttp2 extends WindowsLibraryBase
+{
+    public const NAME = 'nghttp2';
+
+    protected function build(): void
+    {
+        // reset cmake
+        FileSystem::resetDir($this->source_dir . '\build');
+
+        // start build
+        cmd()->cd($this->source_dir)
+            ->execWithWrapper(
+                $this->builder->makeSimpleWrapper('cmake'),
+                '-B build ' .
+                '-A x64 ' .
+                "-DCMAKE_TOOLCHAIN_FILE={$this->builder->cmake_toolchain_file} " .
+                '-DCMAKE_BUILD_TYPE=Release ' .
+                '-DBUILD_SHARED_LIBS=OFF ' .
+                '-DBUILD_STATIC_LIBS=ON ' .
+                '-DENABLE_STATIC_CRT=ON ' .
+                '-DENABLE_LIB_ONLY=ON ' .
+                '-DCMAKE_INSTALL_PREFIX=' . BUILD_ROOT_PATH . ' '
+            )
+            ->execWithWrapper(
+                $this->builder->makeSimpleWrapper('cmake'),
+                "--build build --config Release --target install -j{$this->builder->concurrency}"
+            );
+    }
+}

--- a/src/SPC/builder/windows/library/nghttp2.php
+++ b/src/SPC/builder/windows/library/nghttp2.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SPC\builder\windows\library;
 
 use SPC\store\FileSystem;

--- a/src/SPC/store/FileSystem.php
+++ b/src/SPC/store/FileSystem.php
@@ -185,9 +185,11 @@ class FileSystem
         }
         if ($move_path !== null) {
             $move_path = SOURCE_PATH . '/' . $move_path;
+        } else {
+            $move_path = SOURCE_PATH . "/{$name}";
         }
-        logger()->info("extracting {$name} source to " . ($move_path ?? (SOURCE_PATH . "/{$name}")) . ' ...');
-        $target = self::convertPath($move_path ?? (SOURCE_PATH . "/{$name}"));
+        $target = self::convertPath($move_path);
+        logger()->info("extracting {$name} source to {$target}" . ' ...');
         if (!is_dir($dir = dirname($target))) {
             self::createDir($dir);
         }

--- a/src/globals/test-extensions.php
+++ b/src/globals/test-extensions.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 // If you want to test your added extensions and libs, add below (comma separated, example `bcmath,openssl`).
 $extensions = match (PHP_OS_FAMILY) {
     'Linux', 'Darwin' => 'event,gettext',
-    'Windows' => 'mbstring',
+    'Windows' => 'mbstring,curl,ssh2',
 };
 
 // If you want to test lib-suggests feature with extension, add them below (comma separated, example `libwebp,libavif`).


### PR DESCRIPTION
## What does this PR do?

Add curl and ssh2 support for windows.

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [X] If it's a extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [X] If you changed the behavior of static-php-cli, add docs in [static-php/static-php-cli-docs](https://github.com/static-php/static-php-cli-docs) .
- [X] If you updated `config/xxxx.json` content, run `bin/spc dev:sort-config xxx`.
