### PR TITLE
Add missing ext source when downloading pre-built grpc

### DIFF
--- a/src/SPC/builder/extension/grpc.php
+++ b/src/SPC/builder/extension/grpc.php
@@ -22,7 +22,13 @@ class grpc extends Extension
             throw new \RuntimeException('grpc extension does not support windows yet');
         }
         if (!is_link(SOURCE_PATH . '/php-src/ext/grpc')) {
-            shell()->exec('ln -s ' . $this->builder->getLib('grpc')->getSourceDir() . '/src/php/ext/grpc ' . SOURCE_PATH . '/php-src/ext/grpc');
+            if (is_dir($this->builder->getLib('grpc')->getSourceDir() . '/src/php/ext/grpc')) {
+                shell()->exec('ln -s ' . $this->builder->getLib('grpc')->getSourceDir() . '/src/php/ext/grpc ' . SOURCE_PATH . '/php-src/ext/grpc');
+            } elseif (is_dir(BUILD_ROOT_PATH . '/grpc_php_ext_src')) {
+                shell()->exec('ln -s ' . BUILD_ROOT_PATH . '/grpc_php_ext_src ' . SOURCE_PATH . '/php-src/ext/grpc');
+            } else {
+                throw new \RuntimeException('Cannot find grpc source code');
+            }
             $macos = $this->builder instanceof MacOSBuilder ? "\n" . '  LDFLAGS="$LDFLAGS -framework CoreFoundation"' : '';
             FileSystem::replaceFileRegex(SOURCE_PATH . '/php-src/ext/grpc/config.m4', '/GRPC_LIBDIR=.*$/m', 'GRPC_LIBDIR=' . BUILD_LIB_PATH . $macos);
             FileSystem::replaceFileRegex(SOURCE_PATH . '/php-src/ext/grpc/config.m4', '/SEARCH_PATH=.*$/m', 'SEARCH_PATH="' . BUILD_ROOT_PATH . '"');

--- a/src/SPC/builder/unix/library/grpc.php
+++ b/src/SPC/builder/unix/library/grpc.php
@@ -20,5 +20,6 @@ trait grpc
         FileSystem::copyDir($this->source_dir . '/include/grpc', BUILD_INCLUDE_PATH . '/grpc');
         FileSystem::copyDir($this->source_dir . '/include/grpc++', BUILD_INCLUDE_PATH . '/grpc++');
         FileSystem::copyDir($this->source_dir . '/include/grpcpp', BUILD_INCLUDE_PATH . '/grpcpp');
+        FileSystem::copyDir($this->source_dir . '/src/php/ext/grpc', BUILD_ROOT_PATH . '/grpc_php_ext_src');
     }
 }

--- a/src/globals/test-extensions.php
+++ b/src/globals/test-extensions.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 // test php version
 $test_php_version = [
-    '8.1',
-    '8.2',
+    // '8.1',
+    // '8.2',
     '8.3',
     '8.4',
 ];
@@ -36,11 +36,11 @@ $no_strip = false;
 $upx = false;
 
 // prefer downloading pre-built packages to speed up the build process
-$prefer_pre_built = false;
+$prefer_pre_built = true;
 
 // If you want to test your added extensions and libs, add below (comma separated, example `bcmath,openssl`).
 $extensions = match (PHP_OS_FAMILY) {
-    'Linux', 'Darwin' => 'gettext',
+    'Linux', 'Darwin' => 'grpc',
     'Windows' => 'bcmath',
 };
 


### PR DESCRIPTION
## What does this PR do?

Fix #606 .

CI should be failed as expected (except macos-14). Because the only fixed pre-built libs is `grpc-aarch64-darwin.txz` that I manually uploaded. After CI finished, it could be merged and hosted repo will trigger packing libs soon.

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [X] If you modified `*.php`, run `composer cs-fix` at local machine.
- [X] If it's an extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [ ] If you changed the behavior of static-php-cli, update docs in `./docs/`.
- [ ] If you updated `config/xxx.json` content, run `bin/spc dev:sort-config xxx`.
