### PR TITLE
fix libxslt license file path

### DIFF
--- a/config/source.json
+++ b/config/source.json
@@ -592,7 +592,7 @@
         "regex": "/href=\"(?<file>libxslt-(?<version>[^\"]+)\\.tar\\.xz)\"/",
         "license": {
             "type": "file",
-            "path": "COPYING"
+            "path": "Copyright"
         }
     },
     "libyaml": {


### PR DESCRIPTION
## What does this PR do?

fixes the license path of libxslt  #645 