### PR TITLE
fix: downgrade to ICU 74

### DIFF
--- a/config/source.json
+++ b/config/source.json
@@ -187,9 +187,8 @@
         }
     },
     "icu": {
-        "type": "ghrel",
-        "repo": "unicode-org/icu",
-        "match": "icu4c.+-src\\.tgz",
+        "type": "url",
+        "url": "https://github.com/unicode-org/icu/releases/download/release-74-2/icu4c-74_2-src.tgz",
         "license": {
             "type": "file",
             "path": "LICENSE"


### PR DESCRIPTION
## What does this PR do?

It doesn't look currently possible to use ICU 75 with PHP because this version requires C++ 17.
https://github.com/php/php-src/pull/14002 and #414 will fix the issue. In the meantime, we have to downgrade ICU to v74.

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [x] If it's a extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [x] If you changed the behavior of static-php-cli, add docs in [static-php/static-php-cli-docs](https://github.com/static-php/static-php-cli-docs) .
- [x] If you updated `config/xxxx.json` content, run `bin/spc dev:sort-config xxx`.
