### PR TITLE
Fix pack lib command with wrong compression

### DIFF
--- a/src/SPC/command/dev/PackLibCommand.php
+++ b/src/SPC/command/dev/PackLibCommand.php
@@ -83,7 +83,7 @@ class PackLibCommand extends BuildCommand
                     $tar_option = $this->getTarOptionFromSuffix(Config::getPreBuilt('match-pattern'));
                     $filename = str_replace(array_keys($replace), array_values($replace), $filename);
                     $filename = WORKING_DIR . '/dist/' . $filename;
-                    f_passthru('tar ' . $tar_option . ' ' . $filename . ' -T ' . WORKING_DIR . '/packlib_files.txt');
+                    f_passthru("tar {$tar_option} {$filename} -T " . WORKING_DIR . '/packlib_files.txt');
                     logger()->info('Pack library ' . $lib->getName() . ' to ' . $filename . ' complete.');
                 }
             }


### PR DESCRIPTION
## What does this PR do?

The hosted pre-built content is using `.txz`, but real compression is `gzip`, wrongly archived by `-czf`.

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [X] If you modified `*.php`, run `composer cs-fix` at local machine.
- [ ] If it's an extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [ ] If you changed the behavior of static-php-cli, update docs in `./docs/`.
- [ ] If you updated `config/xxx.json` content, run `bin/spc dev:sort-config xxx`.
