### PR TITLE
fix embed SAPI php-config prefix

### DIFF
--- a/src/SPC/builder/linux/LinuxBuilder.php
+++ b/src/SPC/builder/linux/LinuxBuilder.php
@@ -318,6 +318,7 @@ class LinuxBuilder extends UnixBuilderBase
         shell()->cd(SOURCE_PATH . '/php-src')
             ->exec('sed -i "s|//lib|/lib|g" Makefile')
             ->exec(getenv('SPC_CMD_PREFIX_PHP_MAKE') . ' INSTALL_ROOT=' . BUILD_ROOT_PATH . " {$vars} install");
+        FileSystem::replaceFileStr(BUILD_BIN_PATH . '/php-config', 'prefix=""', 'prefix="' . BUILD_ROOT_PATH . '"');
     }
 
     private function getMakeExtraVars(): array


### PR DESCRIPTION
## What does this PR do?

Fixes the embed php-config prefix. Without this, extensions trying to configure with `--with-php-config=/path/to/buildroot/bin/php-config` will use the global php-dev installation or fail.

see #624 