### PR TITLE
rename SPC_RETRY_TIME to SPC_DOWNLOAD_RETRIES to clear up what it's doing sleep 5 seconds between retries

### DIFF
--- a/src/SPC/command/DownloadCommand.php
+++ b/src/SPC/command/DownloadCommand.php
@@ -134,7 +134,7 @@ class DownloadCommand extends BaseCommand
 
             // retry
             $retry = intval($this->getOption('retry'));
-            f_putenv('SPC_RETRY_TIME=' . $retry);
+            f_putenv('SPC_DOWNLOAD_RETRIES=' . $retry);
 
             // Use shallow-clone can reduce git resource download
             if ($this->getOption('shallow-clone')) {

--- a/src/SPC/command/SwitchPhpVersionCommand.php
+++ b/src/SPC/command/SwitchPhpVersionCommand.php
@@ -58,7 +58,7 @@ class SwitchPhpVersionCommand extends BaseCommand
 
         // retry
         $retry = intval($this->getOption('retry'));
-        f_putenv('SPC_RETRY_TIME=' . $retry);
+        f_putenv('SPC_DOWNLOAD_RETRIES=' . $retry);
 
         Downloader::downloadSource('php-src', Config::getSource('php-src'));
 

--- a/src/SPC/store/source/PhpSource.php
+++ b/src/SPC/store/source/PhpSource.php
@@ -34,7 +34,7 @@ class PhpSource extends CustomSourceBase
         // 查找最新的小版本号
         $info = json_decode(Downloader::curlExec(
             url: "https://www.php.net/releases/index.php?json&version={$major_version}",
-            retry: intval(getenv('SPC_RETRY_TIME') ? getenv('SPC_RETRY_TIME') : 0)
+            retries: intval(getenv('SPC_DOWNLOAD_RETRIES') ?: 0)
         ), true);
         if (!isset($info['version'])) {
             throw new DownloaderException("Version {$major_version} not found.");


### PR DESCRIPTION
## What does this PR do?



## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [ ] If you modified `*.php`, run `composer cs-fix` at local machine.
- [ ] If it's an extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [ ] If you changed the behavior of static-php-cli, update docs in `./docs/`.
- [ ] If you updated `config/xxx.json` content, run `bin/spc dev:sort-config xxx`.
