### PR TITLE
Allow CI build to be called by other worklows

### DIFF
--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -93,10 +93,6 @@ on:
         description: Keep debug symbols for debugging
         type: boolean
         default: false
-      vendor-mode:
-        description: Project is in vendor mode
-        type: boolean
-        default: false
 
 env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -198,13 +194,6 @@ jobs:
         with:
           path: downloads
           key: php-dependencies-${{ inputs.os }}
-
-      - if: ${{ inputs.vendor-mode }}
-        run: |
-          composer install --no-dev --classmap-authoritative
-          ls -la
-          ls -la bin/
-
       - name: "Download sources"
         run: ${{ needs.define-build.outputs.download }}
       - name: "Build PHP"

--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -60,23 +60,11 @@ on:
         description: Build target OS
         default: 'linux-x86_64'
         type: string
-        options:
-          - 'linux-x86_64'
-          - 'linux-aarch64'
-          - 'linux-x86_64-glibc'
-          - 'linux-aarch64-glibc'
-          - 'macos-x86_64'
-          - 'macos-aarch64'
       php-version:
         required: true
         description: PHP version to compile
         default: '8.4'
         type: string
-        options:
-          - '8.4'
-          - '8.3'
-          - '8.2'
-          - '8.1'
       extensions:
         description: Extensions to build (comma separated)
         required: true

--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -53,6 +53,58 @@ on:
         description: Keep debug symbols for debugging
         type: boolean
         default: false
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        description: Build target OS
+        default: 'linux-x86_64'
+        type: choice
+        options:
+          - 'linux-x86_64'
+          - 'linux-aarch64'
+          - 'linux-x86_64-glibc'
+          - 'linux-aarch64-glibc'
+          - 'macos-x86_64'
+          - 'macos-aarch64'
+      php-version:
+        required: true
+        description: PHP version to compile
+        default: '8.4'
+        type: choice
+        options:
+          - '8.4'
+          - '8.3'
+          - '8.2'
+          - '8.1'
+      extensions:
+        description: Extensions to build (comma separated)
+        required: true
+        type: string
+      extra-libs:
+        description: Extra libraries to build (optional, comma separated)
+        type: string
+      build-cli:
+        description: Build cli binary
+        default: true
+        type: boolean
+      build-micro:
+        description: Build phpmicro binary
+        type: boolean
+      build-fpm:
+        description: Build fpm binary
+        type: boolean
+      prefer-pre-built:
+        description: Prefer pre-built binaries (reduce build time)
+        type: boolean
+        default: true
+      debug:
+        description: Show full build logs
+        type: boolean
+      no-strip:
+        description: Keep debug symbols for debugging
+        type: boolean
+        default: false
 
 env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -200,7 +200,10 @@ jobs:
           key: php-dependencies-${{ inputs.os }}
 
       - if: ${{ inputs.vendor-mode }}
-        run: composer install --no-dev --classmap-authoritative
+        run: |
+          composer install --no-dev --classmap-authoritative
+          ls -la
+          ls -la bin/
 
       - name: "Download sources"
         run: ${{ needs.define-build.outputs.download }}

--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -113,9 +113,6 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v4
 
-      - if: ${{ inputs.vendor-mode }}
-        run: composer install --no-dev --classmap-authoritative
-
       - name: "Define"
         id: gendef
         run: |
@@ -201,6 +198,9 @@ jobs:
         with:
           path: downloads
           key: php-dependencies-${{ inputs.os }}
+
+      - if: ${{ inputs.vendor-mode }}
+        run: composer install --no-dev --classmap-authoritative
 
       - name: "Download sources"
         run: ${{ needs.define-build.outputs.download }}

--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -59,7 +59,7 @@ on:
         required: true
         description: Build target OS
         default: 'linux-x86_64'
-        type: choice
+        type: string
         options:
           - 'linux-x86_64'
           - 'linux-aarch64'
@@ -71,7 +71,7 @@ on:
         required: true
         description: PHP version to compile
         default: '8.4'
-        type: choice
+        type: string
         options:
           - '8.4'
           - '8.3'

--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -93,6 +93,10 @@ on:
         description: Keep debug symbols for debugging
         type: boolean
         default: false
+      vendor-mode:
+        description: Project is in vendor mode
+        type: boolean
+        default: false
 
 env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -108,6 +112,9 @@ jobs:
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4
+
+      - if: ${{ inputs.vendor-mode }}
+        run: composer install --no-dev --classmap-authoritative
 
       - name: "Define"
         id: gendef


### PR DESCRIPTION
## What does this PR do?

Allow the workflow to be called "programmically" from another workflow. 

This allows us to call the "job" within our main workflow pipeline in bundling all staps separately without copying and/or forking the project.

These changes are partially with changes #687.

Example usage:
```yaml
name: Build Production stack
on:
  workflow_dispatch:
    inputs:
      selectos:
        required: true
        description: Build target OS
        default: 'linux-x86_64'
        type: choice
        options:
          - 'linux-x86_64'
          - 'linux-aarch64'
          - 'linux-x86_64-glibc'
          - 'linux-aarch64-glibc'
          - 'macos-x86_64'
          - 'macos-aarch64'
      php-version:
        required: true
        description: PHP version to compile
        default: '8.4'
        type: choice
        options:
          - '8.4'
          - '8.3'
          - '8.2'
          - '8.1'
      create-docker:
        description: 'Create a docker image'
        type: boolean
        default: true

jobs:
  unix-static-build:
    uses: crazywhalecc/static-php-cli/.github/workflows/build-unix.yml@main
    with:
      os: ${{ inputs.selectos }}
      php-version: ${{ inputs.php-version }}
      extensions: 'odbc,pdo_odbc,bcmath,calendar,ctype,curl,dba,exif,fileinfo,filter,gd,intl,libxml,mbregex,mbstring,msgpack,mysqli,mysqlnd,opcache,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pdo_sqlsrv,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sodium,sqlite3,sqlsrv,tokenizer,xml,xmlreader,xmlwriter,zip,zlib'
  
  main-application:
    needs: unix-static-build
    ....
    
  create-docker-image:
    needs: [main-application, other-jobs]
    ....

```

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [x] If you modified `*.php`, run `composer cs-fix` at local machine.
- [x] If it's an extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [x] If you changed the behavior of static-php-cli, update docs in `./docs/`.
- [x] If you updated `config/xxx.json` content, run `bin/spc dev:sort-config xxx`.
