### PR TITLE
link libgomp statically on glibc

### DIFF
--- a/src/SPC/builder/extension/imagick.php
+++ b/src/SPC/builder/extension/imagick.php
@@ -21,7 +21,7 @@ class imagick extends Extension
             $extra_libs = trim($extra_libs . ' -lgomp');
         }
         if (getenv('SPC_LIBC') === 'glibc') {
-            $extra_libs = trim($extra_libs . ' -l:libgomp.a');
+            $extra_libs = trim($extra_libs . ' -l:libgomp.a -l:libgomp_nonshared.a');
         }
         f_putenv('SPC_EXTRA_LIBS=' . $extra_libs);
         return true;

--- a/src/SPC/builder/extension/imagick.php
+++ b/src/SPC/builder/extension/imagick.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace SPC\builder\extension;
 
 use SPC\builder\Extension;
-use SPC\builder\linux\LinuxBuilder;
 use SPC\util\CustomExt;
 
 #[CustomExt('imagick')]
@@ -13,10 +12,16 @@ class imagick extends Extension
 {
     public function patchBeforeMake(): bool
     {
+        if (PHP_OS_FAMILY !== 'Linux') {
+            return false;
+        }
         // imagick may call omp_pause_all which requires -lgomp
         $extra_libs = getenv('SPC_EXTRA_LIBS') ?: '';
-        if ($this->builder instanceof LinuxBuilder) {
-            $extra_libs .= (empty($extra_libs) ? '' : ' ') . '-lgomp ';
+        if (getenv('SPC_LIBC') === 'musl') {
+            $extra_libs = trim($extra_libs . ' -lgomp');
+        }
+        if (getenv('SPC_LIBC') === 'glibc') {
+            $extra_libs = trim($extra_libs . ' -l:libgomp.a');
         }
         f_putenv('SPC_EXTRA_LIBS=' . $extra_libs);
         return true;

--- a/src/SPC/builder/extension/imagick.php
+++ b/src/SPC/builder/extension/imagick.php
@@ -21,7 +21,13 @@ class imagick extends Extension
             $extra_libs = trim($extra_libs . ' -lgomp');
         }
         if (getenv('SPC_LIBC') === 'glibc') {
-            $extra_libs = trim($extra_libs . ' -l:libgomp.a -l:libgomp_nonshared.a');
+            $ld = f_exec('/usr/bin/gcc --print-file-name=libgomp.a', $output, $result_code);
+            if ($result_code !== 0) {
+                logger()->error('Cannot find libgomp.a, please install libgomp-dev');
+                $extra_libs = trim($extra_libs . ' -l:libgomp.a');
+            } else {
+                $extra_libs = trim($extra_libs . ' ' . $ld);
+            }
         }
         f_putenv('SPC_EXTRA_LIBS=' . $extra_libs);
         return true;

--- a/src/SPC/builder/extension/imagick.php
+++ b/src/SPC/builder/extension/imagick.php
@@ -21,13 +21,7 @@ class imagick extends Extension
             $extra_libs = trim($extra_libs . ' -lgomp');
         }
         if (getenv('SPC_LIBC') === 'glibc') {
-            $ld = f_exec('/usr/bin/gcc --print-file-name=libgomp.a', $output, $result_code);
-            if ($result_code !== 0) {
-                logger()->error('Cannot find libgomp.a, please install libgomp-dev');
-                $extra_libs = trim($extra_libs . ' -l:libgomp.a');
-            } else {
-                $extra_libs = trim($extra_libs . ' ' . $ld);
-            }
+            $extra_libs = trim($extra_libs . ' -l:libgomp.a');
         }
         f_putenv('SPC_EXTRA_LIBS=' . $extra_libs);
         return true;

--- a/src/SPC/builder/extension/imagick.php
+++ b/src/SPC/builder/extension/imagick.php
@@ -21,7 +21,7 @@ class imagick extends Extension
             $extra_libs = trim($extra_libs . ' -lgomp');
         }
         if (getenv('SPC_LIBC') === 'glibc') {
-            $extra_libs = trim($extra_libs . ' -l:libgomp.a');
+            $extra_libs = trim($extra_libs . ' /libgomp.a');
         }
         f_putenv('SPC_EXTRA_LIBS=' . $extra_libs);
         return true;

