### PR TITLE
Work around #597 by acknowledging that winbuild is deprecated

### DIFF
--- a/src/SPC/builder/windows/library/curl.php
+++ b/src/SPC/builder/windows/library/curl.php
@@ -18,7 +18,8 @@ class curl extends WindowsLibraryBase
                 $this->builder->makeSimpleWrapper('nmake'),
                 '/f Makefile.vc WITH_DEVEL=' . BUILD_ROOT_PATH . ' ' .
                 'WITH_PREFIX=' . BUILD_ROOT_PATH . ' ' .
-                'mode=static RTLIBCFG=static WITH_SSL=static WITH_NGHTTP2=static WITH_SSH2=static ENABLE_IPV6=yes WITH_ZLIB=static MACHINE=x64 DEBUG=no'
+                'mode=static RTLIBCFG=static WITH_SSL=static WITH_NGHTTP2=static WITH_SSH2=static ENABLE_IPV6=yes WITH_ZLIB=static MACHINE=x64 DEBUG=no' . ' ' .
+                'WINBUILD_ACKNOWLEDGE_DEPRECATED=yes'
             );
         FileSystem::copyDir($this->source_dir . '\include\curl', BUILD_INCLUDE_PATH . '\curl');
     }

--- a/src/SPC/builder/windows/library/curl.php
+++ b/src/SPC/builder/windows/library/curl.php
@@ -18,8 +18,7 @@ class curl extends WindowsLibraryBase
                 $this->builder->makeSimpleWrapper('nmake'),
                 '/f Makefile.vc WITH_DEVEL=' . BUILD_ROOT_PATH . ' ' .
                 'WITH_PREFIX=' . BUILD_ROOT_PATH . ' ' .
-                'mode=static RTLIBCFG=static WITH_SSL=static WITH_NGHTTP2=static WITH_SSH2=static ENABLE_IPV6=yes WITH_ZLIB=static MACHINE=x64 DEBUG=no' . ' ' .
-                'WINBUILD_ACKNOWLEDGE_DEPRECATED=yes'
+                'mode=static RTLIBCFG=static WITH_SSL=static WITH_NGHTTP2=static WITH_SSH2=static ENABLE_IPV6=yes WITH_ZLIB=static MACHINE=x64 DEBUG=no WINBUILD_ACKNOWLEDGE_DEPRECATED=yes'
             );
         FileSystem::copyDir($this->source_dir . '\include\curl', BUILD_INCLUDE_PATH . '\curl');
     }


### PR DESCRIPTION
## What does this PR do?

It is a short-term workaround for #597. According to the error message detailed in that issue, you can use winbuild anyway if you pass `WINBUILD_ACKNOWLEDGE_DEPRECATED=yes`. So that's what this does.



## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [ ] If it's an extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [ ] If you changed the behavior of static-php-cli, update docs in `./docs/`.
- [ ] If you updated `config/xxx.json` content, run `bin/spc dev:sort-config xxx`.
