### PR TITLE
Add more PHPUnit tests

### DIFF
--- a/tests/SPC/GlobalDefinesTest.php
+++ b/tests/SPC/GlobalDefinesTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+class GlobalDefinesTest extends TestCase
+{
+    public function testGlobalDefines(): void
+    {
+        require __DIR__ . '/../../src/globals/defines.php';
+        $this->assertTrue(defined('WORKING_DIR'));
+    }
+
+    public function testInternalEnv(): void
+    {
+        require __DIR__ . '/../../src/globals/internal-env.php';
+        $this->assertTrue(defined('GNU_ARCH'));
+    }
+}

--- a/tests/SPC/GlobalFunctionsTest.php
+++ b/tests/SPC/GlobalFunctionsTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\Tests;
+
+use PHPUnit\Framework\TestCase;
+use SPC\exception\InterruptException;
+
+/**
+ * @internal
+ */
+class GlobalFunctionsTest extends TestCase
+{
+    public function testMatchPattern(): void
+    {
+        $this->assertEquals('abc', match_pattern('a*c', 'abc'));
+        $this->assertFalse(match_pattern('a*c', 'abcd'));
+    }
+
+    public function testFExec(): void
+    {
+        $this->assertEquals('abc', f_exec('echo abc', $out, $ret));
+        $this->assertEquals(0, $ret);
+        $this->assertEquals(['abc'], $out);
+    }
+
+    public function testPatchPointInterrupt(): void
+    {
+        $except = patch_point_interrupt(0);
+        $this->assertInstanceOf(InterruptException::class, $except);
+    }
+}

--- a/tests/SPC/util/ConfigValidatorTest.php
+++ b/tests/SPC/util/ConfigValidatorTest.php
@@ -137,6 +137,41 @@ class ConfigValidatorTest extends TestCase
         } catch (ValidationException) {
             $this->assertTrue(true);
         }
+        // lib.json is broken by not assoc array
+        try {
+            ConfigValidator::validateLibs(['lib1', 'lib2'], ['source1' => [], 'source2' => []]);
+            $this->fail('should throw ValidationException');
+        } catch (ValidationException) {
+            $this->assertTrue(true);
+        }
+        // lib.json lib is not one of "lib", "package", "root", "target"
+        try {
+            ConfigValidator::validateLibs(['lib1' => ['source' => 'source1', 'type' => 'not one of']], ['source1' => [], 'source2' => []]);
+            $this->fail('should throw ValidationException');
+        } catch (ValidationException) {
+            $this->assertTrue(true);
+        }
+        // lib.json lib if it is "lib" or "package", it must have "source"
+        try {
+            ConfigValidator::validateLibs(['lib1' => ['type' => 'lib']], ['source1' => [], 'source2' => []]);
+            $this->fail('should throw ValidationException');
+        } catch (ValidationException) {
+            $this->assertTrue(true);
+        }
+        // lib.json static-libs must be a list
+        try {
+            ConfigValidator::validateLibs(['lib1' => ['source' => 'source1', 'static-libs-windows' => 'not list']], ['source1' => [], 'source2' => []]);
+            $this->fail('should throw ValidationException');
+        } catch (ValidationException) {
+            $this->assertTrue(true);
+        }
+        // lib.json frameworks must be a list
+        try {
+            ConfigValidator::validateLibs(['lib1' => ['source' => 'source1', 'frameworks' => 'not list']], ['source1' => [], 'source2' => []]);
+            $this->fail('should throw ValidationException');
+        } catch (ValidationException) {
+            $this->assertTrue(true);
+        }
         // source must be string
         try {
             ConfigValidator::validateLibs(['lib1' => ['source' => true]], ['source1' => [], 'source2' => []]);
@@ -168,5 +203,12 @@ class ConfigValidatorTest extends TestCase
         ConfigValidator::validateExts([]);
         $this->expectException(ValidationException::class);
         ConfigValidator::validateExts(null);
+    }
+
+    public function testValidatePkgs(): void
+    {
+        ConfigValidator::validatePkgs([]);
+        $this->expectException(ValidationException::class);
+        ConfigValidator::validatePkgs(null);
     }
 }

