### PR TITLE
Add env variable manager

### DIFF
--- a/src/SPC/ConsoleApplication.php
+++ b/src/SPC/ConsoleApplication.php
@@ -25,7 +25,7 @@ use Symfony\Component\Console\Command\ListCommand;
  */
 final class ConsoleApplication extends Application
 {
-    public const VERSION = '2.1.7';
+    public const VERSION = '2.2.0';
 
     public function __construct()
     {

--- a/src/SPC/builder/LibraryBase.php
+++ b/src/SPC/builder/LibraryBase.php
@@ -206,4 +206,9 @@ abstract class LibraryBase
         }
         logger()->debug('enabling ' . static::NAME . " without {$name}");
     }
+
+    protected function getSnakeCaseName(): string
+    {
+        return str_replace('-', '_', static::NAME);
+    }
 }

--- a/src/SPC/builder/macos/library/libpng.php
+++ b/src/SPC/builder/macos/library/libpng.php
@@ -35,7 +35,7 @@ class libpng extends MacOSLibraryBase
      */
     protected function build(): void
     {
-        $optimizations = match ($this->builder->getOption('arch')) {
+        $optimizations = match (php_uname('m')) {
             'x86_64' => '--enable-intel-sse ',
             'arm64' => '--enable-arm-neon ',
             default => '',
@@ -45,7 +45,7 @@ class libpng extends MacOSLibraryBase
             ->exec('chmod +x ./install-sh')
             ->exec(
                 './configure ' .
-                "--host={$this->builder->getOption('gnu-arch')}-apple-darwin " .
+                '--host=' . arch2gnu(php_uname('m')) . '-apple-darwin ' .
                 '--disable-shared ' .
                 '--enable-static ' .
                 '--enable-hardware-optimizations ' .

--- a/src/SPC/builder/macos/library/openssl.php
+++ b/src/SPC/builder/macos/library/openssl.php
@@ -47,6 +47,7 @@ class openssl extends MacOSLibraryBase
         }
 
         shell()->cd($this->source_dir)
+            ->setEnv(['CFLAGS' => $this->getLibExtraCFlags(), 'LDFLAGS' => $this->getLibExtraLdFlags(), 'LIBS' => $this->getLibExtraLibs()])
             ->exec(
                 "./Configure no-shared {$extra} " .
                 '--prefix=/ ' . // use prefix=/
@@ -55,7 +56,7 @@ class openssl extends MacOSLibraryBase
                 "darwin64-{$this->builder->getOption('arch')}-cc"
             )
             ->exec('make clean')
-            ->exec("make -j{$this->builder->concurrency} CNF_EX_LIBS=\"{$ex_lib}\"")
+            ->execWithEnv("make -j{$this->builder->concurrency} CNF_EX_LIBS=\"{$ex_lib}\"")
             ->exec("make install_sw DESTDIR={$destdir}");
         $this->patchPkgconfPrefix(['libssl.pc', 'openssl.pc', 'libcrypto.pc']);
     }

--- a/src/SPC/builder/traits/UnixLibraryTrait.php
+++ b/src/SPC/builder/traits/UnixLibraryTrait.php
@@ -99,4 +99,19 @@ trait UnixLibraryTrait
             }
         }
     }
+
+    public function getLibExtraCFlags(): string
+    {
+        return getenv($this->getSnakeCaseName() . '_CFLAGS') ?: '';
+    }
+
+    public function getLibExtraLdFlags(): string
+    {
+        return getenv($this->getSnakeCaseName() . '_LDFLAGS') ?: '';
+    }
+
+    public function getLibExtraLibs(): string
+    {
+        return getenv($this->getSnakeCaseName() . '_LIBS') ?: '';
+    }
 }

