### PR TITLE
Update redis to 6.0.2, add alternative license file searcher

### DIFF
--- a/config/source.json
+++ b/config/source.json
@@ -649,11 +649,14 @@
     "redis": {
         "type": "git",
         "path": "php-src/ext/redis",
-        "rev": "5.3.7",
+        "rev": "release/6.0.2",
         "url": "https://github.com/phpredis/phpredis",
         "license": {
             "type": "file",
-            "path": "COPYING"
+            "path": [
+                "LICENSE",
+                "COPYING"
+            ]
         }
     },
     "snappy": {

--- a/docs/en/develop/source-module.md
+++ b/docs/en/develop/source-module.md
@@ -317,3 +317,24 @@ When an open source project has multiple licenses, multiple files can be specifi
    }
 }
 ```
+
+When the license of an open source project uses different files between versions, 
+`path` can be used as an array to list the possible license files:
+
+```json
+{
+  "redis": {
+    "type": "git",
+    "path": "php-src/ext/redis",
+    "rev": "release/6.0.2",
+    "url": "https://github.com/phpredis/phpredis",
+    "license": {
+      "type": "file",
+      "path": [
+        "LICENSE",
+        "COPYING"
+      ]
+    }
+  }
+}
+```

--- a/docs/zh/develop/source-module.md
+++ b/docs/zh/develop/source-module.md
@@ -297,3 +297,23 @@ pkg.json 存放的是非源码类型的文件资源，例如 musl-toolchain、UP
   }
 }
 ```
+
+当一个开源项目的许可证在不同版本间使用不同的文件，`path` 参数可以使用数组将可能的许可证文件列出：
+
+```json
+{
+  "redis": {
+    "type": "git",
+    "path": "php-src/ext/redis",
+    "rev": "release/6.0.2",
+    "url": "https://github.com/phpredis/phpredis",
+    "license": {
+      "type": "file",
+      "path": [
+        "LICENSE",
+        "COPYING"
+      ]
+    }
+  }
+}
+```

--- a/src/SPC/ConsoleApplication.php
+++ b/src/SPC/ConsoleApplication.php
@@ -30,7 +30,7 @@ use Symfony\Component\Console\Application;
  */
 final class ConsoleApplication extends Application
 {
-    public const VERSION = '2.3.3';
+    public const VERSION = '2.3.4';
 
     public function __construct()
     {

--- a/src/SPC/util/LicenseDumper.php
+++ b/src/SPC/util/LicenseDumper.php
@@ -118,20 +118,26 @@ class LicenseDumper
     /**
      * @throws RuntimeException
      */
-    private function loadSourceFile(string $source_name, int $index, ?string $in_path, ?string $custom_base_path = null): string
+    private function loadSourceFile(string $source_name, int $index, null|array|string $in_path, ?string $custom_base_path = null): string
     {
         if (is_null($in_path)) {
             throw new RuntimeException('source [' . $source_name . '] license file is not set, please check config/source.json');
         }
 
-        if (file_exists(SOURCE_PATH . '/' . ($custom_base_path ?? $source_name) . '/' . $in_path)) {
-            return file_get_contents(SOURCE_PATH . '/' . ($custom_base_path ?? $source_name) . '/' . $in_path);
+        if (!is_array($in_path)) {
+            $in_path = [$in_path];
+        }
+
+        foreach ($in_path as $item) {
+            if (file_exists(SOURCE_PATH . '/' . ($custom_base_path ?? $source_name) . '/' . $item)) {
+                return file_get_contents(SOURCE_PATH . '/' . ($custom_base_path ?? $source_name) . '/' . $item);
+            }
         }
 
         if (file_exists(BUILD_ROOT_PATH . '/source-licenses/' . $source_name . '/' . $index . '.txt')) {
             return file_get_contents(BUILD_ROOT_PATH . '/source-licenses/' . $source_name . '/' . $index . '.txt');
         }
 
-        throw new RuntimeException('source [' . $source_name . '] license file [' . $in_path . '] not exist');
+        throw new RuntimeException('Cannot find any license file in source [' . $source_name . '] directory!');
     }
 }

--- a/src/globals/test-extensions.php
+++ b/src/globals/test-extensions.php
@@ -19,13 +19,13 @@ $upx = true;
 
 // If you want to test your added extensions and libs, add below (comma separated, example `bcmath,openssl`).
 $extensions = match (PHP_OS_FAMILY) {
-    'Linux', 'Darwin' => 'imap,swoole-hook-sqlite,swoole',
-    'Windows' => 'igbinary,redis,session',
+    'Linux', 'Darwin' => 'redis,igbinary',
+    'Windows' => 'redis,igbinary',
 };
 
 // If you want to test lib-suggests feature with extension, add them below (comma separated, example `libwebp,libavif`).
 $with_libs = match (PHP_OS_FAMILY) {
-    'Linux', 'Darwin' => '',
+    'Linux', 'Darwin' => 'liblz4',
     'Windows' => '',
 };
 


### PR DESCRIPTION
## What does this PR do?

Update redis to 6.0.2, add alternative license file searcher, fixes #538 

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [X] If it's an extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [x] If you changed the behavior of static-php-cli, update docs in `./docs/`.
- [X] If you updated `config/xxx.json` content, run `bin/spc dev:sort-config xxx`.
