### PR TITLE
Fix/ffi env

### DIFF
--- a/src/SPC/builder/linux/library/libffi.php
+++ b/src/SPC/builder/linux/library/libffi.php
@@ -18,22 +18,22 @@ class libffi extends LinuxLibraryBase
     public function build(): void
     {
         [$lib, , $destdir] = SEPARATED_PATH;
-
         $arch = getenv('SPC_ARCH');
 
         shell()->cd($this->source_dir)
-            ->exec(
+            ->setEnv(['CFLAGS' => $this->getLibExtraCFlags(), 'LDFLAGS' => $this->getLibExtraLdFlags(), 'LIBS' => $this->getLibExtraLibs()])
+            ->execWithEnv(
                 './configure ' .
                 '--enable-static ' .
                 '--disable-shared ' .
                 "--host={$arch}-unknown-linux " .
                 "--target={$arch}-unknown-linux " .
-                '--prefix= ' . // use prefix=/
+                '--prefix= ' .
                 "--libdir={$lib}"
             )
-            ->exec('make clean')
-            ->exec("make -j{$this->builder->concurrency}")
-            ->exec("make install DESTDIR={$destdir}");
+            ->execWithEnv('make clean')
+            ->execWithEnv("make -j{$this->builder->concurrency}")
+            ->execWithEnv("make install DESTDIR={$destdir}");
 
         if (is_file(BUILD_ROOT_PATH . '/lib64/libffi.a')) {
             copy(BUILD_ROOT_PATH . '/lib64/libffi.a', BUILD_ROOT_PATH . '/lib/libffi.a');


### PR DESCRIPTION
Causes:

```console
/opt/rh/devtoolset-10/root/usr/libexec/gcc/x86_64-redhat-linux/10/ld: /app/buildroot/lib/libffi.a(prep_cif.o): relocation R_X86_64_32S against symbol `ffi_type_float' can not be used when making a PIE object; recompile with -fPIE
/opt/rh/devtoolset-10/root/usr/libexec/gcc/x86_64-redhat-linux/10/ld: /app/buildroot/lib/libffi.a(closures.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIE
/opt/rh/devtoolset-10/root/usr/libexec/gcc/x86_64-redhat-linux/10/ld: /app/buildroot/lib/libffi.a(tramp.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIE
/opt/rh/devtoolset-10/root/usr/libexec/gcc/x86_64-redhat-linux/10/ld: /app/buildroot/lib/libffi.a(ffi64.o): relocation R_X86_64_32S against `.rodata' can not be used when making a PIE object; recompile with -fPIE
/opt/rh/devtoolset-10/root/usr/libexec/gcc/x86_64-redhat-linux/10/ld: /app/buildroot/lib/libffi.a(ffiw64.o): relocation R_X86_64_32S against hidden symbol `ffi_closure_win64' can not be used when making a PIE object
/opt/rh/devtoolset-10/root/usr/libexec/gcc/x86_64-redhat-linux/10/ld: /app/buildroot/lib/libffi.a(types.o): warning: relocation in read-only section `.rodata'
/opt/rh/devtoolset-10/root/usr/libexec/gcc/x86_64-redhat-linux/10/ld: warning: GNU indirect functions with DT_TEXTREL may result in a segfault at runtime; recompile with -fPIE
collect2: error: ld returned 1 exit status
```

When trying to compile as -pie. The -fPIC and -fPIE are given in extra flags of the environment.