### PR TITLE
Fix windows ssl bug for curl

### DIFF
--- a/config/lib.json
+++ b/config/lib.json
@@ -78,7 +78,6 @@
             "zlib"
         ],
         "lib-depends-windows": [
-            "openssl",
             "zlib",
             "libssh2",
             "nghttp2"

--- a/src/SPC/ConsoleApplication.php
+++ b/src/SPC/ConsoleApplication.php
@@ -32,7 +32,7 @@ use Symfony\Component\Console\Application;
  */
 final class ConsoleApplication extends Application
 {
-    public const VERSION = '2.5.0';
+    public const VERSION = '2.5.1';
 
     public function __construct()
     {

--- a/src/SPC/builder/windows/library/curl.php
+++ b/src/SPC/builder/windows/library/curl.php
@@ -37,6 +37,8 @@ class curl extends WindowsLibraryBase
                 '-DBUILD_EXAMPLES=OFF ' . // disable examples
                 '-DUSE_LIBIDN2=OFF ' . // disable libidn2
                 '-DCURL_USE_LIBPSL=OFF ' . // disable libpsl
+                '-DCURL_USE_SCHANNEL=ON ' . // use Schannel instead of OpenSSL
+                '-DCURL_USE_OPENSSL=OFF ' . // disable openssl due to certificate issue
                 '-DCURL_ENABLE_SSL=ON ' .
                 '-DUSE_NGHTTP2=ON ' . // enable nghttp2
                 '-DCURL_USE_LIBSSH2=ON ' . // enable libssh2

--- a/src/globals/ext-tests/curl.php
+++ b/src/globals/ext-tests/curl.php
@@ -3,3 +3,16 @@
 declare(strict_types=1);
 
 assert(function_exists('curl_init'));
+assert(function_exists('curl_setopt'));
+assert(function_exists('curl_exec'));
+assert(function_exists('curl_close'));
+$curl_version = curl_version();
+if (stripos($curl_version['ssl_version'], 'schannel') !== false) {
+    $curl = curl_init();
+    curl_setopt($curl, CURLOPT_URL, 'https://example.com/');
+    curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+    curl_setopt($curl, CURLOPT_HEADER, 0);
+    $data = curl_exec($curl);
+    curl_close($curl);
+    assert($data !== false);
+}

--- a/src/globals/test-extensions.php
+++ b/src/globals/test-extensions.php
@@ -21,10 +21,10 @@ $test_php_version = [
 
 // test os (macos-13, macos-14, ubuntu-latest, windows-latest are available)
 $test_os = [
-    'macos-13',
-    'macos-14',
+    // 'macos-13',
+    // 'macos-14',
     'ubuntu-latest',
-    // 'windows-latest',
+    'windows-latest',
 ];
 
 // whether enable thread safe
@@ -41,20 +41,20 @@ $prefer_pre_built = false;
 // If you want to test your added extensions and libs, add below (comma separated, example `bcmath,openssl`).
 $extensions = match (PHP_OS_FAMILY) {
     'Linux', 'Darwin' => '',
-    'Windows' => 'bz2,ctype,curl,dom,filter,gd,iconv,mbstring,opcache,openssl,pdo,pdo_sqlite,phar,session,simplexml,sqlite3,tokenizer,xml,xmlwriter,yaml,zip,zlib',
+    'Windows' => 'mbstring,tokenizer,phar,curl,openssl',
 };
 
 // If you want to test lib-suggests feature with extension, add them below (comma separated, example `libwebp,libavif`).
 $with_libs = match (PHP_OS_FAMILY) {
-    'Linux', 'Darwin' => 'mimalloc',
-    'Windows' => 'libjpeg,libavif,freetype,libwebp',
+    'Linux', 'Darwin' => '',
+    'Windows' => '',
 };
 
 // Please change your test base combination. We recommend testing with `common`.
 // You can use `common`, `bulk`, `minimal` or `none`.
 // note: combination is only available for *nix platform. Windows must use `none` combination
 $base_combination = match (PHP_OS_FAMILY) {
-    'Linux', 'Darwin' => 'bulk',
+    'Linux', 'Darwin' => 'minimal',
     'Windows' => 'none',
 };
 


### PR DESCRIPTION
## What does this PR do?

- Fix #659
- Use Schannel instead of openssl for Windows curl

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [X] If you modified `*.php`, run `composer cs-fix` at local machine.
- [X] If it's an extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [ ] If you changed the behavior of static-php-cli, update docs in `./docs/`.
- [X] If you updated `config/xxx.json` content, run `bin/spc dev:sort-config xxx`.
