### PR TITLE
add opentelemetry extension support

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,3 +335,10 @@ and they all have their own open source licenses.
 
 Please use the `bin/spc dump-license` command to export the open source licenses used in the project after compilation,
 and comply with the corresponding project's LICENSE.
+
+## Troubleshooting
+
+When downloading extensions, you may eventually see errors like `curl: (56) The requested URL returned error: 403` which are often caused by github rate limiting.
+You can verify this by adding `--debug` to the command and will see something like `[DEBU] Running command (no output) : curl -sfSL   "https://api.github.com/repos/openssl/openssl/releases"`.
+
+To fix this, [create](https://github.com/settings/tokens) a personal access token on GitHub and set it as an environment variable `GITHUB_TOKEN=<XXX>`.

--- a/README.md
+++ b/README.md
@@ -335,10 +335,3 @@ and they all have their own open source licenses.
 
 Please use the `bin/spc dump-license` command to export the open source licenses used in the project after compilation,
 and comply with the corresponding project's LICENSE.
-
-## Troubleshooting
-
-When downloading extensions, you may eventually see errors like `curl: (56) The requested URL returned error: 403` which are often caused by github rate limiting.
-You can verify this by adding `--debug` to the command and will see something like `[DEBU] Running command (no output) : curl -sfSL   "https://api.github.com/repos/openssl/openssl/releases"`.
-
-To fix this, [create](https://github.com/settings/tokens) a personal access token on GitHub and set it as an environment variable `GITHUB_TOKEN=<XXX>`.

--- a/config/ext.json
+++ b/config/ext.json
@@ -432,6 +432,21 @@
         "type": "builtin",
         "arg-type-unix": "custom"
     },
+    "opentelemetry": {
+        "notes": true,
+        "support": {
+            "Windows": "wip"
+        },
+        "arg-type": "enable",
+        "source": "opentelemetry",
+        "unix-only": true,
+        "ext-suggests": [
+            "grpc",
+            "protobuf",
+            "ffi"
+        ],
+        "type": "external"
+    },
     "openssl": {
         "notes": true,
         "type": "builtin",

--- a/config/ext.json
+++ b/config/ext.json
@@ -450,7 +450,6 @@
         "support": {
             "Windows": "wip"
         },
-        "arg-type": "enable",
         "source": "opentelemetry",
         "unix-only": true,
         "ext-suggests": [

--- a/config/ext.json
+++ b/config/ext.json
@@ -446,18 +446,11 @@
         ]
     },
     "opentelemetry": {
-        "notes": true,
         "support": {
-            "Windows": "wip"
+            "BSD": "wip"
         },
-        "source": "opentelemetry",
-        "unix-only": true,
-        "ext-suggests": [
-            "grpc",
-            "protobuf",
-            "ffi"
-        ],
-        "type": "external"
+        "type": "external",
+        "source": "opentelemetry"
     },
     "parallel": {
         "support": {

--- a/config/ext.json
+++ b/config/ext.json
@@ -432,6 +432,19 @@
         "type": "builtin",
         "arg-type-unix": "custom"
     },
+    "openssl": {
+        "notes": true,
+        "type": "builtin",
+        "arg-type": "custom",
+        "arg-type-windows": "with",
+        "lib-depends": [
+            "openssl",
+            "zlib"
+        ],
+        "ext-depends": [
+            "zlib"
+        ]
+    },
     "opentelemetry": {
         "notes": true,
         "support": {
@@ -446,19 +459,6 @@
             "ffi"
         ],
         "type": "external"
-    },
-    "openssl": {
-        "notes": true,
-        "type": "builtin",
-        "arg-type": "custom",
-        "arg-type-windows": "with",
-        "lib-depends": [
-            "openssl",
-            "zlib"
-        ],
-        "ext-depends": [
-            "zlib"
-        ]
     },
     "parallel": {
         "support": {

--- a/config/source.json
+++ b/config/source.json
@@ -667,6 +667,16 @@
             "path": "COPYING"
         }
     },
+    "opentelemetry": {
+        "type": "url",
+        "url": "https://pecl.php.net/get/opentelemetry",
+        "path": "php-src/ext/opentelemetry",
+        "filename": "opentelemetry.tgz",
+        "license": {
+            "type": "file",
+            "path": "LICENSE"
+        }
+    },
     "openssl": {
         "type": "ghrel",
         "repo": "openssl/openssl",

--- a/config/source.json
+++ b/config/source.json
@@ -667,16 +667,6 @@
             "path": "COPYING"
         }
     },
-    "opentelemetry": {
-        "type": "url",
-        "url": "https://pecl.php.net/get/opentelemetry",
-        "path": "php-src/ext/opentelemetry",
-        "filename": "opentelemetry.tgz",
-        "license": {
-            "type": "file",
-            "path": "LICENSE"
-        }
-    },
     "openssl": {
         "type": "ghrel",
         "repo": "openssl/openssl",
@@ -691,6 +681,16 @@
         "license": {
             "type": "file",
             "path": "LICENSE.txt"
+        }
+    },
+    "opentelemetry": {
+        "type": "url",
+        "url": "https://pecl.php.net/get/opentelemetry",
+        "path": "php-src/ext/opentelemetry",
+        "filename": "opentelemetry.tgz",
+        "license": {
+            "type": "file",
+            "path": "LICENSE"
         }
     },
     "parallel": {

--- a/docs/en/guide/troubleshooting.md
+++ b/docs/en/guide/troubleshooting.md
@@ -8,8 +8,15 @@ here will describe how to check the errors by yourself and report Issue.
 Problems with downloading resources are one of the most common problems with spc. 
 The main reason is that the addresses used for SPC download resources are generally the official website of the corresponding project or GitHub, etc.,
 and these websites may occasionally go down and block IP addresses.
-Currently, version 2.0.0 has not added an automatic retry mechanism, so after encountering a download failure, 
-you can try to call the download command multiple times. If you confirm that the address is indeed inaccessible, 
+After encountering a download failure, 
+you can try to call the download command multiple times. 
+
+When downloading extensions, you may eventually see errors like `curl: (56) The requested URL returned error: 403` which are often caused by github rate limiting.
+You can verify this by adding `--debug` to the command and will see something like `[DEBU] Running command (no output) : curl -sfSL   "https://api.github.com/repos/openssl/openssl/releases"`.
+
+To fix this, [create](https://github.com/settings/tokens) a personal access token on GitHub and set it as an environment variable `GITHUB_TOKEN=<XXX>`.
+
+If you confirm that the address is indeed inaccessible, 
 you can submit an Issue or PR to update the url or download type.
 
 ## Doctor Can't Fix Something

--- a/docs/zh/guide/troubleshooting.md
+++ b/docs/zh/guide/troubleshooting.md
@@ -5,7 +5,14 @@
 ## 下载失败问题
 
 下载资源问题是 spc 最常见的问题之一。主要是由于 spc 下载资源使用的地址一般均为对应项目的官方网站或 GitHub 等，而这些网站可能偶尔会宕机、屏蔽 IP 地址。
-目前 2.0.0 版本还没有加入自动重试机制，所以在遇到下载失败后，可以多次尝试调用下载命令。如果确认地址确实无法正常访问，可以提交 Issue 或 PR 更新地址。
+在遇到下载失败后，可以多次尝试调用下载命令。
+
+当下载资源时，你可能最终会看到类似 `curl: (56) The requested URL returned error: 403` 的错误，这通常是由于 GitHub 限制导致的。
+你可以通过在命令中添加 `--debug` 来验证，会看到类似 `[DEBU] Running command (no output) : curl -sfSL   "https://api.github.com/repos/openssl/openssl/releases"` 的输出。
+
+要解决这个问题，可以在 GitHub 上 [创建](https://github.com/settings/token) 一个个人访问令牌，并将其设置为环境变量 `GITHUB_TOKEN=<XXX>`。
+
+如果确认地址确实无法正常访问，可以提交 Issue 或 PR 更新地址。
 
 ## doctor 无法修复
 

--- a/src/SPC/builder/extension/opentelemetry.php
+++ b/src/SPC/builder/extension/opentelemetry.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\extension;
+
+use SPC\builder\Extension;
+use SPC\builder\windows\WindowsBuilder;
+use SPC\util\CustomExt;
+use SPC\util\GlobalEnvManager;
+
+#[CustomExt('opentelemetry')]
+class opentelemetry extends Extension
+{
+    public function validate(): void
+    {
+        if ($this->builder->getPHPVersionID() < 80000 && getenv('SPC_SKIP_PHP_VERSION_CHECK') !== 'yes') {
+            throw new \RuntimeException('The opentelemetry extension requires PHP 8.0 or later');
+        }
+    }
+
+    public function patchBeforeBuildconf(): bool
+    {
+        // soft link to the grpc source code
+        if ($this->builder instanceof WindowsBuilder) {
+            // not support windows yet
+            throw new \RuntimeException('opentelemetry extension does not support windows yet');
+        }
+        return false;
+    }
+
+    public function patchBeforeMake(): bool
+    {
+        // add -Wno-strict-prototypes
+        GlobalEnvManager::putenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_CFLAGS=' . getenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_CFLAGS') . ' -Wno-strict-prototypes');
+        return true;
+    }
+
+    public function getUnixConfigureArg(): string
+    {
+        return '--enable-opentelemetry=' . BUILD_ROOT_PATH . '/opentelemetry GRPC_LIB_SUBDIR=' . BUILD_LIB_PATH;
+    }
+}

--- a/src/SPC/builder/extension/opentelemetry.php
+++ b/src/SPC/builder/extension/opentelemetry.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SPC\builder\extension;
 
 use SPC\builder\Extension;
+use SPC\store\FileSystem;
 use SPC\util\CustomExt;
 use SPC\util\GlobalEnvManager;
 
@@ -16,6 +17,19 @@ class opentelemetry extends Extension
         if ($this->builder->getPHPVersionID() < 80000 && getenv('SPC_SKIP_PHP_VERSION_CHECK') !== 'yes') {
             throw new \RuntimeException('The opentelemetry extension requires PHP 8.0 or later');
         }
+    }
+
+    public function patchBeforeBuildconf(): bool
+    {
+        if (PHP_OS_FAMILY === 'Windows') {
+            FileSystem::replaceFileStr(
+                SOURCE_PATH . '/php-src/ext/opentelemetry/config.w32',
+                "EXTENSION('opentelemetry', 'opentelemetry.c otel_observer.c', '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');",
+                "EXTENSION('opentelemetry', 'opentelemetry.c otel_observer.c', PHP_OPENTELEMETRY_SHARED, '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');"
+            );
+            return true;
+        }
+        return false;
     }
 
     public function patchBeforeMake(): bool

--- a/src/SPC/builder/extension/opentelemetry.php
+++ b/src/SPC/builder/extension/opentelemetry.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace SPC\builder\extension;
 
 use SPC\builder\Extension;
-use SPC\builder\windows\WindowsBuilder;
 use SPC\util\CustomExt;
 use SPC\util\GlobalEnvManager;
 
@@ -17,16 +16,10 @@ class opentelemetry extends Extension
         if ($this->builder->getPHPVersionID() < 80000 && getenv('SPC_SKIP_PHP_VERSION_CHECK') !== 'yes') {
             throw new \RuntimeException('The opentelemetry extension requires PHP 8.0 or later');
         }
-    }
 
