### PR TITLE
Fix openssl missing cert bug for Linux & macOS

### DIFF
--- a/src/SPC/builder/linux/library/openssl.php
+++ b/src/SPC/builder/linux/library/openssl.php
@@ -69,6 +69,7 @@ class openssl extends LinuxLibraryBase
                 "{$env} ./Configure no-shared {$extra} " .
                 '--prefix=/ ' .
                 '--libdir=lib ' .
+                '--openssldir=/etc/ssl ' .
                 '-static ' .
                 "{$zlib_extra}" .
                 'no-legacy ' .

--- a/src/SPC/builder/macos/library/openssl.php
+++ b/src/SPC/builder/macos/library/openssl.php
@@ -54,7 +54,7 @@ class openssl extends MacOSLibraryBase
                 "./Configure no-shared {$extra} " .
                 '--prefix=/ ' . // use prefix=/
                 "--libdir={$lib} " .
-                '--openssldir=/System/Library/OpenSSL ' .
+                '--openssldir=/etc/ssl ' .
                 "darwin64-{$this->builder->getOption('arch')}-cc"
             )
             ->exec('make clean')

--- a/src/globals/ext-tests/openssl.php
+++ b/src/globals/ext-tests/openssl.php
@@ -4,3 +4,4 @@ declare(strict_types=1);
 
 assert(function_exists('openssl_digest'));
 assert(openssl_digest('123456', 'md5') === 'e10adc3949ba59abbe56e057f20f883e');
+assert(file_get_contents('https://example.com/') !== false);

--- a/src/globals/test-extensions.php
+++ b/src/globals/test-extensions.php
@@ -35,12 +35,12 @@ $no_strip = false;
 $upx = false;
 
 // prefer downloading pre-built packages to speed up the build process
-$prefer_pre_built = true;
+$prefer_pre_built = false;
 
 // If you want to test your added extensions and libs, add below (comma separated, example `bcmath,openssl`).
 $extensions = match (PHP_OS_FAMILY) {
-    'Linux', 'Darwin' => 'imagick',
-    'Windows' => 'zlib',
+    'Linux', 'Darwin' => 'openssl',
+    'Windows' => 'openssl',
 };
 
 // If you want to test lib-suggests feature with extension, add them below (comma separated, example `libwebp,libavif`).


### PR DESCRIPTION
## What does this PR do?

Fix openssl missing cert bug for linux and macOS.

Probably fixes: 
- #421 
- #24
- https://github.com/dunglas/frankenphp/issues/582
- https://github.com/dunglas/frankenphp/issues/679
- https://github.com/dunglas/frankenphp/pull/1287
- https://github.com/dunglas/frankenphp/issues/984
- https://github.com/NativePHP/laravel/issues/20
- https://github.com/beyondcode/herd-community/issues/87
- https://github.com/beyondcode/herd-community/discussions/977
- https://frankenphp.dev/docs/known-issues/#troubleshooting-tlsssl-issues-with-static-binaries
- https://static-php.dev/en/faq/#unable-to-use-ssl
- Maybe more...

## Introduction

I recently did some research between static-php and different distributions, maybe it is a better and permanent(maybe) solution to directly specify `--openssldir=/etc/ssl` when static-php builds static openssl.

Doing this will allow PHP to detect and use the same configuration and certificates as many system, and it should be hard to find an OS missing root certificates in 2024.

This path currently works well on common OS such as CentOS, Ubuntu, Debian, Alpine, macOS, etc., and adding it in static-php-cli should solve most OpenSSL cert problems, **including FrankenPHP, Herd, NativePHP**.

This issue has been going on for a long time, and now is the time to solve it once and for all.

cc @dunglas @simonhamp @mpociot 

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [x] If it's an extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [ ] If you changed the behavior of static-php-cli, update docs in `./docs/`.
- [x] If you updated `config/xxx.json` content, run `bin/spc dev:sort-config xxx`.
