### PR TITLE
Add multiple XML related extensions support for Windows

### DIFF
--- a/config/ext.json
+++ b/config/ext.json
@@ -123,8 +123,12 @@
     "iconv": {
         "type": "builtin",
         "arg-type": "with-prefix",
-        "lib-depends": [
+        "arg-type-windows": "with",
+        "lib-depends-unix": [
             "libiconv"
+        ],
+        "lib-depends-windows": [
+            "libiconv-win"
         ]
     },
     "igbinary": {
@@ -351,9 +355,11 @@
     "simplexml": {
         "type": "builtin",
         "arg-type": "custom",
-        "arg-type-windows": "with",
         "lib-depends": [
             "libxml2"
+        ],
+        "ext-depends-windows": [
+            "xml"
         ]
     },
     "snappy": {
@@ -373,6 +379,9 @@
         "arg-type": "custom",
         "lib-depends": [
             "libxml2"
+        ],
+        "ext-depends-windows": [
+            "xml"
         ]
     },
     "sockets": {
@@ -534,6 +543,9 @@
         "arg-type-windows": "with",
         "lib-depends": [
             "libxml2"
+        ],
+        "ext-depends-windows": [
+            "iconv"
         ]
     },
     "xmlreader": {
@@ -541,6 +553,10 @@
         "arg-type": "custom",
         "lib-depends": [
             "libxml2"
+        ],
+        "ext-depends-windows": [
+            "xml",
+            "dom"
         ]
     },
     "xmlwriter": {
@@ -548,6 +564,9 @@
         "arg-type": "custom",
         "lib-depends": [
             "libxml2"
+        ],
+        "ext-depends-windows": [
+            "xml"
         ]
     },
     "xsl": {

--- a/config/lib.json
+++ b/config/lib.json
@@ -245,6 +245,13 @@
             "localcharset.h"
         ]
     },
+    "libiconv-win": {
+        "source": "libiconv-win",
+        "static-libs-windows": [
+            "libiconv.lib",
+            "libiconv_a.lib"
+        ]
+    },
     "libjpeg": {
         "source": "libjpeg",
         "static-libs-unix": [
@@ -334,20 +341,24 @@
             "libxml2.a"
         ],
         "static-libs-windows": [
-            [
-                "libxml2s.lib",
-                "libxml2_a.lib"
-            ]
+            "libxml2s.lib",
+            "libxml2_a.lib"
         ],
         "headers": [
             "libxml2"
         ],
-        "lib-depends": [
+        "lib-depends-unix": [
             "libiconv"
         ],
-        "lib-suggests": [
+        "lib-suggests-unix": [
             "xz",
             "icu",
+            "zlib"
+        ],
+        "lib-depends-windows": [
+            "libiconv-win"
+        ],
+        "lib-suggests-windows": [
             "zlib"
         ]
     },

--- a/config/source.json
+++ b/config/source.json
@@ -331,7 +331,7 @@
     },
     "libxml2": {
         "type": "url",
-        "url": "https://github.com/GNOME/libxml2/archive/refs/tags/v2.9.14.tar.gz",
+        "url": "https://github.com/GNOME/libxml2/archive/refs/tags/v2.12.5.tar.gz",
         "license": {
             "type": "file",
             "path": "Copyright"

--- a/config/source.json
+++ b/config/source.json
@@ -254,6 +254,15 @@
             "path": "COPYING"
         }
     },
+    "libiconv-win": {
+        "type": "git",
+        "rev": "master",
+        "url": "https://github.com/static-php/libiconv-win.git",
+        "license": {
+            "type": "file",
+            "path": "source/COPYING"
+        }
+    },
     "libjpeg": {
         "type": "ghtar",
         "repo": "libjpeg-turbo/libjpeg-turbo",

--- a/src/SPC/builder/Extension.php
+++ b/src/SPC/builder/Extension.php
@@ -212,7 +212,7 @@ class Extension
             // Trim additional content & escape special characters to allow inline usage
             $test = str_replace(
                 ['<?php', 'declare(strict_types=1);', "\n", '"', '$'],
-                ['', '', '', '\"', '\$'],
+                ['', '', '', '\"', '$'],
                 file_get_contents(FileSystem::convertPath(ROOT_DIR . '/src/globals/tests/' . $this->getName() . '.php'))
             );
 

--- a/src/SPC/builder/extension/xml.php
+++ b/src/SPC/builder/extension/xml.php
@@ -6,6 +6,7 @@ namespace SPC\builder\extension;
 
 use SPC\builder\Extension;
 use SPC\exception\RuntimeException;
+use SPC\store\FileSystem;
 use SPC\util\CustomExt;
 
 #[CustomExt('xml')]
@@ -31,6 +32,27 @@ class xml extends Extension
             default => throw new RuntimeException('Not accept non-xml extension'),
         };
         $arg .= ' --with-libxml="' . BUILD_ROOT_PATH . '"';
+        return $arg;
+    }
+
+    public function patchBeforeBuildconf(): bool
+    {
+        FileSystem::replaceFileStr(SOURCE_PATH . '/php-src/win32/build/config.w32', 'dllmain.c ', '');
+        return true;
+    }
+
+    public function getWindowsConfigureArg(): string
+    {
+        $arg = match ($this->name) {
+            'xml' => '--with-xml',
+            'soap' => '--enable-soap',
+            'xmlreader' => '--enable-xmlreader',
+            'xmlwriter' => '--enable-xmlwriter',
+            'dom' => '--with-dom',
+            'simplexml' => '--with-simplexml',
+            default => throw new RuntimeException('Not accept non-xml extension'),
+        };
+        $arg .= ' --with-libxml';
         return $arg;
     }
 }