-    public function patchBeforeBuildconf(): bool
-    {
-        // soft link to the grpc source code
-        if ($this->builder instanceof WindowsBuilder) {
-            // not support windows yet
+        if (PHP_OS_FAMILY === 'Windows') {
             throw new \RuntimeException('opentelemetry extension does not support windows yet');
         }
-        return false;
     }
 
     public function patchBeforeMake(): bool
@@ -34,10 +27,5 @@ class opentelemetry extends Extension
         // add -Wno-strict-prototypes
         GlobalEnvManager::putenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_CFLAGS=' . getenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_CFLAGS') . ' -Wno-strict-prototypes');
         return true;
-    }
-
-    public function getUnixConfigureArg(): string
-    {
-        return '--enable-opentelemetry=' . BUILD_ROOT_PATH . '/opentelemetry';
     }
 }

--- a/src/SPC/builder/extension/opentelemetry.php
+++ b/src/SPC/builder/extension/opentelemetry.php
@@ -38,6 +38,6 @@ class opentelemetry extends Extension
 
     public function getUnixConfigureArg(): string
     {
-        return '--enable-opentelemetry=' . BUILD_ROOT_PATH . '/opentelemetry GRPC_LIB_SUBDIR=' . BUILD_LIB_PATH;
+        return '--enable-opentelemetry=' . BUILD_ROOT_PATH . '/opentelemetry';
     }
 }

