### PR TITLE
Vendor mode in a custom project, with custom extensions

### DIFF
--- a/src/SPC/ConsoleApplication.php
+++ b/src/SPC/ConsoleApplication.php
@@ -30,7 +30,7 @@ use Symfony\Component\Console\Application;
 /**
  * static-php-cli console app entry
  */
-final class ConsoleApplication extends Application
+class ConsoleApplication extends Application
 {
     public const VERSION = '2.5.1';
 

--- a/src/SPC/builder/unix/UnixBuilderBase.php
+++ b/src/SPC/builder/unix/UnixBuilderBase.php
@@ -50,7 +50,7 @@ abstract class UnixBuilderBase extends BuilderBase
                 array_unshift($libFiles, ...$lib->getStaticLibs());
             }
         }
-        return array_map(fn ($x) => realpath(BUILD_LIB_PATH . "/{$x}"), $libFiles);
+        return array_map(fn($x) => realpath(BUILD_LIB_PATH . "/{$x}"), $libFiles);
     }
 
     /**
@@ -98,6 +98,10 @@ abstract class UnixBuilderBase extends BuilderBase
             ROOT_DIR . '/src/SPC/builder/' . osfamily2dir() . '/library',
             'SPC\builder\\' . osfamily2dir() . '\library'
         );
+        $classes = array_merge($classes, FileSystem::getClassesPsr4(
+            WORKING_DIR . '/src/builder/' . osfamily2dir() . '/library',
+            'App\builder\\' . osfamily2dir() . '\library'
+        ));
         foreach ($classes as $class) {
             if (defined($class . '::NAME') && $class::NAME !== 'unknown' && Config::getLib($class::NAME) !== null) {
                 $support_lib_list[$class::NAME] = $class;

--- a/src/SPC/builder/windows/WindowsBuilder.php
+++ b/src/SPC/builder/windows/WindowsBuilder.php
@@ -110,18 +110,18 @@ class WindowsBuilder extends BuilderBase
         cmd()->cd(SOURCE_PATH . '\php-src')
             ->exec(
                 "{$this->sdk_prefix} configure.bat --task-args \"" .
-                '--disable-all ' .
-                '--disable-cgi ' .
-                '--with-php-build=' . BUILD_ROOT_PATH . ' ' .
-                '--with-extra-includes=' . BUILD_INCLUDE_PATH . ' ' .
-                '--with-extra-libs=' . BUILD_LIB_PATH . ' ' .
-                ($enableCli ? '--enable-cli=yes ' : '--enable-cli=no ') .
-                ($enableMicro ? ('--enable-micro=yes ' . $micro_logo . $micro_w32) : '--enable-micro=no ') .
-                ($enableEmbed ? '--enable-embed=yes ' : '--enable-embed=no ') .
-                $config_file_scan_dir .
-                "{$this->makeExtensionArgs()} " .
-                $zts .
-                '"'
+                    '--disable-all ' .
+                    '--disable-cgi ' .
+                    '--with-php-build=' . BUILD_ROOT_PATH . ' ' .
+                    '--with-extra-includes=' . BUILD_INCLUDE_PATH . ' ' .
+                    '--with-extra-libs=' . BUILD_LIB_PATH . ' ' .
+                    ($enableCli ? '--enable-cli=yes ' : '--enable-cli=no ') .
+                    ($enableMicro ? ('--enable-micro=yes ' . $micro_logo . $micro_w32) : '--enable-micro=no ') .
+                    ($enableEmbed ? '--enable-embed=yes ' : '--enable-embed=no ') .
+                    $config_file_scan_dir .
+                    "{$this->makeExtensionArgs()} " .
+                    $zts .
+                    '"'
             );
 
         SourcePatcher::patchBeforeMake($this);
@@ -223,6 +223,10 @@ class WindowsBuilder extends BuilderBase
             ROOT_DIR . '\src\SPC\builder\\' . osfamily2dir() . '\library',
             'SPC\builder\\' . osfamily2dir() . '\library'
         );
+        $classes = array_merge($classes, FileSystem::getClassesPsr4(
+            WORKING_DIR . '\src\builder\\' . osfamily2dir() . '\library',
+            'App\builder\\' . osfamily2dir() . '\library'
+        ));
         foreach ($classes as $class) {
             if (defined($class . '::NAME') && $class::NAME !== 'unknown' && Config::getLib($class::NAME) !== null) {
                 $support_lib_list[$class::NAME] = $class;

--- a/src/SPC/store/FileSystem.php
+++ b/src/SPC/store/FileSystem.php
@@ -24,16 +24,25 @@ class FileSystem
             WORKING_DIR . '/config/' . $config . '.json',
             ROOT_DIR . '/config/' . $config . '.json',
         ];
+
+        $all = [];
         foreach ($tries as $try) {
             if (file_exists($try)) {
                 $json = json_decode(self::readFile($try), true);
                 if (!is_array($json)) {
                     throw new FileSystemException('Reading ' . $try . ' failed');
                 }
-                return $json;
+                $all = array_merge($json, $all);
             }
         }
-        throw new FileSystemException('Reading ' . $config . '.json failed');
+
+        ksort($all);
+
+        if (count($all) === 0) {
+            throw new FileSystemException('Reading ' . $config . '.json failed');
+        }
+
+        return $all;
     }
 
     /**

--- a/src/SPC/util/CustomExt.php
+++ b/src/SPC/util/CustomExt.php
@@ -24,6 +24,7 @@ class CustomExt
     public static function loadCustomExt(): void
     {
         $classes = FileSystem::getClassesPsr4(ROOT_DIR . '/src/SPC/builder/extension', 'SPC\builder\extension');
+        $classes = array_merge($classes, FileSystem::getClassesPsr4(WORKING_DIR . '/src/builder/extension', 'App\builder\extension'));
         foreach ($classes as $class) {
             $reflection = new \ReflectionClass($class);
             foreach ($reflection->getAttributes(CustomExt::class) as $attribute) {


### PR DESCRIPTION
## What does this PR do?
Minor changes for allowing to use the library in a custom project instead of forking and adjusting code within the "project base".

Thread of the question can be found in #687.

Added the following options to adjust:
- Adding a custom command
- Allow for custom changes for `BuilderProvider` after initializing.
- By adding the following tree/namespace you can add custom extensions project-based without forking:

```bash
➜  poc-vendored-php-static-cli git:(main) tree --gitignore
.
├── bin
│   └── spc
├── composer.json
├── composer.lock
├── config
│   ├── ext.json
│   ├── lib.json
│   └── source.json
└── src
    ├── ConsoleApplication.php
    ├── MyCommand.php
    └── builder
        ├── extension
        │   └── snowflake.php
        ├── linux
        │   └── library
        │       └── snowflake.php
        ├── macos
        │   └── library
        │       └── snowflake.php
        └── unix
            └── library
                └── snowflake.php
```

Project example can be found here. In the example I have added `pdo_snowflake` extension, because I need it, and it gives a good example. 

Compling works, only the testing part fails at the moment due to PHP not using the `pdo_snowflake.so` file.

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [ ] If you modified `*.php`, run `composer cs-fix` at local machine.
- [ ] If it's an extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [ ] If you changed the behavior of static-php-cli, update docs in `./docs/`.
- [ ] If you updated `config/xxx.json` content, run `bin/spc dev:sort-config xxx`.
