### PR TITLE
Update SQLite to 3.45

### DIFF
--- a/config/source.json
+++ b/config/source.json
@@ -751,7 +751,7 @@
     },
     "sqlite": {
         "type": "url",
-        "url": "https://sqlite.org/2024/sqlite-autoconf-3450200.tar.gz",
+        "url": "https://www.sqlite.org/2024/sqlite-autoconf-3450200.tar.gz",
         "provide-pre-built": true,
         "license": {
             "type": "text",

--- a/config/source.json
+++ b/config/source.json
@@ -69,23 +69,6 @@
             "path": "LICENSE"
         }
     },
-    "librdkafka": {
-        "type": "ghtar",
-        "repo": "confluentinc/librdkafka",
-        "license": {
-            "type": "file",
-            "path": "LICENSE"
-        }
-    },
-    "ext-rdkafka": {
-        "type": "ghtar",
-        "repo": "arnaud-lb/php-rdkafka",
-        "path": "php-src/ext/rdkafka",
-        "license": {
-            "type": "file",
-            "path": "LICENSE"
-        }
-    },
     "ext-event": {
         "type": "url",
         "url": "https://bitbucket.org/osmanov/pecl-event/get/3.0.8.tar.gz",
@@ -140,6 +123,15 @@
         "url": "https://pecl.php.net/get/memcache",
         "path": "php-src/ext/memcache",
         "filename": "memcache.tgz",
+        "license": {
+            "type": "file",
+            "path": "LICENSE"
+        }
+    },
+    "ext-rdkafka": {
+        "type": "ghtar",
+        "repo": "arnaud-lb/php-rdkafka",
+        "path": "php-src/ext/rdkafka",
         "license": {
             "type": "file",
             "path": "LICENSE"
@@ -437,6 +429,14 @@
         "type": "git",
         "url": "https://github.com/alanxz/rabbitmq-c.git",
         "rev": "master",
+        "license": {
+            "type": "file",
+            "path": "LICENSE"
+        }
+    },
+    "librdkafka": {
+        "type": "ghtar",
+        "repo": "confluentinc/librdkafka",
         "license": {
             "type": "file",
             "path": "LICENSE"

--- a/config/source.json
+++ b/config/source.json
@@ -752,7 +752,7 @@
     "sqlite": {
         "type": "url",
         "url": "https://sqlite.org/2024/sqlite-autoconf-3450200.tar.gz",
-        "provide-pre-built": false,
+        "provide-pre-built": true,
         "license": {
             "type": "text",
             "text": "The author disclaims copyright to this source code.  In place of\na legal notice, here is a blessing:\n\n  *   May you do good and not evil.\n  *   May you find forgiveness for yourself and forgive others.\n  *   May you share freely, never taking more than you give."

--- a/config/source.json
+++ b/config/source.json
@@ -751,8 +751,8 @@
     },
     "sqlite": {
         "type": "url",
-        "url": "https://www.sqlite.org/2023/sqlite-autoconf-3430200.tar.gz",
-        "provide-pre-built": true,
+        "url": "https://sqlite.org/2024/sqlite-autoconf-3450200.tar.gz",
+        "provide-pre-built": false,
         "license": {
             "type": "text",
             "text": "The author disclaims copyright to this source code.  In place of\na legal notice, here is a blessing:\n\n  *   May you do good and not evil.\n  *   May you find forgiveness for yourself and forgive others.\n  *   May you share freely, never taking more than you give."


### PR DESCRIPTION
## What does this PR do?

This updates the embedded version of SQLite to 3.45 so that statically built PHP binaries can work with Drupal 11 (see the [minimum system requirements for SQLite](https://www.drupal.org/docs/getting-started/system-requirements/database-server-requirements#s-sqlite)).

I tested the build in a fork and it worked fine for me: https://github.com/phenaproxima/static-php-cli/actions/runs/12320225739. I then manually tested that artifact with Drupal 11, and it was able to install without issues.



## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [x] If it's an extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [x] If you changed the behavior of static-php-cli, update docs in `./docs/`.
- [x] If you updated `config/xxx.json` content, run `bin/spc dev:sort-config xxx`.