--- a/src/SPC/builder/windows/library/libiconv_win.php
+++ b/src/SPC/builder/windows/library/libiconv_win.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\windows\library;
+
+use SPC\builder\windows\SystemUtil;
+use SPC\exception\RuntimeException;
+use SPC\store\FileSystem;
+
+class libiconv_win extends WindowsLibraryBase
+{
+    public const NAME = 'libiconv-win';
+
+    protected function build()
+    {
+        $vs_ver_dir = match (SystemUtil::findVisualStudio()['version']) {
+            'vs17' => '/MSVC17',
+            'vs16' => '/MSVC16',
+            default => throw new RuntimeException('Current VS version is not supported yet!'),
+        };
+
+        // start build
+        cmd()->cd($this->source_dir . $vs_ver_dir)
+            ->execWithWrapper(
+                $this->builder->makeSimpleWrapper('msbuild'),
+                'libiconv.sln /t:Rebuild /p:Configuration=Release /p:Platform=x64'
+            );
+        FileSystem::createDir(BUILD_LIB_PATH);
+        FileSystem::createDir(BUILD_INCLUDE_PATH);
+        copy($this->source_dir . $vs_ver_dir . '\x64\lib\libiconv.lib', BUILD_LIB_PATH . '\libiconv.lib');
+        copy($this->source_dir . $vs_ver_dir . '\x64\lib\libiconv_a.lib', BUILD_LIB_PATH . '\libiconv_a.lib');
+        copy($this->source_dir . '\source\include\iconv.h', BUILD_INCLUDE_PATH . '\iconv.h');
+    }
+}