--- a/tests/SPC/util/DependencyUtilTest.php
+++ b/tests/SPC/util/DependencyUtilTest.php
@@ -16,6 +16,12 @@ final class DependencyUtilTest extends TestCase
 {
     public function testGetExtLibsByDeps(): void
     {
+        // setup
+        $bak = [
+            'source' => Config::$source,
+            'lib' => Config::$lib,
+            'ext' => Config::$ext,
+        ];
         // example
         Config::$source = [
             'test1' => [
@@ -82,6 +88,10 @@ final class DependencyUtilTest extends TestCase
         $this->assertTrue($b < $a);
         $this->assertTrue($c < $a);
         $this->assertTrue($c < $b);
+        // restore
+        Config::$source = $bak['source'];
+        Config::$lib = $bak['lib'];
+        Config::$ext = $bak['ext'];
     }
 
     public function testNotExistExtException(): void

--- a/tests/SPC/util/LicenseDumperTest.php
+++ b/tests/SPC/util/LicenseDumperTest.php
@@ -33,6 +33,10 @@ final class LicenseDumperTest extends TestCase
 
     public function testDumpWithSingleLicense(): void
     {
+        $bak = [
+            'source' => Config::$source,
+            'lib' => Config::$lib,
+        ];
         Config::$lib = [
             'lib-base' => ['type' => 'root'],
             'php' => ['type' => 'root'],
@@ -54,10 +58,17 @@ final class LicenseDumperTest extends TestCase
         $dumper->dump(self::DIRECTORY);
 
         $this->assertFileExists(self::DIRECTORY . '/lib_fake_lib_0.txt');
+        // restore
+        Config::$source = $bak['source'];
+        Config::$lib = $bak['lib'];
     }
 
     public function testDumpWithMultipleLicenses(): void
     {
+        $bak = [
+            'source' => Config::$source,
+            'lib' => Config::$lib,
+        ];
         Config::$lib = [
             'lib-base' => ['type' => 'root'],
             'php' => ['type' => 'root'],
@@ -91,5 +102,9 @@ final class LicenseDumperTest extends TestCase
         $this->assertFileExists(self::DIRECTORY . '/lib_fake_lib_0.txt');
         $this->assertFileExists(self::DIRECTORY . '/lib_fake_lib_1.txt');
         $this->assertFileExists(self::DIRECTORY . '/lib_fake_lib_2.txt');
+
+        // restore
+        Config::$source = $bak['source'];
+        Config::$lib = $bak['lib'];
     }
 }

--- a/tests/SPC/util/SPCConfigUtilTest.php
+++ b/tests/SPC/util/SPCConfigUtilTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\Tests\util;
+
+use PHPUnit\Framework\TestCase;
+use SPC\builder\BuilderProvider;
+use SPC\exception\FileSystemException;
+use SPC\store\FileSystem;
+use SPC\util\SPCConfigUtil;
+use Symfony\Component\Console\Input\ArgvInput;
+
+/**
+ * @internal
+ */
+class SPCConfigUtilTest extends TestCase
+{
+    /**
+     * @throws FileSystemException
+     */
+    public static function setUpBeforeClass(): void
+    {
+        $testdir = WORKING_DIR . '/.configtest';
+        FileSystem::createDir($testdir);
+        FileSystem::writeFile($testdir . '/lib.json', file_get_contents(ROOT_DIR . '/config/lib.json'));
+        FileSystem::writeFile($testdir . '/ext.json', file_get_contents(ROOT_DIR . '/config/ext.json'));
+        FileSystem::writeFile($testdir . '/source.json', file_get_contents(ROOT_DIR . '/config/source.json'));
+        FileSystem::loadConfigArray('lib', $testdir);
+        FileSystem::loadConfigArray('ext', $testdir);
+        FileSystem::loadConfigArray('source', $testdir);
+    }
+
+    /**
+     * @throws FileSystemException
+     */
+    public static function tearDownAfterClass(): void
+    {
+        FileSystem::removeDir(WORKING_DIR . '/.configtest');
+    }
+
+    public function testConstruct(): void
+    {
+        $this->assertInstanceOf(SPCConfigUtil::class, new SPCConfigUtil());
+        $this->assertInstanceOf(SPCConfigUtil::class, new SPCConfigUtil(BuilderProvider::makeBuilderByInput(new ArgvInput())));
+    }
+
+    public function testConfig(): void
+    {
+        // normal
+        $result = (new SPCConfigUtil())->config(['bcmath']);
+        $this->assertStringContainsString(BUILD_ROOT_PATH . '/include', $result['cflags']);
+        $this->assertStringContainsString(BUILD_ROOT_PATH . '/lib', $result['ldflags']);
+        $this->assertStringContainsString('-lphp', $result['libs']);
+
+        // has cpp
+        $result = (new SPCConfigUtil())->config(['swoole']);
+        $this->assertStringContainsString(PHP_OS_FAMILY === 'Darwin' ? '-lc++' : '-lstdc++', $result['libs']);
+
+        // has mimalloc.o in lib dir
+        // backup first
+        if (file_exists(BUILD_LIB_PATH . '/mimalloc.o')) {
+            $bak = file_get_contents(BUILD_LIB_PATH . '/mimalloc.o');
+            @unlink(BUILD_LIB_PATH . '/mimalloc.o');
+        }
+        file_put_contents(BUILD_LIB_PATH . '/mimalloc.o', '');
+        $result = (new SPCConfigUtil())->config(['bcmath'], ['mimalloc']);
+        $this->assertStringStartsWith(BUILD_LIB_PATH . '/mimalloc.o', $result['libs']);
+        @unlink(BUILD_LIB_PATH . '/mimalloc.o');
+        if (isset($bak)) {
+            file_put_contents(BUILD_LIB_PATH . '/mimalloc.o', $bak);
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Add more PHPUnit tests for independent components.

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [X] If you modified `*.php`, run `composer cs-fix` at local machine.
- [ ] If it's an extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [ ] If you changed the behavior of static-php-cli, update docs in `./docs/`.
- [ ] If you updated `config/xxx.json` content, run `bin/spc dev:sort-config xxx`.
