### PR TITLE
Fix libavif build on VS2019 syntax error

### DIFF
--- a/config/source.json
+++ b/config/source.json
@@ -365,8 +365,9 @@
         }
     },
     "libavif": {
-        "type": "url",
-        "url": "https://github.com/AOMediaCodec/libavif/archive/refs/tags/v1.2.0.tar.gz",
+        "type": "ghtar",
+        "repo": "AOMediaCodec/libavif",
+        "provide-pre-built": true,
         "license": {
             "type": "file",
             "path": "LICENSE"

--- a/config/source.json
+++ b/config/source.json
@@ -366,7 +366,7 @@
     },
     "libavif": {
         "type": "url",
-        "url": "https://github.com/AOMediaCodec/libavif/archive/refs/tags/v1.1.1.tar.gz",
+        "url": "https://github.com/AOMediaCodec/libavif/archive/refs/tags/v1.2.0.tar.gz",
         "license": {
             "type": "file",
             "path": "LICENSE"

--- a/config/source.json
+++ b/config/source.json
@@ -365,9 +365,8 @@
         }
     },
     "libavif": {
-        "type": "ghtar",
-        "repo": "AOMediaCodec/libavif",
-        "provide-pre-built": true,
+        "type": "url",
+        "url": "https://github.com/AOMediaCodec/libavif/archive/refs/tags/v1.1.1.tar.gz",
         "license": {
             "type": "file",
             "path": "LICENSE"

--- a/src/SPC/builder/windows/library/libavif.php
+++ b/src/SPC/builder/windows/library/libavif.php
@@ -12,6 +12,8 @@ class libavif extends WindowsLibraryBase
 
     protected function build(): void
     {
+        // workaround for libavif 1.2.0 bug
+        FileSystem::replaceFileStr($this->source_dir . '\src\read.c', 'avifFileType ftyp = {};', 'avifFileType ftyp = { 0 };');
         // reset cmake
         FileSystem::resetDir($this->source_dir . '\build');
 

--- a/src/globals/test-extensions.php
+++ b/src/globals/test-extensions.php
@@ -25,6 +25,7 @@ $test_os = [
     // 'macos-14',
     // 'ubuntu-latest',
     'windows-2019',
+    'windows-latest',
 ];
 
 // whether enable thread safe

--- a/src/globals/test-extensions.php
+++ b/src/globals/test-extensions.php
@@ -14,17 +14,17 @@ declare(strict_types=1);
 // test php version
 $test_php_version = [
     '8.1',
-    '8.2',
-    '8.3',
+    // '8.2',
+    // '8.3',
     '8.4',
 ];
 
 // test os (macos-13, macos-14, ubuntu-latest, windows-latest are available)
 $test_os = [
-    'macos-13',
-    'macos-14',
-    'ubuntu-latest',
-    // 'windows-latest',
+    // 'macos-13',
+    // 'macos-14',
+    // 'ubuntu-latest',
+    'windows-2019',
 ];
 
 // whether enable thread safe
@@ -41,13 +41,13 @@ $prefer_pre_built = false;
 // If you want to test your added extensions and libs, add below (comma separated, example `bcmath,openssl`).
 $extensions = match (PHP_OS_FAMILY) {
     'Linux', 'Darwin' => 'gettext',
-    'Windows' => 'bcmath',
+    'Windows' => 'gd',
 };
 
 // If you want to test lib-suggests feature with extension, add them below (comma separated, example `libwebp,libavif`).
 $with_libs = match (PHP_OS_FAMILY) {
     'Linux', 'Darwin' => '',
-    'Windows' => '',
+    'Windows' => 'libavif',
 };
 
 // Please change your test base combination. We recommend testing with `common`.


### PR DESCRIPTION
## What does this PR do?

Created upstream issue: https://github.com/AOMediaCodec/libavif/issues/2686, and fix #648 

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [X] If you modified `*.php`, run `composer cs-fix` at local machine.
- [X] If it's an extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [ ] If you changed the behavior of static-php-cli, update docs in `./docs/`.
- [ ] If you updated `config/xxx.json` content, run `bin/spc dev:sort-config xxx`.
