### PR TITLE
Add libcares support for curl

### DIFF
--- a/config/lib.json
+++ b/config/lib.json
@@ -53,7 +53,8 @@
             "libssh2",
             "brotli",
             "nghttp2",
-            "zstd"
+            "zstd",
+            "libcares"
         ],
         "lib-suggests-windows": [
             "brotli",

--- a/src/SPC/builder/unix/library/curl.php
+++ b/src/SPC/builder/unix/library/curl.php
@@ -47,6 +47,8 @@ trait curl
         $extra .= $this->builder->getLib('idn2') ? '-DUSE_LIBIDN2=ON ' : '-DUSE_LIBIDN2=OFF ';
         // lib:psl
         $extra .= $this->builder->getLib('psl') ? '-DCURL_USE_LIBPSL=ON ' : '-DCURL_USE_LIBPSL=OFF ';
+        // lib:libcares
+        $extra .= $this->builder->getLib('libcares') ? '-DENABLE_ARES=ON ' : '';
 
         FileSystem::resetDir($this->source_dir . '/build');
         // compile！

--- a/src/globals/test-extensions.php
+++ b/src/globals/test-extensions.php
@@ -19,13 +19,13 @@ $upx = true;
 
 // If you want to test your added extensions and libs, add below (comma separated, example `bcmath,openssl`).
 $extensions = match (PHP_OS_FAMILY) {
-    'Linux', 'Darwin' => 'imap,swoole,openssl,rar',
+    'Linux', 'Darwin' => 'curl',
     'Windows' => 'amqp,apcu',
 };
 
 // If you want to test lib-suggests feature with extension, add them below (comma separated, example `libwebp,libavif`).
 $with_libs = match (PHP_OS_FAMILY) {
-    'Linux', 'Darwin' => '',
+    'Linux', 'Darwin' => 'libcares',
     'Windows' => '',
 };
 


### PR DESCRIPTION
## What does this PR do?

Add libcares support for curl, fix #510 

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [X] If it's an extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [ ] If you changed the behavior of static-php-cli, update docs in `./docs/`.
- [X] If you updated `config/xxx.json` content, run `bin/spc dev:sort-config xxx`.
