### PR TITLE
Add embed sanity check and spc-config command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -199,3 +199,7 @@ jobs:
 
       - name: "Run Build Tests (build)"
         run: php src/globals/test-extensions.php build_cmd ${{ matrix.os }} ${{ matrix.php }}
+
+      - name: "Run Build Tests (build - embed for non-windows)"
+        if: matrix.os != 'windows-latest'
+        run: php src/globals/test-extensions.php build_embed_cmd ${{ matrix.os }} ${{ matrix.php }}

--- a/config/lib.json
+++ b/config/lib.json
@@ -143,7 +143,6 @@
         "source": "grpc",
         "static-libs-unix": [
             "libgrpc.a",
-            "libboringssl.a",
             "libcares.a"
         ],
         "lib-depends": [

--- a/docs/zh/guide/manual-build.md
+++ b/docs/zh/guide/manual-build.md
@@ -493,3 +493,75 @@ static-php-cli 开放的方法非常多，文档中无法一一列举，但只�
 - 如果你想重新构建一次，但不重新下载源码，可以先 `rm -rf buildroot source` 删除编译目录和源码目录，然后重新构建。
 - 如果你想更新某个依赖的版本，可以使用 `bin/spc del-download <source-name>` 删除指定的源码，然后使用 `download <source-name>` 重新下载。
 - 如果你想更新所有依赖的版本，可以使用 `bin/spc download --clean` 删除所有下载的源码，然后重新下载。
+
+## embed 使用
+
+如果你想将 static-php 嵌入到其他 C 语言程序中，可以使用 `--build-embed` 构建一个 embed 版本的 PHP。
+
+```bash
+bin/spc build {your extensions} --build-embed --debug
+```
+
+在通常的情况下，PHP embed 编译后会生成 `php-config`。对于 static-php，我们提供了 `spc-config`，用于获取编译时的参数。
+另外，在使用 embed SAPI（libphp.a）时，你需要使用和编译 libphp 相同的编译器，否则会出现链接错误。
+
+下面是 spc-config 的基本用法：
+
+```bash
+# output all flags and options
+bin/spc spc-config curl,zlib,phar,openssl
+
+# output libs
+bin/spc spc-config curl,zlib,phar,openssl --libs
+
+# output includes
+bin/spc spc-config curl,zlib,phar,openssl --includes
+```
+
+默认情况下，static-php 在不同系统使用的编译器分别是：
+
+- macOS: `clang`
+- Linux (Alpine Linux): `gcc`
+- Linux (glibc based distros, x86_64): `/usr/local/musl/bin/x86_64-linux-musl-gcc`
+- Linux (glibc based distros, aarch64): `/usr/local/musl/bin/aarch64-linux-musl-gcc`
+- FreeBSD: `clang`
+
+下面是一个使用 embed SAPI 的例子：
+
+```c
+// embed.c
+#include <sapi/embed/php_embed.h>
+
+int main(int argc,char **argv){
+
+    PHP_EMBED_START_BLOCK(argc,argv)
+
+    zend_file_handle file_handle;
+
+    zend_stream_init_filename(&file_handle,"embed.php");
+
+    if(php_execute_script(&file_handle) == FAILURE){
+        php_printf("Failed to execute PHP script.\n");
+    }
+
+    PHP_EMBED_END_BLOCK()
+    return 0;
+}
+```
+
+
+```php
+<?php 
+// embed.php
+echo "Hello world!\n";
+```
+
+```bash
+# compile in debian/ubuntu x86_64
+/usr/local/musl/bin/x86_64-linux-musl-gcc embed.c $(bin/spc spc-config bcmath,zlib) -static -o embed
+# compile in macOS/FreeBSD
+clang embed.c $(bin/spc spc-config bcmath,zlib) -o embed
+
+./embed
+# out: Hello world!
+```

--- a/src/SPC/ConsoleApplication.php
+++ b/src/SPC/ConsoleApplication.php
@@ -22,6 +22,7 @@ use SPC\command\DumpLicenseCommand;
 use SPC\command\ExtractCommand;
 use SPC\command\InstallPkgCommand;
 use SPC\command\MicroCombineCommand;
+use SPC\command\SPCConfigCommand;
 use SPC\command\SwitchPhpVersionCommand;
 use Symfony\Component\Console\Application;
 
@@ -30,7 +31,7 @@ use Symfony\Component\Console\Application;
  */
 final class ConsoleApplication extends Application
 {
-    public const VERSION = '2.4.1';
+    public const VERSION = '2.4.2';
 
     public function __construct()
     {
@@ -52,6 +53,7 @@ final class ConsoleApplication extends Application
                 new ExtractCommand(),
                 new MicroCombineCommand(),
                 new SwitchPhpVersionCommand(),
+                new SPCConfigCommand(),
 
                 // Dev commands
                 new AllExtCommand(),

--- a/src/SPC/builder/BuilderBase.php
+++ b/src/SPC/builder/BuilderBase.php
@@ -25,6 +25,12 @@ abstract class BuilderBase
     /** @var array<string, Extension> extensions */
     protected array $exts = [];
 
+    /** @var array<int, string> extension names */
+    protected array $ext_list = [];
+
+    /** @var array<int, string> library names */
+    protected array $lib_list = [];
+
     /** @var bool compile libs only (just mark it) */
     protected bool $libs_only = false;
 
@@ -161,7 +167,7 @@ abstract class BuilderBase
      * @throws FileSystemException
      * @throws RuntimeException
      * @throws \ReflectionException
-     * @throws WrongUsageException
+     * @throws \Throwable|WrongUsageException
      * @internal
      */
     public function proveExts(array $extensions, bool $skip_check_deps = false): void
@@ -191,6 +197,7 @@ abstract class BuilderBase
         foreach ($this->exts as $ext) {
             $ext->checkDependency();
         }
+        $this->ext_list = $extensions;
     }
 
     /**

--- a/src/SPC/builder/extension/pgsql.php
+++ b/src/SPC/builder/extension/pgsql.php
@@ -21,14 +21,6 @@ class pgsql extends Extension
      */
     public function patchBeforeConfigure(): bool
     {
-        if ($this->builder->getPHPVersionID() >= 80400) {
-            FileSystem::replaceFileStr(
-                SOURCE_PATH . '/php-src/configure',
-                'LIBS="-lpq',
-                'LIBS="-lpq -lpgport -lpgcommon -lssl -lcrypto -lz -lm'
-            );
-            return true;
-        }
         FileSystem::replaceFileRegex(
             SOURCE_PATH . '/php-src/configure',
             '/-lpq/',

--- a/src/SPC/builder/unix/library/gettext.php
+++ b/src/SPC/builder/unix/library/gettext.php
@@ -19,6 +19,7 @@ trait gettext
                 '--disable-java ' .
                 '--disable-c+ ' .
                 $extra .
+                '--with-included-gettext ' .
                 '--with-libiconv-prefix=' . BUILD_ROOT_PATH . ' ' .
                 '--prefix=' . BUILD_ROOT_PATH
             )

--- a/src/SPC/builder/windows/WindowsBuilder.php
+++ b/src/SPC/builder/windows/WindowsBuilder.php
@@ -248,6 +248,7 @@ class WindowsBuilder extends BuilderBase
         foreach ($this->libs as $lib) {
             $lib->calcDependency();
         }
+        $this->lib_list = $sorted_libraries;
     }
 
     /**

--- a/src/SPC/command/BuildCliCommand.php
+++ b/src/SPC/command/BuildCliCommand.php
@@ -181,7 +181,9 @@ class BuildCliCommand extends BuildCommand
 
             // compile stopwatch :P
             $time = round(microtime(true) - START_TIME, 3);
-            logger()->info('Build complete, used ' . $time . ' s !');
+            logger()->info('');
+            logger()->info('   Build complete, used ' . $time . ' s !');
+            logger()->info('');
 
             // ---------- When using bin/spc-alpine-docker, the build root path is different from the host system ----------
             $build_root_path = BUILD_ROOT_PATH;

--- a/src/SPC/command/SPCConfigCommand.php
+++ b/src/SPC/command/SPCConfigCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\command;
+
+use SPC\exception\RuntimeException;
+use SPC\util\SPCConfigUtil;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand('spc-config', 'Build dependencies')]
+class SPCConfigCommand extends BuildCommand
+{
+    protected bool $no_motd = true;
+
+    public function configure(): void
+    {
+        $this->addArgument('extensions', InputArgument::OPTIONAL, 'The extensions will be compiled, comma separated');
+        $this->addOption('with-libs', null, InputOption::VALUE_REQUIRED, 'add additional libraries, comma separated', '');
+        $this->addOption('with-suggested-libs', 'L', null, 'Build with suggested libs for selected exts and libs');
+        $this->addOption('with-suggested-exts', 'E', null, 'Build with suggested extensions for selected exts');
+        $this->addOption('includes', null, null, 'Add additional include path');
+        $this->addOption('libs', null, null, 'Add additional libs path');
+    }
+
+    /**
+     * @throws RuntimeException
+     */
+    public function handle(): int
+    {
+        // transform string to array
+        $libraries = array_map('trim', array_filter(explode(',', $this->getOption('with-libs'))));
+        // transform string to array
+        $extensions = $this->getArgument('extensions') ? $this->parseExtensionList($this->getArgument('extensions')) : [];
+        $include_suggest_ext = $this->getOption('with-suggested-exts');
+        $include_suggest_lib = $this->getOption('with-suggested-libs');
+
+        $util = new SPCConfigUtil(null, $this->input);
+        $config = $util->config($extensions, $libraries, $include_suggest_ext, $include_suggest_lib);
+
+        if ($this->getOption('includes')) {
+            $this->output->writeln($config['cflags']);
+        } elseif ($this->getOption('libs')) {
+            $this->output->writeln("{$config['ldflags']} {$config['libs']}");
+        } else {
+            $this->output->writeln("{$config['cflags']} {$config['ldflags']} {$config['libs']}");
+        }
+
+        return 0;
+    }
+}

--- a/src/SPC/util/SPCConfigUtil.php
+++ b/src/SPC/util/SPCConfigUtil.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\util;
+
+use SPC\builder\BuilderBase;
+use SPC\builder\BuilderProvider;
+use SPC\builder\macos\MacOSBuilder;
+use SPC\store\Config;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputInterface;
+
+class SPCConfigUtil
+{
+    public function __construct(private ?BuilderBase $builder = null, ?InputInterface $input = null)
+    {
+        if ($builder === null) {
+            $this->builder = BuilderProvider::makeBuilderByInput($input ?? new ArgvInput());
+        }
+    }
+
+    public function config(array $extensions = [], array $libraries = [], bool $include_suggest_ext = false, bool $include_suggest_lib = false): array
+    {
+        [$extensions, $libraries] = DependencyUtil::getExtsAndLibs($extensions, $libraries, $include_suggest_ext, $include_suggest_lib);
+
+        ob_start();
+        $this->builder->proveLibs($libraries);
+        $this->builder->proveExts($extensions);
+        ob_get_clean();
+        $ldflags = $this->getLdflagsString();
+        $libs = $this->getLibsString($libraries);
+        $cflags = $this->getIncludesString();
+
+        // embed
+        $libs = '-lphp -lc ' . $libs;
+        $extra_env = getenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_LIBS');
+        if (is_string($extra_env)) {
+            $libs .= ' ' . $extra_env;
+        }
+        // c++
+        if ($this->builder->hasCpp()) {
+            $libs .= $this->builder instanceof MacOSBuilder ? ' -lc++' : ' -lstdc++';
+        }
+        return [
+            'cflags' => $cflags,
+            'ldflags' => $ldflags,
+            'libs' => $libs,
+        ];
+    }
+
+    private function getIncludesString(): string
+    {
+        $base = BUILD_INCLUDE_PATH;
+        $php_embed_includes = [
+            "-I{$base}",
+            "-I{$base}/php",
+            "-I{$base}/php/main",
+            "-I{$base}/php/TSRM",
+            "-I{$base}/php/Zend",
+            "-I{$base}/php/ext",
+        ];
+        return implode(' ', $php_embed_includes);
+    }
+
+    private function getLdflagsString(): string
+    {
+        return '-L' . BUILD_LIB_PATH;
+    }
+
+    private function getLibsString(array $libraries): string
+    {
+        $short_name = [];
+        foreach (array_reverse($libraries) as $library) {
+            $libs = Config::getLib($library, 'static-libs', []);
+            foreach ($libs as $lib) {
+                $short_name[] = $this->getShortLibName($lib);
+            }
+            if (PHP_OS_FAMILY !== 'Darwin') {
+                continue;
+            }
+            foreach (Config::getLib($library, 'frameworks', []) as $fw) {
+                $ks = '-framework ' . $fw;
+                if (!in_array($ks, $short_name)) {
+                    $short_name[] = $ks;
+                }
+            }
+        }
+        // patch: imagick (imagemagick wrapper) for linux needs -lgomp
+        if (in_array('imagemagick', $libraries) && PHP_OS_FAMILY === 'Linux') {
+            $short_name[] = '-lgomp';
+        }
+        return implode(' ', $short_name);
+    }
+
+    private function getShortLibName(string $lib): string
+    {
+        if (!str_starts_with($lib, 'lib') || !str_ends_with($lib, '.a')) {
+            return BUILD_LIB_PATH . '/' . $lib;
+        }
+        // get short name
+        return '-l' . substr($lib, 3, -2);
+    }
+}

--- a/src/SPC/util/UnixShell.php
+++ b/src/SPC/util/UnixShell.php
@@ -62,6 +62,9 @@ class UnixShell
             logger()->debug(ConsoleColor::blue('[EXEC] ') . ConsoleColor::gray($cmd));
         }
         logger()->debug('Executed at: ' . debug_backtrace()[0]['file'] . ':' . debug_backtrace()[0]['line']);