--- a/src/SPC/builder/unix/library/imagemagick.php
+++ b/src/SPC/builder/unix/library/imagemagick.php
@@ -18,8 +18,7 @@ trait imagemagick
      */
     protected function build(): void
     {
-        // TODO: imagemagick build with bzip2 failed with bugs, we need to fix it in the future
-        $extra = '--without-jxl --without-x --enable-openmp --without-bzlib ';
+        $extra = '--without-jxl --without-x --enable-openmp ';
         $required_libs = '';
         $optional_libs = [
             'libzip' => 'zip',
@@ -31,6 +30,7 @@ trait imagemagick
             'xz' => 'lzma',
             'zstd' => 'zstd',
             'freetype' => 'freetype',
+            'bzip2' => 'bzlib',
         ];
         foreach ($optional_libs as $lib => $option) {
             $extra .= $this->builder->getLib($lib) ? "--with-{$option} " : "--without-{$option} ";

--- a/src/SPC/util/SPCConfigUtil.php
+++ b/src/SPC/util/SPCConfigUtil.php
@@ -93,7 +93,13 @@ class SPCConfigUtil
         // patch: imagick (imagemagick wrapper) for linux needs -lgomp
         if (in_array('imagemagick', $libraries) && PHP_OS_FAMILY === 'Linux') {
             if (getenv('SPC_LIBC') === 'glibc') {
-                $short_name[] = '-l:libgomp.a -l:libgomp_nonshared.a';
+                $ld = f_exec('/usr/bin/gcc --print-file-name=libgomp.a', $output, $result_code);
+                if ($result_code !== 0) {
+                    // logger()->error('Cannot find libgomp.a, please install libgomp-dev');
+                    $short_name[] = '-l:libgomp.a';
+                } else {
+                    $short_name[] = $ld;
+                }
             } else {
                 $short_name[] = '-lgomp';
             }

--- a/src/SPC/util/SPCConfigUtil.php
+++ b/src/SPC/util/SPCConfigUtil.php
@@ -93,7 +93,7 @@ class SPCConfigUtil
         // patch: imagick (imagemagick wrapper) for linux needs -lgomp
         if (in_array('imagemagick', $libraries) && PHP_OS_FAMILY === 'Linux') {
             if (getenv('SPC_LIBC') === 'glibc') {
-                $short_name[] = '-l:libgomp.a';
+                $short_name[] = '-l:libgomp.a -l:libgomp_nonshared.a';
             } else {
                 $short_name[] = '-lgomp';
             }

--- a/src/SPC/util/SPCConfigUtil.php
+++ b/src/SPC/util/SPCConfigUtil.php
@@ -93,7 +93,7 @@ class SPCConfigUtil
         // patch: imagick (imagemagick wrapper) for linux needs -lgomp
         if (in_array('imagemagick', $libraries) && PHP_OS_FAMILY === 'Linux') {
             if (getenv('SPC_LIBC') === 'glibc') {
-                $short_name[] = '-l:libgomp.a -l:libgomp_nonshared.a';
+                $short_name[] = '/libgomp.a';
             } else {
                 $short_name[] = '-lgomp';
             }

--- a/src/SPC/util/SPCConfigUtil.php
+++ b/src/SPC/util/SPCConfigUtil.php
@@ -92,7 +92,11 @@ class SPCConfigUtil
         }
         // patch: imagick (imagemagick wrapper) for linux needs -lgomp
         if (in_array('imagemagick', $libraries) && PHP_OS_FAMILY === 'Linux') {
-            $short_name[] = '-lgomp';
+            if (getenv('SPC_LIBC') === 'glibc') {
+                $short_name[] = '-l:libgomp.a';
+            } else {
+                $short_name[] = '-lgomp';
+            }
         }
         return implode(' ', $short_name);
     }

--- a/src/SPC/util/SPCConfigUtil.php
+++ b/src/SPC/util/SPCConfigUtil.php
@@ -93,13 +93,7 @@ class SPCConfigUtil
         // patch: imagick (imagemagick wrapper) for linux needs -lgomp
         if (in_array('imagemagick', $libraries) && PHP_OS_FAMILY === 'Linux') {
             if (getenv('SPC_LIBC') === 'glibc') {
-                $ld = f_exec('/usr/bin/gcc --print-file-name=libgomp.a', $output, $result_code);
-                if ($result_code !== 0) {
-                    // logger()->error('Cannot find libgomp.a, please install libgomp-dev');
-                    $short_name[] = '-l:libgomp.a';
-                } else {
-                    $short_name[] = $ld;
-                }
+                $short_name[] = '-l:libgomp.a -l:libgomp_nonshared.a';
             } else {
                 $short_name[] = '-lgomp';
             }


### PR DESCRIPTION
## What does this PR do?


gcc linking against glibc tries to link everything dynamically by default. with -l:libgomp.a we force it to link gomp statically.