### PR TITLE
fix attr and acl build without autogen.sh (if we don't download from git

### DIFF
--- a/src/SPC/builder/unix/library/attr.php
+++ b/src/SPC/builder/unix/library/attr.php
@@ -20,7 +20,7 @@ trait attr
                 'LIBS' => $this->getLibExtraLibs(),
             ])
             ->execWithEnv('libtoolize --force --copy')
-            ->execWithEnv('./autogen.sh')
+            ->execWithEnv('./autogen.sh || autoreconf -if')
             ->execWithEnv('./configure --prefix= --enable-static --disable-shared --with-pic --disable-nls')
             ->execWithEnv("make -j {$this->builder->concurrency}")
             ->exec('make install DESTDIR=' . BUILD_ROOT_PATH);

--- a/src/SPC/builder/unix/library/libacl.php
+++ b/src/SPC/builder/unix/library/libacl.php
@@ -36,7 +36,7 @@ trait libacl
                 'LIBS' => $this->getLibExtraLibs(),
             ])
             ->execWithEnv('libtoolize --force --copy')
-            ->execWithEnv('./autogen.sh')
+            ->execWithEnv('./autogen.sh || autoreconf -if')
             ->execWithEnv('./configure --prefix= --enable-static --disable-shared --disable-tests --disable-nls')
             ->execWithEnv("make -j {$this->builder->concurrency}")
             ->exec('make install DESTDIR=' . BUILD_ROOT_PATH);


### PR DESCRIPTION
## What does this PR do?
the tarballs don't contain a autogen.sh file. Fall through to autoreconf instead.

Fix #717