### PR TITLE
Add pgsql extension for Windows <#664>

### DIFF
--- a/config/ext.json
+++ b/config/ext.json
@@ -515,8 +515,11 @@
             "pdo",
             "pgsql"
         ],
-        "lib-depends": [
+        "lib-depends-unix": [
             "postgresql"
+        ],
+        "lib-depends-windows": [
+            "postgresql-win"
         ]
     },
     "pdo_sqlite": {

--- a/config/ext.json
+++ b/config/ext.json
@@ -523,6 +523,7 @@
         },
         "type": "builtin",
         "arg-type": "with-prefix",
+        "arg-type-windows": "custom",
         "ext-depends": [
             "pdo",
             "pgsql"

--- a/config/ext.json
+++ b/config/ext.json
@@ -426,6 +426,12 @@
         },
         "notes": true
     },
+    "odbc": {
+        "type": "builtin",
+        "lib-depends-unix": [
+            "unixodbc"
+        ]
+    },
     "opcache": {
         "type": "builtin",
         "arg-type-unix": "custom"
@@ -492,9 +498,15 @@
             "mysqlnd"
         ]
     },
+    "pdo_odbc": {
+        "type": "builtin",
+        "arg-type": "with",
+        "lib-depends-unix": [
+            "unixodbc"
+        ]
+    },
     "pdo_pgsql": {
         "support": {
-            "Windows": "wip",
             "BSD": "wip"
         },
         "type": "builtin",
@@ -535,14 +547,16 @@
     },
     "pgsql": {
         "support": {
-            "Windows": "wip",
             "BSD": "wip"
         },
         "notes": true,
         "type": "builtin",
         "arg-type": "custom",
-        "lib-depends": [
+        "lib-depends-unix": [
             "postgresql"
+        ],
+        "lib-depends-windows": [
+            "postgresql-win"
         ]
     },
     "phar": {

--- a/config/lib.json
+++ b/config/lib.json
@@ -677,15 +677,6 @@
             "libpq.lib",
             "libpgport.lib",
             "libpgcommon.lib"
-        ],
-        "lib-depends": [
-            "libiconv-win",
-            "libxml2",
-            "openssl",
-            "zlib"
-        ],
-        "lib-suggests": [
-            "zstd"
         ]
     },
     "pthreads4w": {

--- a/config/lib.json
+++ b/config/lib.json
@@ -666,6 +666,23 @@
             "zstd"
         ]
     },
+    "postgresql-win": {
+        "source": "postgresql-win",
+        "static-libs": [
+            "libpq.lib",
+            "libpgport.lib",
+            "libpgcommon.lib"
+        ],
+        "lib-depends": [
+            "libiconv-win",
+            "libxml2",
+            "openssl",
+            "zlib"
+        ],
+        "lib-suggests": [
+            "zstd"
+        ]
+    },
     "pthreads4w": {
         "source": "pthreads4w",
         "static-libs-windows": [

--- a/config/source.json
+++ b/config/source.json
@@ -753,7 +753,11 @@
     },
     "postgresql-win": {
         "type": "url",
-        "url": "https://get.enterprisedb.com/postgresql/postgresql-16.8-1-windows-x64-binaries.zip"
+        "url": "https://get.enterprisedb.com/postgresql/postgresql-16.8-1-windows-x64-binaries.zip",
+        "license": {
+            "type": "text",
+            "text": "PostgreSQL Database Management System\n(also known as Postgres, formerly as Postgres95)\n\nPortions Copyright (c) 1996-2025, The PostgreSQL Global Development Group\n\nPortions Copyright (c) 1994, The Regents of the University of California\n\nPermission to use, copy, modify, and distribute this software and its\ndocumentation for any purpose, without fee, and without a written\nagreement is hereby granted, provided that the above copyright notice\nand this paragraph and the following two paragraphs appear in all\ncopies.\n\nIN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY\nFOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES,\nINCLUDING LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS\nDOCUMENTATION, EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF\nTHE POSSIBILITY OF SUCH DAMAGE.\n\nTHE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,\nINCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY\nAND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS\nON AN \"AS IS\" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATIONS\nTO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS."
+        }
     },
     "protobuf": {
         "type": "url",

--- a/config/source.json
+++ b/config/source.json
@@ -751,6 +751,10 @@
             "path": "COPYRIGHT"
         }
     },