--- a/src/SPC/builder/unix/library/brotli.php
+++ b/src/SPC/builder/unix/library/brotli.php
@@ -18,14 +18,15 @@ trait brotli
     {
         FileSystem::resetDir($this->source_dir . '/build-dir');
         shell()->cd($this->source_dir . '/build-dir')
-            ->exec(
+            ->setEnv(['CFLAGS' => $this->getLibExtraCFlags(), 'LDFLAGS' => $this->getLibExtraLdFlags(), 'LIBS' => $this->getLibExtraLibs()])
+            ->execWithEnv(
                 'cmake ' .
                 "{$this->builder->makeCmakeArgs()} " .
                 '-DBUILD_SHARED_LIBS=OFF ' .
                 '..'
             )
-            ->exec("cmake --build . -j {$this->builder->concurrency}")
-            ->exec('make install DESTDIR=' . BUILD_ROOT_PATH);
+            ->execWithEnv("cmake --build . -j {$this->builder->concurrency}")
+            ->execWithEnv('make install DESTDIR=' . BUILD_ROOT_PATH);
         $this->patchPkgconfPrefix(['libbrotlicommon.pc', 'libbrotlidec.pc', 'libbrotlienc.pc']);
         shell()->cd(BUILD_ROOT_PATH . '/lib')->exec('ln -sf libbrotlicommon.a libbrotli.a');
         foreach (FileSystem::scanDirFiles(BUILD_ROOT_PATH . '/lib/', false, true) as $filename) {

--- a/src/SPC/builder/unix/library/bzip2.php
+++ b/src/SPC/builder/unix/library/bzip2.php
@@ -9,8 +9,9 @@ trait bzip2
     protected function build(): void
     {
         shell()->cd($this->source_dir)
-            ->exec("make PREFIX='" . BUILD_ROOT_PATH . "' clean")
-            ->exec("make -j{$this->builder->concurrency} {$this->builder->getEnvString()} PREFIX='" . BUILD_ROOT_PATH . "' libbz2.a")
+            ->setEnv(['CFLAGS' => $this->getLibExtraCFlags(), 'LDFLAGS' => $this->getLibExtraLdFlags(), 'LIBS' => $this->getLibExtraLibs()])
+            ->execWithEnv("make PREFIX='" . BUILD_ROOT_PATH . "' clean")
+            ->execWithEnv("make -j{$this->builder->concurrency} {$this->builder->getEnvString()} PREFIX='" . BUILD_ROOT_PATH . "' libbz2.a")
             ->exec('cp libbz2.a ' . BUILD_LIB_PATH)
             ->exec('cp bzlib.h ' . BUILD_INCLUDE_PATH);
     }

--- a/src/SPC/builder/unix/library/curl.php
+++ b/src/SPC/builder/unix/library/curl.php
@@ -51,10 +51,11 @@ trait curl
         FileSystem::resetDir($this->source_dir . '/build');
         // compile！
         shell()->cd($this->source_dir . '/build')
+            ->setEnv(['CFLAGS' => $this->getLibExtraCFlags(), 'LDFLAGS' => $this->getLibExtraLdFlags(), 'LIBS' => $this->getLibExtraLibs()])
             ->exec('sed -i.save s@\${CMAKE_C_IMPLICIT_LINK_LIBRARIES}@@ ../CMakeLists.txt')
-            ->exec("cmake {$this->builder->makeCmakeArgs()} -DBUILD_SHARED_LIBS=OFF -DBUILD_CURL_EXE=OFF -DBUILD_LIBCURL_DOCS=OFF {$extra} ..")
-            ->exec("make -j{$this->builder->concurrency}")
-            ->exec('make install DESTDIR=' . BUILD_ROOT_PATH);
+            ->execWithEnv("cmake {$this->builder->makeCmakeArgs()} -DBUILD_SHARED_LIBS=OFF -DBUILD_CURL_EXE=OFF -DBUILD_LIBCURL_DOCS=OFF {$extra} ..")
+            ->execWithEnv("make -j{$this->builder->concurrency}")
+            ->execWithEnv('make install DESTDIR=' . BUILD_ROOT_PATH);
         // patch pkgconf
         $this->patchPkgconfPrefix(['libcurl.pc']);
         shell()->cd(BUILD_LIB_PATH . '/cmake/CURL/')

--- a/src/SPC/builder/unix/library/freetype.php
+++ b/src/SPC/builder/unix/library/freetype.php
@@ -26,15 +26,16 @@ trait freetype
         $suggested .= ' ';
 
         shell()->cd($this->source_dir)
+            ->setEnv(['CFLAGS' => $this->getLibExtraCFlags(), 'LDFLAGS' => $this->getLibExtraLdFlags(), 'LIBS' => $this->getLibExtraLibs()])
             ->exec('sh autogen.sh')
-            ->exec(
+            ->execWithEnv(
                 './configure ' .
                 '--enable-static --disable-shared --without-harfbuzz --prefix= ' .
                 $suggested
             )
-            ->exec('make clean')
-            ->exec("make -j{$this->builder->concurrency}")
-            ->exec('make install DESTDIR=' . BUILD_ROOT_PATH);
+            ->execWithEnv('make clean')
+            ->execWithEnv("make -j{$this->builder->concurrency}")
+            ->execWithEnv('make install DESTDIR=' . BUILD_ROOT_PATH);
         $this->patchPkgconfPrefix(['freetype2.pc']);
         FileSystem::replaceFileStr(
             BUILD_ROOT_PATH . '/lib/pkgconfig/freetype2.pc',

--- a/src/SPC/builder/unix/library/gettext.php
+++ b/src/SPC/builder/unix/library/gettext.php
@@ -11,7 +11,8 @@ trait gettext
         $extra = $this->builder->getLib('ncurses') ? ('--with-libncurses-prefix=' . BUILD_ROOT_PATH . ' ') : '';
         $extra .= $this->builder->getLib('libxml2') ? ('--with-libxml2-prefix=' . BUILD_ROOT_PATH . ' ') : '';
         shell()->cd($this->source_dir)
-            ->exec(
+            ->setEnv(['CFLAGS' => $this->getLibExtraCFlags(), 'LDFLAGS' => $this->getLibExtraLdFlags(), 'LIBS' => $this->getLibExtraLibs()])
+            ->execWithEnv(
                 './configure ' .
                 '--enable-static ' .
                 '--disable-shared ' .
@@ -21,8 +22,8 @@ trait gettext
                 '--with-libiconv-prefix=' . BUILD_ROOT_PATH . ' ' .
                 '--prefix=' . BUILD_ROOT_PATH
             )
-            ->exec('make clean')
-            ->exec("make -j{$this->builder->concurrency}")
-            ->exec('make install');
+            ->execWithEnv('make clean')
+            ->execWithEnv("make -j{$this->builder->concurrency}")
+            ->execWithEnv('make install');
     }
 }

--- a/src/SPC/builder/unix/library/gmp.php
+++ b/src/SPC/builder/unix/library/gmp.php
@@ -16,13 +16,14 @@ trait gmp
     protected function build(): void
     {
         shell()->cd($this->source_dir)
-            ->exec(
+            ->setEnv(['CFLAGS' => $this->getLibExtraCFlags(), 'LDFLAGS' => $this->getLibExtraLdFlags(), 'LIBS' => $this->getLibExtraLibs()])
+            ->execWithEnv(
                 './configure ' .
                 '--enable-static --disable-shared ' .
                 '--prefix='
             )
-            ->exec('make clean')
-            ->exec("make -j{$this->builder->concurrency}")
+            ->execWithEnv('make clean')
+            ->execWithEnv("make -j{$this->builder->concurrency}")
             ->exec('make install DESTDIR=' . BUILD_ROOT_PATH);
         $this->patchPkgconfPrefix(['gmp.pc']);
     }

--- a/src/SPC/builder/unix/library/imagemagick.php
+++ b/src/SPC/builder/unix/library/imagemagick.php
@@ -39,15 +39,18 @@ trait imagemagick
             }
         }
 
-        $ldflags = $this instanceof LinuxLibraryBase ? ('LDFLAGS="-static" ') : '';
+        $ldflags = $this instanceof LinuxLibraryBase ? ('-static') : '';
 
         // libxml iconv patch
-        $required_libs .= $this instanceof MacOSLibraryBase ? (' -liconv') : '';
+        $required_libs .= $this instanceof MacOSLibraryBase ? ('-liconv') : '';
         shell()->cd($this->source_dir)
-            ->exec(
-                'PKG_CONFIG="$PKG_CONFIG --static" ' .
-                $ldflags .
-                "LIBS='{$required_libs}' " .
+            ->setEnv([
+                'CFLAGS' => $this->getLibExtraCFlags(),
+                'LDFLAGS' => $this->getLibExtraLdFlags() ?: $ldflags,
+                'LIBS' => $this->getLibExtraLibs() ?: $required_libs,
+                'PKG_CONFIG' => '$PKG_CONFIG --static',
+            ])
+            ->execWithEnv(
                 './configure ' .
                 '--enable-static --disable-shared ' .
                 $extra .

--- a/src/SPC/builder/unix/library/ldap.php
+++ b/src/SPC/builder/unix/library/ldap.php
@@ -25,9 +25,15 @@ trait ldap
         $alt .= $this->builder->getLib('libsodium') ? '--with-argon2=libsodium ' : '--enable-argon2=no ';
         f_putenv('PKG_CONFIG=' . BUILD_ROOT_PATH . '/bin/pkg-config');
         f_putenv('PKG_CONFIG_PATH=' . BUILD_LIB_PATH . '/pkgconfig');
+        $ldflags = '-L' . BUILD_LIB_PATH;
         shell()->cd($this->source_dir)
-            ->exec(
-                $this->builder->makeAutoconfFlags(AUTOCONF_LDFLAGS | AUTOCONF_CPPFLAGS) .
+            ->setEnv([
+                'CFLAGS' => $this->getLibExtraCFlags(),
+                'LDFLAGS' => $this->getLibExtraLdFlags() ?: $ldflags,
+                'LIBS' => $this->getLibExtraLibs(),
+            ])
+            ->execWithEnv(
+                $this->builder->makeAutoconfFlags(AUTOCONF_CPPFLAGS) .
                 ' ./configure ' .
                 '--enable-static ' .
                 '--disable-shared ' .

--- a/src/SPC/builder/unix/library/libargon2.php
+++ b/src/SPC/builder/unix/library/libargon2.php
@@ -11,9 +11,10 @@ trait libargon2
     protected function build()
     {
         shell()->cd($this->source_dir)
+            ->setEnv(['CFLAGS' => $this->getLibExtraCFlags(), 'LDFLAGS' => $this->getLibExtraLdFlags(), 'LIBS' => $this->getLibExtraLibs()])
             ->exec("make PREFIX='' clean")
-            ->exec("make -j{$this->builder->concurrency} PREFIX=''")
-            ->exec("make install PREFIX='' DESTDIR=" . BUILD_ROOT_PATH);
+            ->execWithEnv("make -j{$this->builder->concurrency} PREFIX=''")
+            ->execWithEnv("make install PREFIX='' DESTDIR=" . BUILD_ROOT_PATH);
 
         $this->patchPkgconfPrefix(['libargon2.pc']);
 

--- a/src/SPC/builder/unix/library/libavif.php
+++ b/src/SPC/builder/unix/library/libavif.php
@@ -22,9 +22,10 @@ trait libavif
         FileSystem::resetDir($this->source_dir . '/build');
         // Start build
         shell()->cd($this->source_dir . '/build')
-            ->exec("cmake {$this->builder->makeCmakeArgs()} -DBUILD_SHARED_LIBS=OFF ..")
-            ->exec("cmake --build . -j {$this->builder->concurrency}")
-            ->exec('make install DESTDIR=' . BUILD_ROOT_PATH);
+            ->setEnv(['CFLAGS' => $this->getLibExtraCFlags(), 'LDFLAGS' => $this->getLibExtraLdFlags(), 'LIBS' => $this->getLibExtraLibs()])
+            ->execWithEnv("cmake {$this->builder->makeCmakeArgs()} -DBUILD_SHARED_LIBS=OFF ..")
+            ->execWithEnv("cmake --build . -j {$this->builder->concurrency}")
+            ->execWithEnv('make install DESTDIR=' . BUILD_ROOT_PATH);
         // patch pkgconfig
         $this->patchPkgconfPrefix(['libavif.pc']);
         $this->cleanLaFiles();

--- a/src/SPC/builder/unix/library/libcares.php
+++ b/src/SPC/builder/unix/library/libcares.php
@@ -14,8 +14,9 @@ trait libcares
     protected function build(): void
     {
         shell()->cd($this->source_dir)
-            ->exec('./configure --prefix=' . BUILD_ROOT_PATH . ' --enable-static --disable-shared --disable-tests')
-            ->exec("make -j {$this->builder->concurrency}")
+            ->setEnv(['CFLAGS' => $this->getLibExtraCFlags(), 'LDFLAGS' => $this->getLibExtraLdFlags(), 'LIBS' => $this->getLibExtraLibs()])
+            ->execWithEnv('./configure --prefix=' . BUILD_ROOT_PATH . ' --enable-static --disable-shared --disable-tests')
+            ->execWithEnv("make -j {$this->builder->concurrency}")
             ->exec('make install');
     }
 }

--- a/src/SPC/builder/unix/library/libevent.php
+++ b/src/SPC/builder/unix/library/libevent.php
@@ -20,7 +20,8 @@ trait libevent
         FileSystem::resetDir($this->source_dir . '/build');
         // Start build
         shell()->cd($this->source_dir . '/build')
-            ->exec(
+            ->setEnv(['CFLAGS' => $this->getLibExtraCFlags(), 'LDFLAGS' => $this->getLibExtraLdFlags(), 'LIBS' => $this->getLibExtraLibs()])
+            ->execWithEnv(
                 'cmake ' .
                 '-DCMAKE_INSTALL_PREFIX=' . BUILD_ROOT_PATH . ' ' .
                 "-DCMAKE_TOOLCHAIN_FILE={$this->builder->cmake_toolchain_file} " .
@@ -33,7 +34,7 @@ trait libevent
                 '-DEVENT__DISABLE_SAMPLES=ON ' .
                 '..'
             )
-            ->exec("cmake --build . -j {$this->builder->concurrency}")
+            ->execWithEnv("cmake --build . -j {$this->builder->concurrency}")
             ->exec('make install');
     }
 }

--- a/src/SPC/builder/windows/WindowsBuilder.php
+++ b/src/SPC/builder/windows/WindowsBuilder.php
@@ -13,6 +13,7 @@ use SPC\store\FileSystem;
 use SPC\store\SourceManager;
 use SPC\store\SourcePatcher;
 use SPC\util\DependencyUtil;
+use SPC\util\GlobalEnvManager;
 
 class WindowsBuilder extends BuilderBase
 {
@@ -33,6 +34,8 @@ class WindowsBuilder extends BuilderBase
     {
         $this->options = $options;
 
+        GlobalEnvManager::init($this);
+
         // ---------- set necessary options ----------
         // set sdk (require visual studio 16 or 17)
         $vs = SystemUtil::findVisualStudio()['version'];
@@ -42,7 +45,7 @@ class WindowsBuilder extends BuilderBase
         $this->zts = $this->getOption('enable-zts', false);
 
         // set concurrency
-        $this->concurrency = SystemUtil::getCpuCount();
+        $this->concurrency = intval(getenv('SPC_CONCURRENCY'));
 
         // make cmake toolchain
         $this->cmake_toolchain_file = SystemUtil::makeCmakeToolchainFile();
@@ -56,9 +59,10 @@ class WindowsBuilder extends BuilderBase
     public function buildPHP(int $build_target = BUILD_TARGET_NONE): void
     {
         // ---------- Update extra-libs ----------
-        $extra_libs = $this->getOption('extra-libs', '');
+        $extra_libs = getenv('SPC_EXTRA_LIBS') ?: '';
         $extra_libs .= (empty($extra_libs) ? '' : ' ') . implode(' ', $this->getAllStaticLibFiles());
-        $this->setOption('extra-libs', $extra_libs);
+        f_putenv('SPC_EXTRA_LIBS=' . $extra_libs);
+
         $enableCli = ($build_target & BUILD_TARGET_CLI) === BUILD_TARGET_CLI;
         $enableFpm = ($build_target & BUILD_TARGET_FPM) === BUILD_TARGET_FPM;
         $enableMicro = ($build_target & BUILD_TARGET_MICRO) === BUILD_TARGET_MICRO;
@@ -77,7 +81,7 @@ class WindowsBuilder extends BuilderBase
         if ($this->getOption('with-upx-pack', false)) {
             if (!file_exists($makefile . '.originfile')) {
                 copy($makefile, $makefile . '.originfile');
-                FileSystem::replaceFileStr($makefile, '$(MICRO_SFX):', "_MICRO_UPX = {$this->getOption('upx-exec')} --best $(MICRO_SFX)\n$(MICRO_SFX):");
+                FileSystem::replaceFileStr($makefile, '$(MICRO_SFX):', '_MICRO_UPX = ' . getenv('UPX_EXEC') . " --best $(MICRO_SFX)\n$(MICRO_SFX):");
                 FileSystem::replaceFileStr($makefile, '@$(_MICRO_MT)', "@$(_MICRO_MT)\n\t@$(_MICRO_UPX)");
             }
         } elseif (file_exists($makefile . '.originfile')) {
@@ -319,7 +323,7 @@ class WindowsBuilder extends BuilderBase
 
         // with-upx-pack for cli
         if ($this->getOption('with-upx-pack', false) && $type === BUILD_TARGET_CLI) {
-            cmd()->exec($this->getOption('upx-exec') . ' --best ' . escapeshellarg($src));
+            cmd()->exec(getenv('UPX_EXEC') . ' --best ' . escapeshellarg($src));
         }
 
         logger()->info('Deploying ' . $this->getBuildTypeName($type) . ' file');

--- a/src/SPC/util/GlobalEnvManager.php
+++ b/src/SPC/util/GlobalEnvManager.php
@@ -40,15 +40,6 @@ class GlobalEnvManager
         self::putenv('SOURCE_PATH=' . SOURCE_PATH);
         self::putenv('DOWNLOAD_PATH=' . DOWNLOAD_PATH);
 
-        // Init system-specific env
-        match (PHP_OS_FAMILY) {
-            'Windows' => self::initWindowsEnv($builder),
-            'Darwin' => self::initDarwinEnv($builder),
-            'Linux' => self::initLinuxEnv($builder),
-            'BSD' => 'TODO',
-            default => logger()->warning('Unknown OS: ' . PHP_OS_FAMILY),
-        };
-
         // Init SPC env
         self::initIfNotExists('SPC_CONCURRENCY', match (PHP_OS_FAMILY) {
             'Windows' => (string) WindowsSystemUtil::getCpuCount(),
@@ -57,6 +48,15 @@ class GlobalEnvManager
             'BSD' => (string) BSDSystemUtil::getCpuCount(),
             default => '1',
         });
+
+        // Init system-specific env
+        match (PHP_OS_FAMILY) {
+            'Windows' => self::initWindowsEnv($builder),
+            'Darwin' => self::initDarwinEnv($builder),
+            'Linux' => self::initLinuxEnv($builder),
+            'BSD' => 'TODO',
+            default => logger()->warning('Unknown OS: ' . PHP_OS_FAMILY),
+        };
     }
 
     private static function initWindowsEnv(BuilderBase $builder): void

--- a/src/SPC/util/GlobalEnvManager.php
+++ b/src/SPC/util/GlobalEnvManager.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\util;
+
+use SPC\builder\BuilderBase;
+use SPC\builder\freebsd\SystemUtil as BSDSystemUtil;
+use SPC\builder\linux\SystemUtil as LinuxSystemUtil;
+use SPC\builder\macos\SystemUtil as MacOSSystemUtil;
+use SPC\builder\windows\SystemUtil as WindowsSystemUtil;
+use SPC\exception\RuntimeException;
+
+/**
+ * Environment variable manager
+ */
+class GlobalEnvManager
+{
+    private static array $env_cache = [];
+
+    public static function getInitializedEnv(): array
+    {
+        return self::$env_cache;
+    }
+
+    /**
+     * Initialize the environment variables
+     *
+     * @param  BuilderBase      $builder Builder
+     * @throws RuntimeException
+     */
+    public static function init(BuilderBase $builder): void
+    {
+        // Init global env, build related path
+        self::putenv('BUILD_ROOT_PATH=' . BUILD_ROOT_PATH);
+        self::putenv('BUILD_INCLUDE_PATH=' . BUILD_INCLUDE_PATH);
+        self::putenv('BUILD_LIB_PATH=' . BUILD_LIB_PATH);
+        self::putenv('BUILD_BIN_PATH=' . BUILD_BIN_PATH);
+        self::putenv('PKG_ROOT_PATH=' . PKG_ROOT_PATH);
+        self::putenv('SOURCE_PATH=' . SOURCE_PATH);
+        self::putenv('DOWNLOAD_PATH=' . DOWNLOAD_PATH);
+
+        // Init system-specific env
+        match (PHP_OS_FAMILY) {
+            'Windows' => self::initWindowsEnv($builder),
+            'Darwin' => self::initDarwinEnv($builder),
+            'Linux' => self::initLinuxEnv($builder),
+            'BSD' => 'TODO',
+            default => logger()->warning('Unknown OS: ' . PHP_OS_FAMILY),
+        };
+
+        // Init SPC env
+        self::initIfNotExists('SPC_CONCURRENCY', match (PHP_OS_FAMILY) {
+            'Windows' => (string) WindowsSystemUtil::getCpuCount(),
+            'Darwin' => (string) MacOSSystemUtil::getCpuCount(),
+            'Linux' => (string) LinuxSystemUtil::getCpuCount(),
+            'BSD' => (string) BSDSystemUtil::getCpuCount(),
+            default => '1',
+        });
+    }
+
+    private static function initWindowsEnv(BuilderBase $builder): void
+    {
+        // Windows need php-sdk binary tools
+        self::initIfNotExists('PHP_SDK_PATH', WORKING_DIR . DIRECTORY_SEPARATOR . 'php-sdk-binary-tools');
+    }
+
+    private static function initLinuxEnv(BuilderBase $builder): void
+    {
+        // Init C Compiler and C++ Compiler (alpine)
+        if (\SPC\builder\linux\SystemUtil::isMuslDist()) {
+            self::initIfNotExists('CC', 'gcc');
+            self::initIfNotExists('CXX', 'g++');
+            self::initIfNotExists('AR', 'ar');
+            self::initIfNotExists('LD', 'ld.gold');
+        } else {
+            $arch = arch2gnu(php_uname('m'));
+            self::initIfNotExists('CC', "{$arch}-linux-musl-gcc");
+            self::initIfNotExists('CXX', "{$arch}-linux-musl-g++");
+            self::initIfNotExists('AR', "{$arch}-linux-musl-ar");
+            self::initIfNotExists('LD', 'ld.gold');
+            self::putenv("PATH=/usr/local/musl/bin:/usr/local/musl/{$arch}-linux-musl/bin:" . getenv('PATH'));
+        }
+
+        // Init arch-specific cflags
+        self::initIfNotExists('SPC_DEFAULT_C_FLAGS', '');
+        self::initIfNotExists('SPC_DEFAULT_CXX_FLAGS', '');
+        self::initIfNotExists('SPC_EXTRA_LIBS', '');
+
+        // Init linux-only env
+        self::initIfNotExists('UPX_EXEC', PKG_ROOT_PATH . '/bin/upx');
+        self::initIfNotExists('GNU_ARCH', arch2gnu(php_uname('m')));
+
+        // optimization flags with different strip option
+        $php_extra_cflags_optimize = $builder->getOption('no-strip') ? '-g -O0' : '-g -Os';
+        // optimization flags with different c compiler
+        $clang_use_lld = str_ends_with(getenv('CC'), 'clang') && LinuxSystemUtil::findCommand('lld') ? '-Xcompiler -fuse-ld=lld ' : '';
+
+        $init_spc_cmd_maps = [
+            // Init default build command prefix
+            'SPC_CMD_PREFIX_PHP_BUILDCONF' => './buildconf --force',
+            'SPC_CMD_PREFIX_PHP_CONFIGURE' => $builder->getOption('ld_library_path') . ' ./configure --prefix= --with-valgrind=no --enable-shared=no --enable-static=yes --disable-all --disable-cgi --disable-phpdbg',
+            'SPC_CMD_PREFIX_PHP_MAKE' => 'make -j' . getenv('SPC_CONCURRENCY'),
+            // Init default build vars for build command
+            'SPC_CMD_VAR_PHP_CONFIGURE_CFLAGS' => getenv('SPC_DEFAULT_C_FLAGS'),
+            'SPC_CMD_VAR_PHP_CONFIGURE_CPPFLAGS' => '-I' . BUILD_INCLUDE_PATH,
+            'SPC_CMD_VAR_PHP_CONFIGURE_LDFLAGS' => '-L' . BUILD_LIB_PATH,
+            'SPC_CMD_VAR_PHP_CONFIGURE_LIBS' => '-ldl -lpthread',
+            'SPC_CMD_VAR_PHP_MAKE_EXTRA_CFLAGS' => $php_extra_cflags_optimize . ' -fno-ident -fPIE',
+            'SPC_CMD_VAR_PHP_MAKE_EXTRA_LIBS' => '',
+            'SPC_CMD_VAR_PHP_MAKE_EXTRA_LDFLAGS_PROGRAM' => $clang_use_lld . '-all-static',
+        ];
+
+        foreach ($init_spc_cmd_maps as $name => $value) {
+            self::initIfNotExists($name, $value);
+        }
+
+        self::initUnixEnv($builder);
+    }
+
+    private static function initDarwinEnv(BuilderBase $builder): void
+    {
+        // Init C Compiler and C++ Compiler
+        self::initIfNotExists('CC', 'clang');
+        self::initIfNotExists('CXX', 'clang++');
+
+        // Init arch-specific cflags
+        self::initIfNotExists('SPC_DEFAULT_C_FLAGS', match (php_uname('m')) {
+            'arm64', 'aarch64' => '--target=arm64-apple-darwin',
+            default => '--target=x86_64-apple-darwin',
+        });
+        // Init arch-specific cxxflags
+        self::initIfNotExists('SPC_DEFAULT_CXX_FLAGS', match (php_uname('m')) {
+            'arm64', 'aarch64' => '--target=arm64-apple-darwin',
+            default => '--target=x86_64-apple-darwin',
+        });
+
+        // Init extra libs (will be appended before `before-php-buildconf` event point)
+        self::initIfNotExists('SPC_EXTRA_LIBS', '');
+
+        $init_spc_cmd_maps = [
+            // Init default build command prefix
+            'SPC_CMD_PREFIX_PHP_BUILDCONF' => './buildconf --force',
+            'SPC_CMD_PREFIX_PHP_CONFIGURE' => './configure --prefix= --with-valgrind=no --enable-shared=no --enable-static=yes --disable-all --disable-cgi --disable-phpdbg',
+            'SPC_CMD_PREFIX_PHP_MAKE' => 'make -j' . getenv('SPC_CONCURRENCY'),
+            // Init default build vars for build command
+            'SPC_CMD_VAR_PHP_CONFIGURE_CFLAGS' => getenv('SPC_DEFAULT_C_FLAGS') . ' -Werror=unknown-warning-option',
+            'SPC_CMD_VAR_PHP_CONFIGURE_CPPFLAGS' => '-I' . BUILD_INCLUDE_PATH,
+            'SPC_CMD_VAR_PHP_CONFIGURE_LDFLAGS' => '-L' . BUILD_LIB_PATH,
+            'SPC_CMD_VAR_PHP_MAKE_EXTRA_CFLAGS' => $builder->getOption('no-strip') ? '-g -O0' : '-g -Os',
+            'SPC_CMD_VAR_PHP_MAKE_EXTRA_LIBS' => '-lresolv',
+        ];
+        foreach ($init_spc_cmd_maps as $name => $value) {
+            self::initIfNotExists($name, $value);
+        }
+
+        self::initUnixEnv($builder);
+    }
+
+    private static function initUnixEnv(BuilderBase $builder): void
+    {
+        self::putenv('PATH=' . BUILD_ROOT_PATH . '/bin:' . getenv('PATH'));
+        self::putenv('PKG_CONFIG=' . BUILD_BIN_PATH . '/pkg-config');
+        self::putenv('PKG_CONFIG_PATH=' . BUILD_ROOT_PATH . '/lib/pkgconfig');
+    }
+
+    /**
+     * Initialize the environment variable if it does not exist
+     *
+     * @param string $name  Environment variable name
+     * @param string $value Environment variable value
+     */
+    private static function initIfNotExists(string $name, string $value): void
+    {
+        if (($val = getenv($name)) === false) {
+            self::putenv($name . '=' . $value);
+        } else {
+            logger()->debug("env [{$name}] existing: {$val}");
+        }
+    }
+
+    private static function putenv(string $val): void
+    {
+        f_putenv($val);
+        self::$env_cache[] = $val;
+    }
+}

--- a/src/SPC/util/UnixShell.php
+++ b/src/SPC/util/UnixShell.php
@@ -62,7 +62,12 @@ class UnixShell
 
     public function setEnv(array $env): UnixShell
     {
-        $this->env = array_merge($this->env, $env);
+        foreach ($env as $k => $v) {
+            if ($v === '') {
+                continue;
+            }
+            $this->env[$k] = $v;
+        }
         return $this;
     }
 


### PR DESCRIPTION
## What does this PR do?

Add environment variable manager. It will allow you to customize build flags.

- Fix #385 
- Fix #382 
- Fix #377 
- Fix #331 

Docs preview:

| var name | default value | comment |
| --- | --- | --- |
| `SPC_CMD_VAR_PHP_MAKE_EXTRA_CFLAGS` | `-g -Os -fno-ident -fPIE` | used in php-src's `make EXTRA_CFLAGS={$val}` |

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [ ] If it's a extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [ ] If you changed the behavior of static-php-cli, add docs in [static-php/static-php-cli-docs](https://github.com/static-php/static-php-cli-docs) .
- [x] If you updated `config/xxxx.json` content, run `bin/spc dev:sort-config xxx`.
