### PR TITLE
fix SPC_NO_MUSL_PATH not working in .env.ini

### DIFF
--- a/src/SPC/builder/linux/LinuxBuilder.php
+++ b/src/SPC/builder/linux/LinuxBuilder.php
@@ -29,11 +29,13 @@ class LinuxBuilder extends UnixBuilderBase
         // check musl-cross make installed if we use musl-cross-make
         $arch = arch2gnu(php_uname('m'));
 
-        // set library path, some libraries need it. (We cannot use `putenv` here, because cmake will be confused)
-        $this->setOptionIfNotExist('library_path', "LIBRARY_PATH=/usr/local/musl/{$arch}-linux-musl/lib");
-        $this->setOptionIfNotExist('ld_library_path', "LD_LIBRARY_PATH=/usr/local/musl/{$arch}-linux-musl/lib");
-
         GlobalEnvManager::init($this);
+
+        // set library path, some libraries need it. (We cannot use `putenv` here, because cmake will be confused)
+        if (getenv('SPC_NO_MUSL_PATH') !== '1') {
+            $this->setOptionIfNotExist('library_path', 'LIBRARY_PATH=/usr/local/musl/lib');
+            $this->setOptionIfNotExist('ld_library_path', 'LD_LIBRARY_PATH=/usr/local/musl/lib');
+        }
 
         if (str_ends_with(getenv('CC'), 'linux-musl-gcc') && !file_exists("/usr/local/musl/bin/{$arch}-linux-musl-gcc") && (getenv('SPC_NO_MUSL_PATH') !== 'yes')) {
             throw new WrongUsageException('musl-cross-make not installed, please install it first. (You can use `doctor` command to install it)');

--- a/src/SPC/util/GlobalEnvManager.php
+++ b/src/SPC/util/GlobalEnvManager.php
@@ -57,10 +57,6 @@ class GlobalEnvManager
                 self::putenv("SPC_LINUX_DEFAULT_CXX={$arch}-linux-musl-g++");
                 self::putenv("SPC_LINUX_DEFAULT_AR={$arch}-linux-musl-ar");
             }
-            self::putenv("SPC_PHP_DEFAULT_LD_LIBRARY_PATH_CMD=LD_LIBRARY_PATH=/usr/local/musl/{$arch}-linux-musl/lib");
-            if (getenv('SPC_NO_MUSL_PATH') !== 'yes') {
-                self::putenv("PATH=/usr/local/musl/bin:/usr/local/musl/{$arch}-linux-musl/bin:" . getenv('PATH'));
-            }
         }
 
         // Init env.ini file, read order:
@@ -91,6 +87,11 @@ class GlobalEnvManager
             'BSD' => self::applyConfig($ini['freebsd']),
             default => null,
         };
+
+        if (PHP_OS_FAMILY === 'Linux' && getenv('SPC_NO_MUSL_PATH') !== '1') {
+            self::putenv("SPC_PHP_DEFAULT_LD_LIBRARY_PATH_CMD=LD_LIBRARY_PATH=/usr/local/musl/{$arch}-linux-musl/lib");
+            self::putenv("PATH=/usr/local/musl/bin:/usr/local/musl/{$arch}-linux-musl/bin:" . getenv('PATH'));
+        }
     }
 
     public static function putenv(string $val): void


### PR DESCRIPTION
## What does this PR do?
prior to this patch, setting SPC_NO_MUSL_PATH has to be defined in the environment. setting it in .env.ini had no effect.

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [] If it's an extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [ ] If you changed the behavior of static-php-cli, update docs in `./docs/`.
- [ ] If you updated `config/xxx.json` content, run `bin/spc dev:sort-config xxx`.