--- a/src/SPC/builder/extension/opentelemetry.php
+++ b/src/SPC/builder/extension/opentelemetry.php
@@ -16,10 +16,6 @@ class opentelemetry extends Extension
         if ($this->builder->getPHPVersionID() < 80000 && getenv('SPC_SKIP_PHP_VERSION_CHECK') !== 'yes') {
             throw new \RuntimeException('The opentelemetry extension requires PHP 8.0 or later');
         }
-
-        if (PHP_OS_FAMILY === 'Windows') {
-            throw new \RuntimeException('opentelemetry extension does not support windows yet');
-        }
     }
 
     public function patchBeforeMake(): bool

--- a/src/globals/ext-tests/opentelemetry.php
+++ b/src/globals/ext-tests/opentelemetry.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+assert(function_exists('OpenTelemetry\Instrumentation\hook'));

--- a/src/globals/test-extensions.php
+++ b/src/globals/test-extensions.php
@@ -13,17 +13,18 @@ declare(strict_types=1);
 
 // test php version
 $test_php_version = [
-    // '8.1',
-    // '8.2',
-    // '8.3',
+    '8.1',
+    '8.2',
+    '8.3',
     '8.4',
 ];
 
 // test os (macos-13, macos-14, ubuntu-latest, windows-latest are available)
 $test_os = [
+    'macos-13',
     'macos-14',
     'ubuntu-latest',
-    // 'windows-latest',
+    'windows-latest',
 ];
 
 // whether enable thread safe
@@ -39,8 +40,8 @@ $prefer_pre_built = true;
 
 // If you want to test your added extensions and libs, add below (comma separated, example `bcmath,openssl`).
 $extensions = match (PHP_OS_FAMILY) {
-    'Linux', 'Darwin' => 'dio',
-    'Windows' => 'dio',
+    'Linux', 'Darwin' => 'opentelemetry',
+    'Windows' => 'opentelemetry',
 };
 
 // If you want to test lib-suggests feature with extension, add them below (comma separated, example `libwebp,libavif`).


### PR DESCRIPTION
## What does this PR do?

Add Support for opentelemetry instrumentation in PHP > 8

## Checklist before merging
- [X] If you updated `config/xxx.json` content, run `bin/spc dev:sort-config xxx`.
