### PR TITLE
Add legacy CentOS distro support

### DIFF
--- a/src/SPC/builder/linux/SystemUtil.php
+++ b/src/SPC/builder/linux/SystemUtil.php
@@ -21,13 +21,16 @@ class SystemUtil
         switch (true) {
             case file_exists('/etc/centos-release'):
                 $lines = file('/etc/centos-release');
+                $centos = true;
                 goto rh;
             case file_exists('/etc/redhat-release'):
                 $lines = file('/etc/redhat-release');
+                $centos = false;
                 rh:
                 foreach ($lines as $line) {
                     if (preg_match('/release\s+(\d*(\.\d+)*)/', $line, $matches)) {
-                        $ret['dist'] = 'redhat';
+                        /* @phpstan-ignore-next-line */
+                        $ret['dist'] = $centos ? 'centos' : 'redhat';
                         $ret['ver'] = $matches[1];
                     }
                 }
@@ -171,6 +174,8 @@ class SystemUtil
             'debian', 'ubuntu', 'Deepin',
             // rhel-like
             'redhat',
+            // centos
+            'centos',
             // alpine
             'alpine',
             // arch

--- a/src/SPC/doctor/item/LinuxToolCheckList.php
+++ b/src/SPC/doctor/item/LinuxToolCheckList.php
@@ -57,7 +57,7 @@ class LinuxToolCheckList
 
         $required = match ($distro['dist']) {
             'alpine' => self::TOOLS_ALPINE,
-            'redhat' => self::TOOLS_RHEL,
+            'redhat', 'centos' => self::TOOLS_RHEL,
             'arch' => self::TOOLS_ARCH,
             default => self::TOOLS_DEBIAN,
         };
@@ -72,6 +72,7 @@ class LinuxToolCheckList
                 'ubuntu',
                 'alpine',
                 'redhat',
+                'centos',
                 'Deepin',
                 'arch',
                 'debian' => CheckResult::fail(implode(', ', $missing) . ' not installed on your system', 'install-linux-tools', [$distro, $missing]),
@@ -121,13 +122,14 @@ class LinuxToolCheckList
             'ubuntu', 'debian', 'Deepin' => 'apt-get install -y',
             'alpine' => 'apk add',
             'redhat' => 'dnf install -y',
+            'centos' => 'yum install -y',
             'arch' => 'pacman -S --noconfirm',
             default => throw new RuntimeException('Current linux distro does not have an auto-install script for musl packages yet.'),
         };
         $prefix = '';
-        if (get_current_user() !== 'root') {
+        if (($user = exec('whoami')) !== 'root') {
             $prefix = 'sudo ';
-            logger()->warning('Current user is not root, using sudo for running command');
+            logger()->warning('Current user (' . $user . ') is not root, using sudo for running command');
         }
         try {
             $is_debian = in_array($distro['dist'], ['debian', 'ubuntu', 'Deepin']);


### PR DESCRIPTION
## What does this PR do?

Add legacy CentOS distro support, especially for CentOS 7.x.

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [ ] If it's an extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [ ] If you changed the behavior of static-php-cli, update docs in `./docs/`.
- [ ] If you updated `config/xxx.json` content, run `bin/spc dev:sort-config xxx`.
