### PR TITLE
mimalloc v2.2.3 is bugged on musl

### DIFF
--- a/config/source.json
+++ b/config/source.json
@@ -639,7 +639,7 @@
     "mimalloc": {
         "type": "ghtagtar",
         "repo": "microsoft/mimalloc",
-        "match": "v2.+",
+        "match": "v2.2.[^3].*",
         "provide-pre-built": false,
         "license": {
             "type": "file",


### PR DESCRIPTION
## What does this PR do?

locks the download version to 2.2.x (where x is not 3)