### PR TITLE
update php default to 8.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Basic usage for building php with some extensions:
 ./bin/spc download --for-extensions="openssl,pcntl,mbstring,pdo_sqlite"
 # download pre-built libraries first (save time for compiling dependencies)
 ./bin/spc download --for-extensions="openssl,curl,mbstring,mbregex" --prefer-pre-built
-# download different PHP version (--with-php=x.y or --with-php=x.y.z, recommend 8.1 ~ 8.3)
+# download different PHP version (--with-php=x.y or --with-php=x.y.z, recommend 8.4)
 ./bin/spc download --for-extensions="openssl,curl,mbstring" --with-php=8.1
 
 # with bcmath,openssl,tokenizer,sqlite3,pdo_sqlite,ftp,curl extension, build both CLI and phpmicro SAPI

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Basic usage for building php with some extensions:
 ./bin/spc download --for-extensions="openssl,pcntl,mbstring,pdo_sqlite"
 # download pre-built libraries first (save time for compiling dependencies)
 ./bin/spc download --for-extensions="openssl,curl,mbstring,mbregex" --prefer-pre-built
-# download different PHP version (--with-php=x.y or --with-php=x.y.z, recommend 8.4)
+# download different PHP version (--with-php=x.y or --with-php=x.y.z, recommend 8.3 ~ 8.4)
 ./bin/spc download --for-extensions="openssl,curl,mbstring" --with-php=8.1
 
 # with bcmath,openssl,tokenizer,sqlite3,pdo_sqlite,ftp,curl extension, build both CLI and phpmicro SAPI

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     ],
     "scripts": {
         "analyse": "phpstan analyse --memory-limit 300M",
-        "cs-fix": "PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer fix",
+        "cs-fix": "php-cs-fixer fix",
         "test": "vendor/bin/phpunit tests/ --no-coverage",
         "build:phar": "vendor/bin/box compile"
     },

--- a/docs/en/guide/manual-build.md
+++ b/docs/en/guide/manual-build.md
@@ -139,7 +139,7 @@ Use the command `bin/spc download` to download the source code required for comp
 including php-src and the source code of various dependent libraries.
 
 ```bash
-# Download all dependencies
+# Download all dependencies, defaults to php 8.4
 bin/spc download --all
 
 # Download all dependent packages, and specify the main version of PHP to download, optional: 8.1, 8.2, 8.3, 8.4

--- a/src/SPC/command/DownloadCommand.php
+++ b/src/SPC/command/DownloadCommand.php
@@ -30,7 +30,7 @@ class DownloadCommand extends BaseCommand
         $this->addArgument('sources', InputArgument::REQUIRED, 'The sources will be compiled, comma separated');
         $this->addOption('shallow-clone', null, null, 'Clone shallow');
         $this->addOption('with-openssl11', null, null, 'Use openssl 1.1');
-        $this->addOption('with-php', null, InputOption::VALUE_REQUIRED, 'version in major.minor format (default 8.3)', '8.3');
+        $this->addOption('with-php', null, InputOption::VALUE_REQUIRED, 'version in major.minor format (default 8.4)', '8.4');
         $this->addOption('clean', null, null, 'Clean old download cache and source before fetch');
         $this->addOption('all', 'A', null, 'Fetch all sources that static-php-cli needed');
         $this->addOption('custom-url', 'U', InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Specify custom source download url, e.g "php-src:https://downloads.php.net/~eric/php-8.3.0beta1.tar.gz"');
@@ -118,7 +118,7 @@ class DownloadCommand extends BaseCommand
             }
 
             // Define PHP major version
-            $ver = $this->php_major_ver = $this->getOption('with-php') ?? '8.1';
+            $ver = $this->php_major_ver = $this->getOption('with-php');
             define('SPC_BUILD_PHP_VERSION', $ver);
             // match x.y
             preg_match('/^\d+\.\d+$/', $ver, $matches);


### PR DESCRIPTION
Had to revert the PHP_CS_FIXER.. there as it fails to run. The alias works on unix anyway.

```ps
PS C:\src\static-php-cli> git commit -a -m "update php defaul to 8.4"
pre-commit: 
 - composer cs-fix -- --config=.php-cs-fixer.php --dry-run --diff... : failed
captainhook failed executing all actions, took: 1.10s

composer cs-fix -- --config=.php-cs-fixer.php --dry-run --diff {$STAGED_FILES|of-type:php}
  command output:
> PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer fix --config=.php-cs-fixer.php --dry-run --diff src/SPC/command/DownloadCommand.php
'PHP_CS_FIXER_IGNORE_ENV' is not recognized as an internal or external command,
operable program or batch file.
Script PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer fix handling the cs-fix event returned with error code 1
failed to execute: composer cs-fix -- --config=.php-cs-fixer.php --dry-run --diff src/SPC/command/DownloadCommand.php
```