### PR TITLE
feat: compile OpenSSL with debug symbols if --no-strip is passed

### DIFF
--- a/src/SPC/builder/linux/library/openssl.php
+++ b/src/SPC/builder/linux/library/openssl.php
@@ -58,6 +58,12 @@ class openssl extends LinuxLibraryBase
             $zlib_extra = '';
         }
 
+        if ($this->builder->getOption('no-strip')) {
+            $debug_extra = '-d ';
+        } else {
+            $debug_extra = '';
+        }
+
         $ex_lib = trim($ex_lib);
 
         $clang_postfix = SystemUtil::getCCType(getenv('CC')) === 'clang' ? '-clang' : '';
@@ -68,6 +74,7 @@ class openssl extends LinuxLibraryBase
                 '--prefix=/ ' .
                 '--libdir=lib ' .
                 '-static ' .
+                "{$debug_extra}" .
                 "{$zlib_extra}" .
                 'no-legacy ' .
                 "linux-{$this->builder->getOption('arch')}{$clang_postfix}"


### PR DESCRIPTION
## What does this PR do?

It enables the debug symbols of OpenSSL if `--no-strip` is passed.

First step for https://github.com/crazywhalecc/static-php-cli/issues/377.


