### PR TITLE
remove EXTENSION_DIR 

### DIFF
--- a/config/env.ini
+++ b/config/env.ini
@@ -43,14 +43,6 @@ SPC_CONCURRENCY=${CPU_COUNT}
 SPC_SKIP_PHP_VERSION_CHECK="no"
 ; Ignore some check item for bin/spc doctor command, comma separated (e.g. SPC_SKIP_DOCTOR_CHECK_ITEMS="if homebrew has installed")
 SPC_SKIP_DOCTOR_CHECK_ITEMS=""
-; EXTENSION_DIR where the built php will look for extension when a .ini instructs to load them
-; only useful for builds targeting not pure-static linking
-; default paths
-; Ubuntu/Debian: /usr/lib/php/{PHP_VERSION}/
-; RHEL: /usr/lib64/php/modules
-; Alpine: /usr/lib/php{PHP_VERSION}/modules
-; where {PHP_VERSION} is 84 for php 8.4
-EXTENSION_DIR=
 
 [windows]
 ; php-sdk-binary-tools path


### PR DESCRIPTION
by default, we already offer `--with-config-file-scan-dir`

## What does this PR do?

I just realized that the --with-config-file-scan-dir option *does* work, but only when EXTENSION_DIR environment variable is not set or set to empty. Hence we can get rid of the environment variable.

Props to php's build documentation to be majorly confusing about this aspect.