### PR TITLE
fix: xz download

### DIFF
--- a/config/source.json
+++ b/config/source.json
@@ -719,7 +719,7 @@
     "xz": {
         "type": "ghrel",
         "repo": "tukaani-project/xz",
-        "match": "zx.+\\.tar\\.xz",
+        "match": "xz.+\\.tar\\.xz",
         "prefer-stable": true,
         "license": {
             "type": "file",

--- a/config/source.json
+++ b/config/source.json
@@ -717,8 +717,10 @@
         }
     },
     "xz": {
-        "type": "url",
-        "url": "https://fossies.org/linux/misc/xz-5.4.7.tar.xz",
+        "type": "ghrel",
+        "repo": "tukaani-project/xz",
+        "match": "zx.+\\.tar\\.xz",
+        "prefer-stable": true,
         "license": {
             "type": "file",
             "path": "COPYING"


### PR DESCRIPTION
## What does this PR do?

fossies.org seems to have availability issues, and the project recommends using GitHub again now that the security issue has been fixed: https://tukaani.org/xz/#_source_packages

I took the opportunity to upgrade the package.