### PR TITLE
Fix install-pkg different arch cache bug

### DIFF
--- a/src/SPC/store/PackageManager.php
+++ b/src/SPC/store/PackageManager.php
@@ -24,6 +24,7 @@ class PackageManager
                 default => throw new WrongUsageException('Unsupported OS!'),
             };
             $config = Config::getPkg("{$pkg_name}-{$arch}-{$os}");
+            $pkg_name = "{$pkg_name}-{$arch}-{$os}";
         }
         if ($config === null) {
             throw new WrongUsageException("Package [{$pkg_name}] does not exist, please check the name and correct it !");


### PR DESCRIPTION
## What does this PR do?

Fix install-pkg different arch cache bug.

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [ ] If it's a extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [ ] If you changed the behavior of static-php-cli, add docs in [static-php/static-php-cli-docs](https://github.com/static-php/static-php-cli-docs) .
- [ ] If you updated `config/xxxx.json` content, run `bin/spc dev:sort-config xxx`.