+        if ($this->cd !== null) {
+            $cmd = 'cd ' . escapeshellarg($this->cd) . ' && ' . $cmd;
+        }
         exec($cmd, $out, $code);
         return [$code, $out];
     }

--- a/src/globals/common-tests/embed.c
+++ b/src/globals/common-tests/embed.c
@@ -1,0 +1,17 @@
+#include <sapi/embed/php_embed.h>
+
+int main(int argc,char **argv){
+
+    PHP_EMBED_START_BLOCK(argc,argv)
+
+    zend_file_handle file_handle;
+
+    zend_stream_init_filename(&file_handle,"embed.php");
+
+    if(php_execute_script(&file_handle) == FAILURE){
+        php_printf("Failed to execute PHP script.\n");
+    }
+
+    PHP_EMBED_END_BLOCK()
+    return 0;
+}

--- a/src/globals/common-tests/embed.php
+++ b/src/globals/common-tests/embed.php
@@ -1,0 +1,4 @@
+<?php
+
+declare(strict_types=1);
+echo 'hello' . PHP_EOL;

--- a/src/globals/test-extensions.php
+++ b/src/globals/test-extensions.php
@@ -138,6 +138,7 @@ echo match ($argv[1]) {
     'prefer_pre_built' => $prefer_pre_built ? '--prefer-pre-built' : '',
     'download_cmd' => $down_cmd,
     'build_cmd' => $build_cmd,
+    'build_embed_cmd' => $build_cmd,
     default => '',
 };
 

