### PR TITLE
explicitly state libheif -> --with-heic

### DIFF
--- a/src/SPC/builder/unix/library/imagemagick.php
+++ b/src/SPC/builder/unix/library/imagemagick.php
@@ -28,6 +28,7 @@ trait imagemagick
             'libpng' => 'png',
             'libwebp' => 'webp',
             'libxml2' => 'xml',
+            'libheif' => 'heic',
             'zlib' => 'zlib',
             'xz' => 'lzma',
             'zstd' => 'zstd',


### PR DESCRIPTION
## What does this PR do?

explicitly states --with-heic when using libheif (still default)

Maybe we should make libheic optional though, to see how it plays out with:
https://github.com/dunglas/frankenphp/issues/1487