### PR TITLE
Report why the sanity check for the cli target failed

### DIFF
--- a/src/SPC/builder/unix/UnixBuilderBase.php
+++ b/src/SPC/builder/unix/UnixBuilderBase.php
@@ -143,8 +143,9 @@ abstract class UnixBuilderBase extends BuilderBase
         if (($build_target & BUILD_TARGET_CLI) === BUILD_TARGET_CLI) {
             logger()->info('running cli sanity check');
             [$ret, $output] = shell()->execWithResult(BUILD_ROOT_PATH . '/bin/php -r "echo \"hello\";"');
-            if ($ret !== 0 || trim(implode('', $output)) !== 'hello') {
-                throw new RuntimeException('cli failed sanity check');
+            $raw_output = implode('', $output);
+            if ($ret !== 0 || trim($raw_output) !== 'hello') {
+                throw new RuntimeException("cli failed sanity check: ret[{$ret}]. out[{$raw_output}]");
             }
 
             foreach ($this->exts as $ext) {


### PR DESCRIPTION
## What does this PR do?

Extends the exception thrown when the sanity check for the cli target fails by adding the return code and output generated by the PHP binary (fixes #604).

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [ ] If it's an extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [ ] If you changed the behavior of static-php-cli, update docs in `./docs/`.
- [ ] If you updated `config/xxx.json` content, run `bin/spc dev:sort-config xxx`.
