### PR TITLE
Update automake on gnu docker to fix attr build bug

### DIFF
--- a/bin/build-static-frankenphp
+++ b/bin/build-static-frankenphp
@@ -104,6 +104,14 @@ RUN curl -o make.tgz -fsSL https://ftp.gnu.org/gnu/make/make-4.4.tar.gz && \
     make install && \
     ln -sf /usr/local/bin/make /usr/bin/make
 
+RUN curl -o automake.tgz -fsSL https://ftp.gnu.org/gnu/automake/automake-1.17.tar.xz && \
+    tar -xvf automake.tgz && \
+    cd automake-1.17 && \
+    ./configure && \
+    make && \
+    make install && \
+    ln -sf /usr/local/bin/automake /usr/bin/automake
+
 RUN git clone https://github.com/static-php/gnu-frankenphp --depth=1 /frankenphp
 WORKDIR /frankenphp
 

--- a/bin/spc-gnu-docker
+++ b/bin/spc-gnu-docker
@@ -100,6 +100,14 @@ RUN curl -o make.tgz -fsSL https://ftp.gnu.org/gnu/make/make-4.4.tar.gz && \
     make install && \
     ln -sf /usr/local/bin/make /usr/bin/make
 
+RUN curl -o automake.tgz -fsSL https://ftp.gnu.org/gnu/automake/automake-1.17.tar.xz && \
+    tar -xvf automake.tgz && \
+    cd automake-1.17 && \
+    ./configure && \
+    make && \
+    make install && \
+    ln -sf /usr/local/bin/automake /usr/bin/automake
+
 EOF
 fi
 


### PR DESCRIPTION
## What does this PR do?

Update automake on gnu docker to fix attr build bug. Because `attr` needs `automake >= 1.15`, fix #624 https://github.com/crazywhalecc/static-php-cli/issues/624#issuecomment-2720059555

cc @DubbleClick 

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [ ] If you modified `*.php`, run `composer cs-fix` at local machine.
- [ ] If it's an extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [ ] If you changed the behavior of static-php-cli, update docs in `./docs/`.
- [ ] If you updated `config/xxx.json` content, run `bin/spc dev:sort-config xxx`.
