### PR TITLE
don't set EXTENSION_DIR by default

### DIFF
--- a/config/env.ini
+++ b/config/env.ini
@@ -50,7 +50,7 @@ SPC_SKIP_DOCTOR_CHECK_ITEMS=""
 ; RHEL: /usr/lib64/php/modules
 ; Alpine: /usr/lib/php{PHP_VERSION}/modules
 ; where {PHP_VERSION} is 84 for php 8.4
-EXTENSION_DIR=
+; EXTENSION_DIR=
 
 [windows]
 ; php-sdk-binary-tools path


### PR DESCRIPTION
## What does this PR do?

doesn't set the variable to an empty string by default, because it makes the build command look ugly:

![image](https://github.com/user-attachments/assets/2a546c80-3959-45eb-b0a8-e7024c82bf32)
