### PR TITLE
Add `prefer-stable` option, `dev:lib-ver` and `dev:ext-ver` commands

### DIFF
--- a/config/pre-built.json
+++ b/config/pre-built.json
@@ -1,0 +1,5 @@
+{
+    "repo": "static-php/static-php-cli-hosted",
+    "match-pattern": "{name}-{arch}-{os}.tgz",
+    "pack-config": {}
+}

--- a/config/source.json
+++ b/config/source.json
@@ -47,6 +47,7 @@
         "type": "ghrel",
         "repo": "curl/curl",
         "match": "curl.+\\.tar\\.xz",
+        "prefer-stable": true,
         "license": {
             "type": "file",
             "path": "COPYING"
@@ -194,6 +195,7 @@
         "type": "ghrel",
         "repo": "unicode-org/icu",
         "match": "icu4c.+-src\\.tgz",
+        "prefer-stable": true,
         "license": {
             "type": "file",
             "path": "LICENSE"
@@ -266,6 +268,7 @@
         "type": "ghrel",
         "repo": "c-ares/c-ares",
         "match": "c-ares-.+\\.tar\\.gz",
+        "prefer-stable": true,
         "alt": {
             "type": "filelist",
             "url": "https://c-ares.org/download/",
@@ -280,6 +283,7 @@
         "type": "ghrel",
         "repo": "libevent/libevent",
         "match": "libevent.+\\.tar\\.gz",
+        "prefer-stable": true,
         "license": {
             "type": "file",
             "path": "LICENSE"
@@ -289,6 +293,7 @@
         "type": "ghrel",
         "repo": "libffi/libffi",
         "match": "libffi.+\\.tar\\.gz",
+        "prefer-stable": true,
         "license": {
             "type": "file",
             "path": "LICENSE"
@@ -333,6 +338,7 @@
         "type": "ghrel",
         "repo": "lz4/lz4",
         "match": "lz4-.+\\.tar\\.gz",
+        "prefer-stable": true,
         "license": {
             "type": "file",
             "path": "LICENSE"
@@ -369,6 +375,7 @@
         "type": "ghrel",
         "repo": "jedisct1/libsodium",
         "match": "libsodium-\\d+(\\.\\d+)*\\.tar\\.gz",
+        "prefer-stable": true,
         "license": {
             "type": "file",
             "path": "LICENSE"
@@ -378,6 +385,7 @@
         "type": "ghrel",
         "repo": "libssh2/libssh2",
         "match": "libssh2.+\\.tar\\.gz",
+        "prefer-stable": true,
         "license": {
             "type": "file",
             "path": "COPYING"
@@ -444,6 +452,7 @@
         "type": "ghrel",
         "repo": "yaml/libyaml",
         "match": "yaml-.+\\.tar\\.gz",
+        "prefer-stable": true,
         "license": {
             "type": "file",
             "path": "License"
@@ -453,6 +462,7 @@
         "type": "ghrel",
         "repo": "nih-at/libzip",
         "match": "libzip.+\\.tar\\.xz",
+        "prefer-stable": true,
         "license": {
             "type": "file",
             "path": "LICENSE"
@@ -483,6 +493,7 @@
         "repo": "mongodb/mongo-php-driver",
         "path": "php-src/ext/mongodb",
         "match": "mongodb.+\\.tgz",
+        "prefer-stable": true,
         "license": {
             "type": "file",
             "path": "LICENSE"
@@ -501,6 +512,7 @@
         "type": "ghrel",
         "repo": "nghttp2/nghttp2",
         "match": "nghttp2.+\\.tar\\.xz",
+        "prefer-stable": true,
         "license": {
             "type": "file",
             "path": "COPYING"
@@ -510,6 +522,7 @@
         "type": "ghrel",
         "repo": "kkos/oniguruma",
         "match": "onig-.+\\.tar\\.gz",
+        "prefer-stable": true,
         "license": {
             "type": "file",
             "path": "COPYING"
@@ -649,6 +662,7 @@
         "type": "ghtar",
         "path": "php-src/ext/swoole",
         "repo": "swoole/swoole-src",
+        "prefer-stable": true,
         "license": {
             "type": "file",
             "path": "LICENSE"
@@ -734,6 +748,7 @@
         "type": "ghrel",
         "repo": "madler/zlib",
         "match": "zlib.+\\.tar\\.gz",
+        "prefer-stable": true,
         "license": {
             "type": "text",
             "text": "(C) 1995-2022 Jean-loup Gailly and Mark Adler\n\nThis software is provided 'as-is', without any express or implied\nwarranty.  In no event will the authors be held liable for any damages\narising from the use of this software.\n\nPermission is granted to anyone to use this software for any purpose,\nincluding commercial applications, and to alter it and redistribute it\nfreely, subject to the following restrictions:\n\n1. The origin of this software must not be misrepresented; you must not\n claim that you wrote the original software. If you use this software\n in a product, an acknowledgment in the product documentation would be\n appreciated but is not required.\n2. Altered source versions must be plainly marked as such, and must not be\n misrepresented as being the original software.\n3. This notice may not be removed or altered from any source distribution.\n\nJean-loup Gailly        Mark Adler\njloup@gzip.org          madler@alumni.caltech.edu"
@@ -743,6 +758,7 @@
         "type": "ghrel",
         "repo": "facebook/zstd",
         "match": "zstd.+\\.tar\\.gz",
+        "prefer-stable": true,
         "license": {
             "type": "file",
             "path": "LICENSE"

--- a/src/SPC/ConsoleApplication.php
+++ b/src/SPC/ConsoleApplication.php
@@ -8,7 +8,9 @@ use SPC\command\BuildCliCommand;
 use SPC\command\BuildLibsCommand;
 use SPC\command\DeleteDownloadCommand;
 use SPC\command\dev\AllExtCommand;
+use SPC\command\dev\ExtVerCommand;
 use SPC\command\dev\GenerateExtDocCommand;
+use SPC\command\dev\LibVerCommand;
 use SPC\command\dev\PhpVerCommand;
 use SPC\command\dev\SortConfigCommand;
 use SPC\command\DoctorCommand;
@@ -48,6 +50,8 @@ final class ConsoleApplication extends Application
                 // Dev commands
                 new AllExtCommand(),
                 new PhpVerCommand(),
+                new LibVerCommand(),
+                new ExtVerCommand(),
                 new SortConfigCommand(),
                 new GenerateExtDocCommand(),
             ]

--- a/src/SPC/builder/BuilderBase.php
+++ b/src/SPC/builder/BuilderBase.php
@@ -161,7 +161,7 @@ abstract class BuilderBase
      * @throws WrongUsageException
      * @internal
      */
-    public function proveExts(array $extensions): void
+    public function proveExts(array $extensions, bool $skip_check_deps = false): void
     {
         CustomExt::loadCustomExt();
         $this->emitPatchPoint('before-php-extract');
@@ -179,6 +179,10 @@ abstract class BuilderBase
             $class = CustomExt::getExtClass($extension);
             $ext = new $class($extension, $this);
             $this->addExt($ext);
+        }
+
+        if ($skip_check_deps) {
+            return;
         }
 
         foreach ($this->exts as $ext) {

--- a/src/SPC/builder/Extension.php
+++ b/src/SPC/builder/Extension.php
@@ -229,6 +229,16 @@ class Extension
     }
 
     /**
+     * Get current extension version
+     *
+     * @return null|string Version string or null
+     */
+    public function getExtVersion(): ?string
+    {
+        return null;
+    }
+
+    /**
      * @throws RuntimeException
      */
     protected function addLibraryDependency(string $name, bool $optional = false): void

--- a/src/SPC/builder/LibraryBase.php
+++ b/src/SPC/builder/LibraryBase.php
@@ -183,6 +183,16 @@ abstract class LibraryBase
     }
 
     /**
+     * Get current lib version
+     *
+     * @return null|string Version string or null
+     */
+    public function getLibVersion(): ?string
+    {
+        return null;
+    }
+
+    /**
      * Get current builder object.
      */
     abstract public function getBuilder(): BuilderBase;

--- a/src/SPC/builder/extension/swoole.php
+++ b/src/SPC/builder/extension/swoole.php
@@ -10,6 +10,18 @@ use SPC\util\CustomExt;
 #[CustomExt('swoole')]
 class swoole extends Extension
 {
+    public function getExtVersion(): ?string
+    {
+        // Get version from source directory
+        $file = SOURCE_PATH . '/php-src/ext/swoole/include/swoole_version.h';
+        // Match #define SWOOLE_VERSION "5.1.3"
+        $pattern = '/#define SWOOLE_VERSION "(.+)"/';
+        if (preg_match($pattern, file_get_contents($file), $matches)) {
+            return $matches[1];
+        }
+        return null;
+    }
+
     public function getUnixConfigureArg(): string
     {
         // enable swoole

--- a/src/SPC/builder/macos/MacOSBuilder.php
+++ b/src/SPC/builder/macos/MacOSBuilder.php
@@ -37,7 +37,7 @@ class MacOSBuilder extends UnixBuilderBase
         $this->arch_c_flags = getenv('SPC_DEFAULT_C_FLAGS');
         $this->arch_cxx_flags = getenv('SPC_DEFAULT_CXX_FLAGS');
         // cmake toolchain
-        $this->cmake_toolchain_file = SystemUtil::makeCmakeToolchainFile('Darwin', $this->getOption('arch'), $this->arch_c_flags);
+        $this->cmake_toolchain_file = SystemUtil::makeCmakeToolchainFile('Darwin', $this->getOption('arch', php_uname('m')), $this->arch_c_flags);
 
         // create pkgconfig and include dir (some libs cannot create them automatically)
         f_mkdir(BUILD_LIB_PATH . '/pkgconfig', recursive: true);

--- a/src/SPC/builder/macos/SystemUtil.php
+++ b/src/SPC/builder/macos/SystemUtil.php
@@ -20,7 +20,7 @@ class SystemUtil
      */
     public static function getCpuCount(): int
     {
-        [$ret, $output] = shell()->execWithResult('sysctl -n hw.ncpu');
+        [$ret, $output] = shell()->execWithResult('sysctl -n hw.ncpu', false);
         if ($ret !== 0) {
             throw new RuntimeException('Failed to get cpu count');
         }

--- a/src/SPC/command/dev/ExtVerCommand.php
+++ b/src/SPC/command/dev/ExtVerCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\command\dev;
+
+use SPC\builder\BuilderProvider;
+use SPC\command\BaseCommand;
+use SPC\store\Config;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand('dev:ext-version', 'Returns version of extension from source directory', ['dev:ext-ver'])]
+class ExtVerCommand extends BaseCommand
+{
+    public function configure()
+    {
+        $this->addArgument('extension', InputArgument::REQUIRED, 'The library name');
+    }
+
+    public function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        $this->no_motd = true;
+        parent::initialize($input, $output);
+    }
+
+    public function handle(): int
+    {
+        // Get lib object
+        $builder = BuilderProvider::makeBuilderByInput($this->input);
+
+        $ext_conf = Config::getExt($this->getArgument('extension'));
+        $builder->proveExts([$this->getArgument('extension')], true);
+
+        // Check whether lib is extracted
+        // if (!is_dir(SOURCE_PATH . '/' . $this->getArgument('library'))) {
+        //     $this->output->writeln("<error>Library {$this->getArgument('library')} is not extracted</error>");
+        //     return static::FAILURE;
+        // }
+
+        $version = $builder->getExt($this->getArgument('extension'))->getExtVersion();
+        if ($version === null) {
+            $this->output->writeln("<error>Failed to get version of extension {$this->getArgument('extension')}</error>");
+            return static::FAILURE;
+        }
+        $this->output->writeln("<info>{$version}</info>");
+        return static::SUCCESS;
+    }
+}

--- a/src/SPC/command/dev/LibVerCommand.php
+++ b/src/SPC/command/dev/LibVerCommand.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\command\dev;
+
+use SPC\builder\BuilderProvider;
+use SPC\command\BaseCommand;
+use SPC\exception\WrongUsageException;
+use SPC\store\Config;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand('dev:lib-version', 'Returns version of library from source directory', ['dev:lib-ver'])]
+class LibVerCommand extends BaseCommand
+{
+    public function configure()
+    {
+        $this->addArgument('library', InputArgument::REQUIRED, 'The library name');
+    }
+
+    public function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        $this->no_motd = true;
+        parent::initialize($input, $output);
+    }
+
+    public function handle(): int
+    {
+        // Get lib object
+        $builder = BuilderProvider::makeBuilderByInput($this->input);
+        $builder->setLibsOnly();
+
+        // check lib name exist in lib.json
+        try {
+            Config::getLib($this->getArgument('library'));
+        } catch (WrongUsageException $e) {
+            $this->output->writeln("<error>Library {$this->getArgument('library')} is not supported yet</error>");
+            return static::FAILURE;
+        }
+
+        $builder->proveLibs([$this->getArgument('library')]);
+
+        // Check whether lib is extracted
+        if (!is_dir(SOURCE_PATH . '/' . $this->getArgument('library'))) {
+            $this->output->writeln("<error>Library {$this->getArgument('library')} is not extracted</error>");
+            return static::FAILURE;
+        }
+
+        $version = $builder->getLib($this->getArgument('library'))->getLibVersion();
+        if ($version === null) {
+            $this->output->writeln("<error>Failed to get version of library {$this->getArgument('library')}</error>");
+            return static::FAILURE;
+        }
+        $this->output->writeln("<info>{$version}</info>");
+        return static::SUCCESS;
+    }
+}

--- a/src/SPC/store/FileSystem.php
+++ b/src/SPC/store/FileSystem.php
@@ -195,7 +195,7 @@ class FileSystem
         }
         try {
             self::extractArchive($filename, $target);
-            self::emitSourceExtractHook($name);
+            self::emitSourceExtractHook($name, $target);
         } catch (RuntimeException $e) {
             if (PHP_OS_FAMILY === 'Windows') {
                 f_passthru('rmdir /s /q ' . $target);
@@ -518,10 +518,10 @@ class FileSystem
         return file_put_contents($filename, $file);
     }
 
-    private static function emitSourceExtractHook(string $name): void
+    private static function emitSourceExtractHook(string $name, string $target): void
     {
         foreach ((self::$_extract_hook[$name] ?? []) as $hook) {
-            if ($hook($name) === true) {
+            if ($hook($name, $target) === true) {
                 logger()->info('Patched source [' . $name . '] after extracted');
             }
         }

--- a/src/SPC/store/SourcePatcher.php
+++ b/src/SPC/store/SourcePatcher.php
@@ -24,6 +24,7 @@ class SourcePatcher
         FileSystem::addSourceExtractHook('sqlsrv', [SourcePatcher::class, 'patchSQLSRVWin32']);
         FileSystem::addSourceExtractHook('pdo_sqlsrv', [SourcePatcher::class, 'patchSQLSRVWin32']);
         FileSystem::addSourceExtractHook('yaml', [SourcePatcher::class, 'patchYamlWin32']);
+        FileSystem::addSourceExtractHook('libyaml', [SourcePatcher::class, 'patchLibYaml']);
     }
 
     /**
@@ -345,6 +346,18 @@ class SourcePatcher
     public static function patchYamlWin32(): bool
     {
         FileSystem::replaceFileStr(SOURCE_PATH . '/php-src/ext/yaml/config.w32', "lib.substr(lib.length - 6, 6) == '_a.lib'", "lib.substr(lib.length - 6, 6) == '_a.lib' || 'yes' == 'yes'");
+        return true;
+    }
+
+    public static function patchLibYaml(string $name, string $target): bool
+    {
+        if (!file_exists("{$target}\\cmake\\config.h.in")) {
+            FileSystem::createDir("{$target}\\cmake");
+            copy(ROOT_DIR . '\src\globals\extra\libyaml_config.h.in', "{$target}\\cmake\\config.h.in");
+        }
+        if (!file_exists("{$target}\\YamlConfig.cmake.in")) {
+            copy(ROOT_DIR . '\src\globals\extra\libyaml_YamlConfig.cmake.in', "{$target}\\YamlConfig.cmake.in");
+        }
         return true;
     }
 


### PR DESCRIPTION
## What does this PR do?

- Add `prefer-stable` option for `ghtar`, `ghrel`, `ghtagtar` type. Fix #486 
- Add `dev:lib-ver` and `dev:ext-ver` commands and `getLibVersion()` for `LibraryBase`,  `getExtVersion()` for `Extension`. Fix #482 

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [X] If it's a extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [x] If you changed the behavior of static-php-cli, add docs in [static-php/static-php-cli-docs](https://github.com/static-php/static-php-cli-docs) .
- [X] If you updated `config/xxxx.json` content, run `bin/spc dev:sort-config xxx`.