--- a/src/SPC/builder/windows/library/libxml2.php
+++ b/src/SPC/builder/windows/library/libxml2.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\windows\library;
+
+use SPC\store\FileSystem;
+
+class libxml2 extends WindowsLibraryBase
+{
+    public const NAME = 'libxml2';
+
+    protected function build(): void
+    {
+        $zlib = $this->builder->getLib('zlib') ? 'ON' : 'OFF';
+        // reset cmake
+        FileSystem::resetDir($this->source_dir . '\build');
+
+        // start build
+        cmd()->cd($this->source_dir)
+            ->execWithWrapper(
+                $this->builder->makeSimpleWrapper('cmake'),
+                '-B build ' .
+                '-A x64 ' .
+                "-DCMAKE_TOOLCHAIN_FILE={$this->builder->cmake_toolchain_file} " .
+                '-DBUILD_SHARED_LIBS=OFF ' .
+                '-DBUILD_STATIC_LIBS=ON ' .
+                "-DLIBXML2_WITH_ZLIB={$zlib} " .
+                '-DLIBXML2_WITH_PYTHON=OFF ' .
+                '-DLIBXML2_WITH_ICONV=ON ' .
+                '-DIconv_LIBRARY=' . BUILD_LIB_PATH . ' ' .
+                '-DIconv_INCLUDE_DIR=' . BUILD_INCLUDE_PATH . ' ' .
+                '-DLIBXML2_WITH_LZMA=OFF ' . // xz not supported yet
+                '-DLIBXML2_WITH_PROGRAMS=OFF ' .
+                '-DLIBXML2_WITH_TESTS=OFF ' .
+                '-DCMAKE_INSTALL_PREFIX=' . BUILD_ROOT_PATH . ' '
+            )
+            ->execWithWrapper(
+                $this->builder->makeSimpleWrapper('cmake'),
+                "--build build --config Release --target install -j{$this->builder->concurrency}"
+            );
+        copy(BUILD_LIB_PATH . '\libxml2s.lib', BUILD_LIB_PATH . '\libxml2_a.lib');
+    }
+}

--- a/src/SPC/store/FileSystem.php
+++ b/src/SPC/store/FileSystem.php
@@ -455,9 +455,11 @@ class FileSystem
         } elseif (PHP_OS_FAMILY === 'Windows') {
             // use php-sdk-binary-tools/bin/7za.exe
             $_7z = self::convertPath(PHP_SDK_PATH . '/bin/7za.exe');
+            $tar = self::convertPath(PHP_SDK_PATH . '/msys2/usr/bin/tar.exe');
+            putenv('MSYS=winsymlinks:lnk');
             match (self::extname($filename)) {
                 'tar' => f_passthru("tar -xf {$filename} -C {$target} --strip-components 1"),
-                'xz', 'txz', 'gz', 'tgz', 'bz2' => f_passthru("\"{$_7z}\" x -so {$filename} | tar -f - -x -C {$target} --strip-components 1"),
+                'xz', 'txz', 'gz', 'tgz', 'bz2' => f_passthru("\"{$_7z}\" x -so {$filename} | \"{$tar}\" -f - -x -C {$target} --strip-components 1"),
                 'zip' => f_passthru("\"{$_7z}\" x {$filename} -o{$target} -y"),
                 default => throw new FileSystemException("unknown archive format: {$filename}"),
             };

--- a/src/globals/test-extensions.php
+++ b/src/globals/test-extensions.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 // If you want to test your added extensions and libs, add below (comma separated, example `bcmath,openssl`).
 $extensions = match (PHP_OS_FAMILY) {
     'Linux', 'Darwin' => 'event,gettext',
-    'Windows' => 'mbstring,curl,ssh2',
+    'Windows' => 'mbstring,iconv,dom,xml,xmlwriter,xmlreader,soap,simplexml',
 };
 
 // If you want to test lib-suggests feature with extension, add them below (comma separated, example `libwebp,libavif`).


### PR DESCRIPTION
## What does this PR do?

- Add `iconv,xml,libxml,simplexml,xmlreader,xmlwriter,soap,dom` extension
- Fix sanity check for windows escape chars
- Fix windows tar extract with symlink bug
- 

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [X] If it's a extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [ ] If you changed the behavior of static-php-cli, add docs in [static-php/static-php-cli-docs](https://github.com/static-php/static-php-cli-docs) .
- [X] If you updated `config/xxxx.json` content, run `bin/spc dev:sort-config xxx`.
