### PR TITLE
Fix ncurses pkg-config bug temporarily

### DIFF
--- a/config/source.json
+++ b/config/source.json
@@ -480,9 +480,13 @@
         }
     },
     "ncurses": {
-        "type": "filelist",
-        "url": "https://ftp.gnu.org/pub/gnu/ncurses/",
-        "regex": "/href=\"(?<file>ncurses-(?<version>[^\"]+)\\.tar\\.gz)\"/",
+        "alt": {
+            "type": "filelist",
+            "url": "https://ftp.gnu.org/pub/gnu/ncurses/",
+            "regex": "/href=\"(?<file>ncurses-(?<version>[^\"]+)\\.tar\\.gz)\"/"
+        },
+        "type": "url",
+        "url": "https://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.4.tar.gz",
         "license": {
             "type": "file",
             "path": "COPYING"

--- a/src/globals/test-extensions.php
+++ b/src/globals/test-extensions.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 // If you want to test your added extensions and libs, add below (comma separated, example `bcmath,openssl`).
 $extensions = match (PHP_OS_FAMILY) {
-    'Linux', 'Darwin' => 'imagick',
+    'Linux', 'Darwin' => 'readline',
     'Windows' => 'mbstring,pdo_sqlite,mbregex',
 };
 


### PR DESCRIPTION
## What does this PR do?

Fix ncurses pkg-config bug temporarily. Related issue: #430 #431 .

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [X] If it's a extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [X] If you changed the behavior of static-php-cli, add docs in [static-php/static-php-cli-docs](https://github.com/static-php/static-php-cli-docs) .
- [X] If you updated `config/xxxx.json` content, run `bin/spc dev:sort-config xxx`.