+    "postgresql-win": {
+        "type": "url",
+        "url": "https://get.enterprisedb.com/postgresql/postgresql-16.8-1-windows-x64-binaries.zip"
+    },
     "protobuf": {
         "type": "url",
         "url": "https://pecl.php.net/get/protobuf",

--- a/src/SPC/builder/extension/pdo_pgsql.php
+++ b/src/SPC/builder/extension/pdo_pgsql.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\extension;
+
+use SPC\builder\Extension;
+use SPC\util\CustomExt;
+
+#[CustomExt('pdo_pgsql')]
+class pdo_pgsql extends Extension
+{
+    public function getWindowsConfigureArg(): string
+    {
+        return '--with-pdo-pgsql=yes';
+    }
+}

--- a/src/SPC/builder/extension/pgsql.php
+++ b/src/SPC/builder/extension/pgsql.php
@@ -40,4 +40,16 @@ class pgsql extends Extension
         }
         return '--with-pgsql=' . BUILD_ROOT_PATH;
     }
+
+    /**
+     * @throws WrongUsageException
+     * @throws RuntimeException
+     */
+    public function getWindowsConfigureArg(): string
+    {
+        if ($this->builder->getPHPVersionID() >= 80400) {
+            return '--with-pgsql PGSQL_CFLAGS=-I' . BUILD_INCLUDE_PATH . ' PGSQL_LIBS="-L' . BUILD_LIB_PATH . ' -lpq -lpgport -lpgcommon"';
+        }
+        return '--with-pgsql=' . BUILD_ROOT_PATH;
+    }
 }

--- a/src/SPC/builder/extension/pgsql.php
+++ b/src/SPC/builder/extension/pgsql.php
@@ -48,7 +48,7 @@ class pgsql extends Extension
     public function getWindowsConfigureArg(): string
     {
         if ($this->builder->getPHPVersionID() >= 80400) {
-            return '--with-pgsql PGSQL_CFLAGS=-I' . BUILD_INCLUDE_PATH . ' PGSQL_LIBS="-L' . BUILD_LIB_PATH . ' -lpq -lpgport -lpgcommon"';
+            return '--with-pgsql';
         }
         return '--with-pgsql=' . BUILD_ROOT_PATH;
     }

--- a/src/SPC/builder/windows/library/postgresql_win.php
+++ b/src/SPC/builder/windows/library/postgresql_win.php
@@ -4,20 +4,12 @@ declare(strict_types=1);
 
 namespace SPC\builder\windows\library;
 
-use SPC\store\FileSystem;
-
 class postgresql_win extends WindowsLibraryBase
 {
     public const NAME = 'postgresql-win';
 
     protected function build(): void
     {
-        $builddir = BUILD_ROOT_PATH;
-        $envs = '';
-
-        // reset cmake
-        FileSystem::resetDir($this->source_dir . '\build');
-
         copy($this->source_dir . '\pgsql\lib\libpq.lib', BUILD_LIB_PATH . '\libpq.lib');
         copy($this->source_dir . '\pgsql\lib\libpgport.lib', BUILD_LIB_PATH . '\libpgport.lib');
         copy($this->source_dir . '\pgsql\lib\libpgcommon.lib', BUILD_LIB_PATH . '\libpgcommon.lib');

--- a/src/SPC/builder/windows/library/postgresql_win.php
+++ b/src/SPC/builder/windows/library/postgresql_win.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace SPC\builder\windows\library;
 
-use SPC\exception\FileSystemException;
 use SPC\store\FileSystem;
 
 class postgresql_win extends WindowsLibraryBase
@@ -23,22 +22,14 @@ class postgresql_win extends WindowsLibraryBase
         copy($this->source_dir . '\pgsql\lib\libpgport.lib', BUILD_LIB_PATH . '\libpgport.lib');
         copy($this->source_dir . '\pgsql\lib\libpgcommon.lib', BUILD_LIB_PATH . '\libpgcommon.lib');
 
-        $headerFiles = ['libpq-fe.h', 'postgres_ext.h'];
+        // create libpq folder in buildroot/includes/libpq
+        if (!file_exists(BUILD_INCLUDE_PATH . '\libpq')) {
+            mkdir(BUILD_INCLUDE_PATH . '\libpq');
+        }
+
+        $headerFiles = ['libpq-fe.h', 'postgres_ext.h', 'pg_config_ext.h', 'libpq\libpq-fs.h'];
         foreach ($headerFiles as $header) {
             copy($this->source_dir . '\pgsql\include\\' . $header, BUILD_INCLUDE_PATH . '\\' . $header);
-        }
-    }
-
-    private function getVersion(): string
-    {
-        try {
-            $file = FileSystem::readFile($this->source_dir . '/meson.build');
-            if (preg_match("/^\\s+version:\\s?'(.*)'/m", $file, $match)) {
-                return $match[1];
-            }
-            return 'unknown';
-        } catch (FileSystemException) {
-            return 'unknown';
         }
     }
 }

