### PR TITLE
Add libxml extension wrapper for composer compatibility

### DIFF
--- a/config/ext.json
+++ b/config/ext.json
@@ -278,6 +278,16 @@
             "openssl"
         ]
     },
+    "libxml": {
+        "support": {
+            "BSD": "wip"
+        },
+        "type": "builtin",
+        "arg-type": "none",
+        "ext-depends": [
+            "xml"
+        ]
+    },
     "mbregex": {
         "type": "builtin",
         "arg-type": "custom",

--- a/src/globals/test-extensions.php
+++ b/src/globals/test-extensions.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
 
 // --------------------------------- edit area ---------------------------------
 
-$zts = true;
+$zts = false;
 
 // If you want to test your added extensions and libs, add below (comma separated, example `bcmath,openssl`).
 $extensions = match (PHP_OS_FAMILY) {
-    'Linux', 'Darwin' => 'parallel',
-    'Windows' => 'mbstring,pdo_sqlite,mbregex,parallel',
+    'Linux', 'Darwin' => 'libxml',
+    'Windows' => 'mbstring,pdo_sqlite,mbregex,libxml',
 };
 
 // If you want to test lib-suggests feature with extension, add them below (comma separated, example `libwebp,libavif`).


### PR DESCRIPTION
## What does this PR do?

Add libxml extension wrapper for composer compatibility

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [X] If it's a extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [X] If you changed the behavior of static-php-cli, add docs in [static-php/static-php-cli-docs](https://github.com/static-php/static-php-cli-docs) .
- [X] If you updated `config/xxxx.json` content, run `bin/spc dev:sort-config xxx`.
