### PR TITLE
Add php and lib-base as special libraries to add dependencies to the root node

### DIFF
--- a/config/lib.json
+++ b/config/lib.json
@@ -1,4 +1,29 @@
 {
+    "lib-base": {
+        "type": "root",
+        "lib-depends-unix": [
+            "pkg-config"
+        ]
+    },
+    "php": {
+        "type": "root",
+        "source": "php-src",
+        "lib-depends": [
+            "micro",
+            "lib-base"
+        ]
+    },
+    "micro": {
+        "type": "target",
+        "source": "micro"
+    },
+    "pkg-config": {
+        "type": "package",
+        "source": "pkg-config",
+        "bin-unix": [
+            "pkg-config"
+        ]
+    },
     "brotli": {
         "source": "brotli",
         "static-libs-unix": [
@@ -598,9 +623,6 @@
         "lib-depends": [
             "zlib"
         ]
-    },
-    "pkg-config": {
-        "source": "pkg-config"
     },
     "postgresql": {
         "source": "postgresql",

--- a/src/SPC/builder/unix/UnixBuilderBase.php
+++ b/src/SPC/builder/unix/UnixBuilderBase.php
@@ -110,13 +110,11 @@ abstract class UnixBuilderBase extends BuilderBase
             $sorted_libraries = DependencyUtil::getLibs($libraries);
         }
 
-        // pkg-config must be compiled first, whether it is specified or not
-        if (!in_array('pkg-config', $sorted_libraries)) {
-            array_unshift($sorted_libraries, 'pkg-config');
-        }
-
         // add lib object for builder
         foreach ($sorted_libraries as $library) {
+            if (!in_array(Config::getLib($library, 'type', 'lib'), ['lib', 'package'])) {
+                continue;
+            }
             // if some libs are not supported (but in config "lib.json", throw exception)
             if (!isset($support_lib_list[$library])) {
                 throw new WrongUsageException('library [' . $library . '] is in the lib.json list but not supported to compile, but in the future I will support it!');

--- a/src/SPC/builder/windows/WindowsBuilder.php
+++ b/src/SPC/builder/windows/WindowsBuilder.php
@@ -236,6 +236,9 @@ class WindowsBuilder extends BuilderBase
 
         // add lib object for builder
         foreach ($sorted_libraries as $library) {
+            if (!in_array(Config::getLib($library, 'type', 'lib'), ['lib', 'package'])) {
+                continue;
+            }
             // if some libs are not supported (but in config "lib.json", throw exception)
             if (!isset($support_lib_list[$library])) {
                 throw new WrongUsageException('library [' . $library . '] is in the lib.json list but not supported to compile, but in the future I will support it!');

--- a/src/SPC/command/BaseCommand.php
+++ b/src/SPC/command/BaseCommand.php
@@ -46,7 +46,6 @@ abstract class BaseCommand extends Command
                 E_USER_ERROR => ['PHP Error: ', 'error'],
                 E_USER_WARNING => ['PHP Warning: ', 'warning'],
                 E_USER_NOTICE => ['PHP Notice: ', 'notice'],
-                E_STRICT => ['PHP Strict: ', 'notice'],
                 E_RECOVERABLE_ERROR => ['PHP Recoverable Error: ', 'error'],
                 E_DEPRECATED => ['PHP Deprecated: ', 'notice'],
                 E_USER_DEPRECATED => ['PHP User Deprecated: ', 'notice'],
@@ -56,7 +55,7 @@ abstract class BaseCommand extends Command
             logger()->{$level_tip[1]}($error);
             // 如果 return false 则错误会继续递交给 PHP 标准错误处理
             return true;
-        }, E_ALL | E_STRICT);
+        });
         $version = ConsoleApplication::VERSION;
         if (!$this->no_motd) {
             echo "     _        _   _                 _           

--- a/src/SPC/command/BuildCliCommand.php
+++ b/src/SPC/command/BuildCliCommand.php
@@ -7,6 +7,7 @@ namespace SPC\command;
 use SPC\builder\BuilderProvider;
 use SPC\exception\ExceptionHandler;
 use SPC\exception\WrongUsageException;
+use SPC\store\Config;
 use SPC\store\FileSystem;
 use SPC\store\SourcePatcher;
 use SPC\util\DependencyUtil;
@@ -107,13 +108,14 @@ class BuildCliCommand extends BuildCommand
             $include_suggest_ext = $this->getOption('with-suggested-exts');
             $include_suggest_lib = $this->getOption('with-suggested-libs');
             [$extensions, $libraries, $not_included] = DependencyUtil::getExtsAndLibs($extensions, $libraries, $include_suggest_ext, $include_suggest_lib);
+            $display_libs = array_filter($libraries, fn ($lib) => in_array(Config::getLib($lib, 'type', 'lib'), ['lib', 'package']));
 
             // print info
             $indent_texts = [
                 'Build OS' => PHP_OS_FAMILY . ' (' . php_uname('m') . ')',
                 'Build SAPI' => $builder->getBuildTypeName($rule),
                 'Extensions (' . count($extensions) . ')' => implode(',', $extensions),
-                'Libraries (' . count($libraries) . ')' => implode(',', $libraries),
+                'Libraries (' . count($libraries) . ')' => implode(',', $display_libs),
                 'Strip Binaries' => $builder->getOption('no-strip') ? 'no' : 'yes',
                 'Enable ZTS' => $builder->getOption('enable-zts') ? 'yes' : 'no',
             ];

--- a/src/SPC/command/BuildLibsCommand.php
+++ b/src/SPC/command/BuildLibsCommand.php
@@ -7,6 +7,7 @@ namespace SPC\command;
 use SPC\builder\BuilderProvider;
 use SPC\exception\ExceptionHandler;
 use SPC\exception\RuntimeException;
+use SPC\store\Config;
 use SPC\util\DependencyUtil;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -61,7 +62,9 @@ class BuildLibsCommand extends BuildCommand
             $builder->setLibsOnly();
             // 编译和检查库完整
             $libraries = DependencyUtil::getLibs($libraries);
-            logger()->info('Building libraries: ' . implode(',', $libraries));
+            $display_libs = array_filter($libraries, fn ($lib) => in_array(Config::getLib($lib, 'type', 'lib'), ['lib', 'package']));
+
+            logger()->info('Building libraries: ' . implode(',', $display_libs));
             sleep(2);
             $builder->proveLibs($libraries);
             $builder->validateLibsAndExts();

--- a/src/SPC/command/DownloadCommand.php
+++ b/src/SPC/command/DownloadCommand.php
@@ -312,7 +312,6 @@ class DownloadCommand extends BaseCommand
     private function calculateSourcesByExt(array $extensions, bool $include_suggests = true): array
     {
         [$extensions, $libraries] = $include_suggests ? DependencyUtil::getExtsAndLibs($extensions, [], true, true) : DependencyUtil::getExtsAndLibs($extensions);
-        var_dump($libraries);
         $sources = [];
         foreach ($extensions as $extension) {
             if (Config::getExt($extension, 'type') === 'external') {

--- a/src/SPC/command/DownloadCommand.php
+++ b/src/SPC/command/DownloadCommand.php
@@ -72,10 +72,6 @@ class DownloadCommand extends BaseCommand
         if ($for_ext = $input->getOption('for-extensions')) {
             $ext = $this->parseExtensionList($for_ext);
             $sources = $this->calculateSourcesByExt($ext, !$input->getOption('without-suggestions'));
-            if (PHP_OS_FAMILY !== 'Windows') {
-                array_unshift($sources, 'pkg-config');
-            }
-            array_unshift($sources, 'php-src', 'micro');
             $final_sources = array_merge($final_sources, array_diff($sources, $final_sources));
         }
         // mode: --for-libs
@@ -316,6 +312,7 @@ class DownloadCommand extends BaseCommand
     private function calculateSourcesByExt(array $extensions, bool $include_suggests = true): array
     {
         [$extensions, $libraries] = $include_suggests ? DependencyUtil::getExtsAndLibs($extensions, [], true, true) : DependencyUtil::getExtsAndLibs($extensions);
+        var_dump($libraries);
         $sources = [];
         foreach ($extensions as $extension) {
             if (Config::getExt($extension, 'type') === 'external') {
@@ -323,7 +320,10 @@ class DownloadCommand extends BaseCommand
             }
         }
         foreach ($libraries as $library) {
-            $sources[] = Config::getLib($library, 'source');
+            $source = Config::getLib($library, 'source');
+            if ($source !== null) {
+                $sources[] = $source;
+            }
         }
         return array_values(array_unique($sources));
     }

--- a/src/SPC/command/dev/SortConfigCommand.php
+++ b/src/SPC/command/dev/SortConfigCommand.php
@@ -33,7 +33,17 @@ class SortConfigCommand extends BaseCommand
             case 'lib':
                 $file = json_decode(FileSystem::readFile(ROOT_DIR . '/config/lib.json'), true);
                 ConfigValidator::validateLibs($file);
-                ksort($file);
+                uksort($file, function ($a, $b) use ($file) {
+                    $type_a = $file[$a]['type'] ?? 'lib';
+                    $type_b = $file[$b]['type'] ?? 'lib';
+                    $type_order = ['root', 'target', 'package', 'lib'];
+                    // compare type first
+                    if ($type_a !== $type_b) {
+                        return array_search($type_a, $type_order) <=> array_search($type_b, $type_order);
+                    }
+                    // compare name
+                    return $a <=> $b;
+                });
                 if (!file_put_contents(ROOT_DIR . '/config/lib.json', json_encode($file, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) . "\n")) {
                     $this->output->writeln('<error>Write file lib.json failed!</error>');
                     return static::FAILURE;

--- a/src/SPC/store/Config.php
+++ b/src/SPC/store/Config.php
@@ -73,7 +73,7 @@ class Config
         if (!isset(self::$lib[$name])) {
             throw new WrongUsageException('lib [' . $name . '] is not supported yet');
         }
-        $supported_sys_based = ['static-libs', 'headers', 'lib-depends', 'lib-suggests', 'frameworks'];
+        $supported_sys_based = ['static-libs', 'headers', 'lib-depends', 'lib-suggests', 'frameworks', 'bin'];
         if ($key !== null && in_array($key, $supported_sys_based)) {
             $m_key = match (PHP_OS_FAMILY) {
                 'Windows' => ['-windows', '-win', ''],

--- a/src/SPC/util/DependencyUtil.php
+++ b/src/SPC/util/DependencyUtil.php
@@ -33,7 +33,7 @@ class DependencyUtil
             $ext_suggests = array_map(fn ($x) => "ext@{$x}", $ext_suggests);
             // merge ext-depends with lib-depends
             $lib_depends = Config::getExt($ext_name, 'lib-depends', []);
-            $depends = array_merge($ext_depends, $lib_depends);
+            $depends = array_merge($ext_depends, $lib_depends, ['php']);
             // merge ext-suggests with lib-suggests
             $lib_suggests = Config::getExt($ext_name, 'lib-suggests', []);
             $suggests = array_merge($ext_suggests, $lib_suggests);
@@ -44,7 +44,7 @@ class DependencyUtil
         }
         foreach ($libs as $lib_name => $lib) {
             $dep_list[$lib_name] = [
-                'depends' => Config::getLib($lib_name, 'lib-depends', []),
+                'depends' => array_merge(Config::getLib($lib_name, 'lib-depends', []), ['lib-base']),
                 'suggests' => Config::getLib($lib_name, 'lib-suggests', []),
             ];
         }
@@ -210,6 +210,9 @@ class DependencyUtil
         }
         $visited[$lib_name] = true;
         // 遍历该依赖的所有依赖（此处的 getLib 如果检测到当前库不存在的话，会抛出异常）
+        if (!isset($dep_list[$lib_name])) {
+            throw new WrongUsageException("{$lib_name} not exist !");
+        }
         foreach ($dep_list[$lib_name]['depends'] as $dep) {
             self::visitPlatDeps($dep, $dep_list, $visited, $sorted);
         }

--- a/src/SPC/util/LicenseDumper.php
+++ b/src/SPC/util/LicenseDumper.php
@@ -70,7 +70,7 @@ class LicenseDumper
         }
 
         foreach ($this->libs as $lib) {
-            if (Config::getLib($lib, 'type') !== 'lib') {
+            if (Config::getLib($lib, 'type', 'lib') !== 'lib') {
                 continue;
             }
             $source_name = Config::getLib($lib, 'source');

--- a/src/SPC/util/LicenseDumper.php
+++ b/src/SPC/util/LicenseDumper.php
@@ -70,6 +70,9 @@ class LicenseDumper
         }
 
         foreach ($this->libs as $lib) {
+            if (Config::getLib($lib, 'type') !== 'lib') {
+                continue;
+            }
             $source_name = Config::getLib($lib, 'source');
             foreach ($this->getSourceLicenses($source_name) as $index => $license) {
                 $result = file_put_contents("{$target_dir}/lib_{$lib}_{$index}.txt", $license);

--- a/src/globals/functions.php
+++ b/src/globals/functions.php
@@ -21,6 +21,14 @@ function is_assoc_array(mixed $array): bool
 }
 
 /**
+ * Judge if an array is a list
+ */
+function is_list_array(mixed $array): bool
+{
+    return is_array($array) && (empty($array) || array_keys($array) === range(0, count($array) - 1));
+}
+
+/**
  * Return a logger instance
  */
 function logger(): LoggerInterface

--- a/tests/SPC/builder/ExtensionTest.php
+++ b/tests/SPC/builder/ExtensionTest.php
@@ -71,7 +71,7 @@ class ExtensionTest extends TestCase
     public function testRunCliCheckWindows()
     {
         if (is_unix()) {
-            $this->markTestIncomplete('This test is for Windows only');
+            $this->markTestSkipped('This test is for Windows only');
         } else {
             $this->extension->runCliCheckWindows();
             $this->assertTrue(true);

--- a/tests/SPC/builder/unix/UnixSystemUtilTest.php
+++ b/tests/SPC/builder/unix/UnixSystemUtilTest.php
@@ -26,7 +26,7 @@ class UnixSystemUtilTest extends TestCase
             default => null,
         };
         if ($util_class === null) {
-            self::markTestIncomplete('This test is only for Unix');
+            self::markTestSkipped('This test is only for Unix');
         }
         $this->util = new $util_class();
     }

--- a/tests/SPC/util/DependencyUtilTest.php
+++ b/tests/SPC/util/DependencyUtilTest.php
@@ -29,6 +29,9 @@ final class DependencyUtilTest extends TestCase
             ],
         ];
         Config::$lib = [
+            'lib-base' => [
+                'type' => 'root',
+            ],
             'libaaa' => [
                 'source' => 'test1',
                 'static-libs' => ['libaaa.a'],

--- a/tests/SPC/util/DependencyUtilTest.php
+++ b/tests/SPC/util/DependencyUtilTest.php
@@ -29,9 +29,8 @@ final class DependencyUtilTest extends TestCase
             ],
         ];
         Config::$lib = [
-            'lib-base' => [
-                'type' => 'root',
-            ],
+            'lib-base' => ['type' => 'root'],
+            'php' => ['type' => 'root'],
             'libaaa' => [
                 'source' => 'test1',
                 'static-libs' => ['libaaa.a'],

--- a/tests/SPC/util/LicenseDumperTest.php
+++ b/tests/SPC/util/LicenseDumperTest.php
@@ -34,6 +34,8 @@ final class LicenseDumperTest extends TestCase
     public function testDumpWithSingleLicense(): void
     {
         Config::$lib = [
+            'lib-base' => ['type' => 'root'],
+            'php' => ['type' => 'root'],
             'fake_lib' => [
                 'source' => 'fake_lib',
             ],
@@ -57,6 +59,8 @@ final class LicenseDumperTest extends TestCase
     public function testDumpWithMultipleLicenses(): void
     {
         Config::$lib = [
+            'lib-base' => ['type' => 'root'],
+            'php' => ['type' => 'root'],
             'fake_lib' => [
                 'source' => 'fake_lib',
             ],


### PR DESCRIPTION
## What does this PR do?

Add php and lib-base as special libraries to add dependencies to the root node. Preparation for #611 .

The main changes are to use `php` as a special root library and add `lib-base` as the root library of the original library.

At the same time, `lib.json` becomes 4 types: `root, target, package, lib`, representing:

- root: root node, only `php` and `lib-base`.
- target: virtual library, which may be depended by other libraries but not an independent library, such as `micro` SAPI.
- package: build target is binary dependency, such as `pkg-config`, which can be depended by the root node.
- lib: ordinary dependency library.

cc @DubbleClick 

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [ ] If it's an extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [ ] If you changed the behavior of static-php-cli, update docs in `./docs/`.
- [X] If you updated `config/xxx.json` content, run `bin/spc dev:sort-config xxx`.
