### PR TITLE
don't require libacl and attr - use --with-libs='libacl' if you build…

### DIFF
--- a/config/lib.json
+++ b/config/lib.json
@@ -33,6 +33,7 @@
             "libattr.a"
         ],
         "lib-suggests": [
+            "gettext",
             "libiconv"
         ]
     },
@@ -255,6 +256,7 @@
             "attr"
         ],
         "lib-suggests": [
+            "gettext",
             "libiconv"
         ]
     },

--- a/config/lib.json
+++ b/config/lib.json
@@ -31,6 +31,9 @@
         "source": "attr",
         "static-libs-unix": [
             "libattr.a"
+        ],
+        "lib-suggests": [
+            "libiconv"
         ]
     },
     "brotli": {
@@ -250,6 +253,9 @@
         ],
         "lib-depends": [
             "attr"
+        ],
+        "lib-suggests": [
+            "libiconv"
         ]
     },
     "libaom": {

--- a/config/lib.json
+++ b/config/lib.json
@@ -11,6 +11,9 @@
         "lib-depends": [
             "lib-base",
             "micro"
+        ],
+        "lib-suggests-linux": [
+            "libacl"
         ]
     },
     "micro": {

--- a/config/lib.json
+++ b/config/lib.json
@@ -31,10 +31,6 @@
         "source": "attr",
         "static-libs-unix": [
             "libattr.a"
-        ],
-        "lib-suggests": [
-            "gettext",
-            "libiconv"
         ]
     },
     "brotli": {
@@ -254,10 +250,6 @@
         ],
         "lib-depends": [
             "attr"
-        ],
-        "lib-suggests": [
-            "gettext",
-            "libiconv"
         ]
     },
     "libaom": {

--- a/config/lib.json
+++ b/config/lib.json
@@ -11,11 +11,6 @@
         "lib-depends": [
             "lib-base",
             "micro"
-        ],
-        "lib-depends-linux": [
-            "lib-base",
-            "libacl",
-            "micro"
         ]
     },
     "micro": {

--- a/src/SPC/builder/unix/library/attr.php
+++ b/src/SPC/builder/unix/library/attr.php
@@ -13,7 +13,10 @@ trait attr
      */
     protected function build(): void
     {
-        $options = $this->getBuilder()->getLib('libiconv') === null ? '--disable-nls' : '';
+        $options = $this->getBuilder()->getLib('libiconv') === null ? '--disable-nls' : '--with-libiconv-prefix=' . BUILD_ROOT_PATH;
+        if ($this->getBuilder()->getLib('gettext') !== null) {
+            $options .= ' --with-libintl-prefix=' . BUILD_ROOT_PATH;
+        }
         shell()->cd($this->source_dir)
             ->setEnv([
                 'CFLAGS' => trim('-I' . BUILD_INCLUDE_PATH . ' ' . $this->getLibExtraCFlags()),

--- a/src/SPC/builder/unix/library/attr.php
+++ b/src/SPC/builder/unix/library/attr.php
@@ -13,17 +13,13 @@ trait attr
      */
     protected function build(): void
     {
-        $options = $this->getBuilder()->getLib('libiconv') === null ? '--disable-nls' : '--with-libiconv-prefix=' . BUILD_ROOT_PATH;
-        if ($this->getBuilder()->getLib('gettext') !== null) {
-            $options .= ' --with-libintl-prefix=' . BUILD_ROOT_PATH;
-        }
         shell()->cd($this->source_dir)
             ->setEnv([
                 'CFLAGS' => trim('-I' . BUILD_INCLUDE_PATH . ' ' . $this->getLibExtraCFlags()),
                 'LDFLAGS' => trim('-L' . BUILD_LIB_PATH . ' ' . $this->getLibExtraLdFlags()),
                 'LIBS' => $this->getLibExtraLibs(),
             ])->execWithEnv('./autogen.sh')
-            ->execWithEnv("./configure --prefix= --enable-static --disable-shared {$options}")
+            ->execWithEnv('./configure --prefix= --enable-static --disable-shared --disable-nls')
             ->execWithEnv("make -j {$this->builder->concurrency}")
             ->exec('make install DESTDIR=' . BUILD_ROOT_PATH);
 

--- a/src/SPC/builder/unix/library/attr.php
+++ b/src/SPC/builder/unix/library/attr.php
@@ -13,13 +13,14 @@ trait attr
      */
     protected function build(): void
     {
+        $options = $this->getBuilder()->getLib('libiconv') === null ? '--disable-gettext' : '';
         shell()->cd($this->source_dir)
             ->setEnv([
                 'CFLAGS' => trim('-I' . BUILD_INCLUDE_PATH . ' ' . $this->getLibExtraCFlags()),
                 'LDFLAGS' => trim('-L' . BUILD_LIB_PATH . ' ' . $this->getLibExtraLdFlags()),
                 'LIBS' => $this->getLibExtraLibs(),
             ])->execWithEnv('./autogen.sh')
-            ->execWithEnv('./configure --prefix= --enable-static --disable-shared')
+            ->execWithEnv("./configure --prefix= --enable-static --disable-shared {$options}")
             ->execWithEnv("make -j {$this->builder->concurrency}")
             ->exec('make install DESTDIR=' . BUILD_ROOT_PATH);
 

--- a/src/SPC/builder/unix/library/attr.php
+++ b/src/SPC/builder/unix/library/attr.php
@@ -13,7 +13,7 @@ trait attr
      */
     protected function build(): void
     {
-        $options = $this->getBuilder()->getLib('libiconv') === null ? '--disable-gettext' : '';
+        $options = $this->getBuilder()->getLib('libiconv') === null ? '--disable-nls' : '';
         shell()->cd($this->source_dir)
             ->setEnv([
                 'CFLAGS' => trim('-I' . BUILD_INCLUDE_PATH . ' ' . $this->getLibExtraCFlags()),

--- a/src/SPC/builder/unix/library/libacl.php
+++ b/src/SPC/builder/unix/library/libacl.php
@@ -29,6 +29,7 @@ trait libacl
      */
     protected function build(): void
     {
+        $options = $this->getBuilder()->getLib('libiconv') === null ? '--disable-gettext' : '';
         shell()->cd($this->source_dir)
             ->setEnv([
                 'CFLAGS' => trim('-I' . BUILD_INCLUDE_PATH . ' ' . $this->getLibExtraCFlags()),
@@ -36,7 +37,7 @@ trait libacl
                 'LIBS' => $this->getLibExtraLibs(),
             ])
             ->execWithEnv('./autogen.sh')
-            ->execWithEnv('./configure --prefix= --enable-static --disable-shared --disable-tests --disable-nls')
+            ->execWithEnv("./configure --prefix= --enable-static --disable-shared --disable-tests {$options}")
             ->execWithEnv("make -j {$this->builder->concurrency}")
             ->exec('make install DESTDIR=' . BUILD_ROOT_PATH);
 

--- a/src/SPC/builder/unix/library/libacl.php
+++ b/src/SPC/builder/unix/library/libacl.php
@@ -29,7 +29,7 @@ trait libacl
      */
     protected function build(): void
     {
-        $options = $this->getBuilder()->getLib('libiconv') === null ? '--disable-gettext' : '';
+        $options = $this->getBuilder()->getLib('libiconv') === null ? '--disable-nls' : '';
         shell()->cd($this->source_dir)
             ->setEnv([
                 'CFLAGS' => trim('-I' . BUILD_INCLUDE_PATH . ' ' . $this->getLibExtraCFlags()),

--- a/src/SPC/builder/unix/library/libacl.php
+++ b/src/SPC/builder/unix/library/libacl.php
@@ -29,7 +29,10 @@ trait libacl
      */
     protected function build(): void
     {
-        $options = $this->getBuilder()->getLib('libiconv') === null ? '--disable-nls' : '';
+        $options = $this->getBuilder()->getLib('libiconv') === null ? '--disable-nls' : '--with-libiconv-prefix=' . BUILD_ROOT_PATH;
+        if ($this->getBuilder()->getLib('gettext') !== null) {
+            $options .= ' --with-libintl-prefix=' . BUILD_ROOT_PATH;
+        }
         shell()->cd($this->source_dir)
             ->setEnv([
                 'CFLAGS' => trim('-I' . BUILD_INCLUDE_PATH . ' ' . $this->getLibExtraCFlags()),

--- a/src/SPC/builder/unix/library/libacl.php
+++ b/src/SPC/builder/unix/library/libacl.php
@@ -29,10 +29,6 @@ trait libacl
      */
     protected function build(): void
     {
-        $options = $this->getBuilder()->getLib('libiconv') === null ? '--disable-nls' : '--with-libiconv-prefix=' . BUILD_ROOT_PATH;
-        if ($this->getBuilder()->getLib('gettext') !== null) {
-            $options .= ' --with-libintl-prefix=' . BUILD_ROOT_PATH;
-        }
         shell()->cd($this->source_dir)
             ->setEnv([
                 'CFLAGS' => trim('-I' . BUILD_INCLUDE_PATH . ' ' . $this->getLibExtraCFlags()),
@@ -40,7 +36,7 @@ trait libacl
                 'LIBS' => $this->getLibExtraLibs(),
             ])
             ->execWithEnv('./autogen.sh')
-            ->execWithEnv("./configure --prefix= --enable-static --disable-shared --disable-tests {$options}")
+            ->execWithEnv('./configure --prefix= --enable-static --disable-shared --disable-tests --disable-nls')
             ->execWithEnv("make -j {$this->builder->concurrency}")
             ->exec('make install DESTDIR=' . BUILD_ROOT_PATH);
 

--- a/src/SPC/command/BuildCliCommand.php
+++ b/src/SPC/command/BuildCliCommand.php
@@ -108,9 +108,6 @@ class BuildCliCommand extends BuildCommand
             $include_suggest_ext = $this->getOption('with-suggested-exts');
             $include_suggest_lib = $this->getOption('with-suggested-libs');
             [$extensions, $libraries, $not_included] = DependencyUtil::getExtsAndLibs($extensions, $libraries, $include_suggest_ext, $include_suggest_lib);
-            if (PHP_OS_FAMILY !== 'Linux' || !($rule & BUILD_TARGET_FPM)) {
-                $libraries = array_filter($libraries, fn ($lib) => !in_array($lib, ['attr', 'libacl']));
-            }
             $display_libs = array_filter($libraries, fn ($lib) => in_array(Config::getLib($lib, 'type', 'lib'), ['lib', 'package']));
 
             // print info


### PR DESCRIPTION
… fpm with acl support

unfortunate, but I honestly do not see a good way of solving this issue, without going for an extensive rework, that is imo not justified