--- a/src/SPC/builder/windows/library/postgresql_win.php
+++ b/src/SPC/builder/windows/library/postgresql_win.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\windows\library;
+
+use SPC\exception\FileSystemException;
+use SPC\store\FileSystem;
+
+class postgresql_win extends WindowsLibraryBase
+{
+    public const NAME = 'postgresql-win';
+
+    protected function build(): void
+    {
+        $builddir = BUILD_ROOT_PATH;
+        $envs = '';
+
+        // reset cmake
+        FileSystem::resetDir($this->source_dir . '\build');
+
+        copy($this->source_dir . '\pgsql\lib\libpq.lib', BUILD_LIB_PATH . '\libpq.lib');
+        copy($this->source_dir . '\pgsql\lib\libpgport.lib', BUILD_LIB_PATH . '\libpgport.lib');
+        copy($this->source_dir . '\pgsql\lib\libpgcommon.lib', BUILD_LIB_PATH . '\libpgcommon.lib');
+
+        $headerFiles = ['libpq-fe.h', 'postgres_ext.h'];
+        foreach ($headerFiles as $header) {
+            copy($this->source_dir . '\pgsql\include\\' . $header, BUILD_INCLUDE_PATH . '\\' . $header);
+        }
+    }
+
+    private function getVersion(): string
+    {
+        try {
+            $file = FileSystem::readFile($this->source_dir . '/meson.build');
+            if (preg_match("/^\\s+version:\\s?'(.*)'/m", $file, $match)) {
+                return $match[1];
+            }
+            return 'unknown';
+        } catch (FileSystemException) {
+            return 'unknown';
+        }
+    }
+}

--- a/src/globals/test-extensions.php
+++ b/src/globals/test-extensions.php
@@ -23,7 +23,7 @@ $test_php_version = [
 $test_os = [
     // 'macos-13',
     // 'macos-14',
-    // 'ubuntu-latest',
+    'ubuntu-latest',
     'windows-latest',
 ];
 
@@ -40,8 +40,8 @@ $prefer_pre_built = false;
 
 // If you want to test your added extensions and libs, add below (comma separated, example `bcmath,openssl`).
 $extensions = match (PHP_OS_FAMILY) {
-    'Linux', 'Darwin' => 'gd',
-    'Windows' => 'bz2,ctype,curl,dom,filter,gd,iconv,mbstring,opcache,openssl,pdo,pdo_pgsql,pdo_sqlite,pgsql,phar,session,simplexml,sqlite3,tokenizer,xml,xmlwriter,yaml,zip,zlib',
+    'Linux', 'Darwin' => 'pgsql,pdo_pgsql',
+    'Windows' => 'pgsql,pdo_pgsql',
 };
 
 // If you want to test lib-suggests feature with extension, add them below (comma separated, example `libwebp,libavif`).

--- a/src/globals/test-extensions.php
+++ b/src/globals/test-extensions.php
@@ -41,7 +41,7 @@ $prefer_pre_built = false;
 // If you want to test your added extensions and libs, add below (comma separated, example `bcmath,openssl`).
 $extensions = match (PHP_OS_FAMILY) {
     'Linux', 'Darwin' => 'gd',
-    'Windows' => 'bz2,ctype,curl,dom,filter,gd,iconv,mbstring,opcache,openssl,pdo,pdo_sqlite,phar,session,simplexml,sqlite3,tokenizer,xml,xmlwriter,yaml,zip,zlib',
+    'Windows' => 'bz2,ctype,curl,dom,filter,gd,iconv,mbstring,opcache,openssl,pdo,pdo_pgsql,pdo_sqlite,pgsql,phar,session,simplexml,sqlite3,tokenizer,xml,xmlwriter,yaml,zip,zlib',
 };
 
 // If you want to test lib-suggests feature with extension, add them below (comma separated, example `libwebp,libavif`).


### PR DESCRIPTION
## What does this PR do?
Added `pgsql` and `pdo_pgsql` extension for Windows. Waiting for answers in #664 before ready. Fix #664 

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [x] If you modified `*.php`, run `composer cs-fix` at local machine.
- [x] If it's an extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [ ] If you changed the behavior of static-php-cli, update docs in `./docs/`.
- [x] If you updated `config/xxx.json` content, run `bin/spc dev:sort-config xxx`.
