### PR TITLE
replace ext-zend-opcache with ext-opcache for spc extension list

### DIFF
--- a/src/SPC/command/BaseCommand.php
+++ b/src/SPC/command/BaseCommand.php
@@ -147,6 +147,7 @@ abstract class BaseCommand extends Command
 
     protected function parseExtensionList(string $ext_list): array
     {
+        $ext_list = str_replace('zend-opcache', 'opcache', $ext_list);
         $a = array_map('trim', explode(',', $ext_list));
         return array_values(array_filter($a, function ($x) {
             $filter_internals = [

--- a/src/SPC/command/BaseCommand.php
+++ b/src/SPC/command/BaseCommand.php
@@ -145,20 +145,26 @@ abstract class BaseCommand extends Command
         return static::FAILURE;
     }
 
+    /**
+     * Parse extension list from string, replace alias and filter internal extensions.
+     *
+     * @param string $ext_list Extension string list, e.g. "mbstring,posix,sockets"
+     */
     protected function parseExtensionList(string $ext_list): array
     {
-        $ext_list = str_replace('zend-opcache', 'opcache', $ext_list);
-        $a = array_map('trim', explode(',', $ext_list));
-        return array_values(array_filter($a, function ($x) {
-            $filter_internals = [
-                'core',
-                'hash',
-                'json',
-                'reflection',
-                'spl',
-                'standard',
-            ];
-            if (in_array(strtolower($x), $filter_internals)) {
+        // replace alias
+        $ls = array_map(function ($x) {
+            $lower = strtolower(trim($x));
+            if (isset(SPC_EXTENSION_ALIAS[$lower])) {
+                logger()->notice("Extension [{$lower}] is an alias of [" . SPC_EXTENSION_ALIAS[$lower] . '], it will be replaced.');
+                return SPC_EXTENSION_ALIAS[$lower];
+            }
+            return $lower;
+        }, explode(',', $ext_list));
+
+        // filter internals
+        return array_values(array_filter($ls, function ($x) {
+            if (in_array($x, SPC_INTERNAL_EXTENSIONS)) {
                 logger()->warning("Extension [{$x}] is an builtin extension, it will be ignored.");
                 return false;
             }

--- a/src/globals/defines.php
+++ b/src/globals/defines.php
@@ -38,6 +38,23 @@ const DANGER_CMD = [
     'rmdir',
 ];
 
+// spc internal extensions
+const SPC_INTERNAL_EXTENSIONS = [
+    'core',
+    'hash',
+    'json',
+    'reflection',
+    'spl',
+    'standard',
+];
+
+// spc extension alias
+const SPC_EXTENSION_ALIAS = [
+    'zend opcache' => 'opcache',
+    'zend-opcache' => 'opcache',
+    'zendopcache' => 'opcache',
+];
+
 // file replace strategy
 const REPLACE_FILE_STR = 1;
 const REPLACE_FILE_PREG = 2;

--- a/src/globals/test-extensions.php
+++ b/src/globals/test-extensions.php
@@ -19,7 +19,7 @@ $upx = true;
 
 // If you want to test your added extensions and libs, add below (comma separated, example `bcmath,openssl`).
 $extensions = match (PHP_OS_FAMILY) {
-    'Linux', 'Darwin' => 'libxml,xlswriter,openssl,core,hash,json,standard,SPL,HASH,REFLECTION',
+    'Linux', 'Darwin' => 'libxml,xlswriter,openssl,core,hash,json,standard,SPL,HASH,REFLECTION,zend-opcache',
     'Windows' => 'mbstring,pdo_sqlite,mbregex',
 };
 


### PR DESCRIPTION
This is useful because if your composer.json lists "ext-zend-opcache" (as "ext-opcache" is invalid) and use `composer check-platform-reqs` to select the appropriate extensions, spc will complain that the zend-opcache extension does not exist.

This would also affect the zend-guard and zend-debugger extensions, but they're severely outdated and/or not included in the free available php anyway.