### PR TITLE
Fix Intel Mac build action

### DIFF
--- a/.github/workflows/build-macos-x86_64.yml
+++ b/.github/workflows/build-macos-x86_64.yml
@@ -46,6 +46,14 @@ jobs:
           brew install automake gzip
           echo "SPC_BUILD_OS=macos" >> $GITHUB_ENV
 
+      - name: "Setup PHP"
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.1
+          tools: pecl, composer
+          extensions: curl, openssl, mbstring, tokenizer
+          ini-values: memory_limit=-1
+
       # Cache composer dependencies
       - id: cache-composer-deps
         uses: actions/cache@v3

--- a/.github/workflows/build-macos-x86_64.yml
+++ b/.github/workflows/build-macos-x86_64.yml
@@ -37,7 +37,7 @@ env:
 jobs:
   build:
     name: build ${{ inputs.version }} on macOS x86_64
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build-macos-x86_64.yml
+++ b/.github/workflows/build-macos-x86_64.yml
@@ -37,7 +37,7 @@ env:
 jobs:
   build:
     name: build ${{ inputs.version }} on macOS x86_64
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Intel Mac build GitHub Action as it was missing the PHP runtime, Composer and other parts necessary to run the build process from SPC source.

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [ ] If it's a extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [ ] If you changed the behavior of static-php-cli, add docs in [static-php/static-php-cli-docs](https://github.com/static-php/static-php-cli-docs) .
- [ ] If you updated `config/xxxx.json` content, run `bin/spc dev:sort-config xxx`.