--- a/src/globals/test-extensions.php
+++ b/src/globals/test-extensions.php
@@ -114,7 +114,7 @@ if ($argv[1] === 'download_cmd') {
 }
 
 // generate build command
-if ($argv[1] === 'build_cmd') {
+if ($argv[1] === 'build_cmd' || $argv[1] === 'build_embed_cmd') {
     $build_cmd = 'build ';
     $build_cmd .= quote2($final_extensions) . ' ';
     $build_cmd .= $zts ? '--enable-zts ' : '';


### PR DESCRIPTION
## What does this PR do?

- Add embed sanity check and spc-config command
- Fix #564 
- Fix https://github.com/crazywhalecc/static-php-cli/pull/153#issuecomment-1713959846
- Fix #567

## Example

```bash
# spc-config
bin/spc spc-config apcu,pgsql,openssl,curl --with-libs=nghttp2 --libs

# Output:
# -L/home/jerry/project/static-php-cli/buildroot/lib -lphp -lc -lcurl -lnghttp2 -lpq -lpgport -lpgcommon -lreadline -lncurses -lssl -lcrypto -lxml2 -lz -liconv -lcharset

# Build in embed SAPI
/usr/local/musl/bin/x86_64-linux-musl-gcc path-to-code.c $(bin/spc spc-config $EXTENSIONS) -static -o test
./test
```

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [X] If it's an extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [ ] If you changed the behavior of static-php-cli, update docs in `./docs/`.
- [X] If you updated `config/xxx.json` content, run `bin/spc dev:sort-config xxx`.
