### PR TITLE
Fix windows xlswriter duplicate md5 symbol bug

### DIFF
--- a/src/SPC/builder/windows/SystemUtil.php
+++ b/src/SPC/builder/windows/SystemUtil.php
@@ -99,6 +99,9 @@ SET(CMAKE_EXE_LINKER_FLAGS "{$ldflags}")
 SET(CMAKE_FIND_ROOT_PATH "{$buildroot}")
 SET(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreaded)
 CMAKE;
+        if (!is_dir(SOURCE_PATH)) {
+            FileSystem::createDir(SOURCE_PATH);
+        }
         FileSystem::writeFile(SOURCE_PATH . '\toolchain.cmake', $toolchain);
         return realpath(SOURCE_PATH . '\toolchain.cmake');
     }

--- a/src/globals/patch/spc_fix_xlswriter_win32.patch
+++ b/src/globals/patch/spc_fix_xlswriter_win32.patch
@@ -1,0 +1,30 @@
+diff --git a/library/libxlsxwriter/third_party/md5/md5.c b/library/libxlsxwriter/third_party/md5/md5.c
+index b235e17..ce98e18 100644
+--- a/library/libxlsxwriter/third_party/md5/md5.c
++++ b/library/libxlsxwriter/third_party/md5/md5.c
+@@ -35,7 +35,11 @@
+  * compile-time configuration.
+  */
+ 
+-#ifndef HAVE_OPENSSL
++#ifdef PHP_WIN32
++#include "config.w32.h"
++#endif
++
++#ifndef HAVE_OPENSSL_EXT
+ 
+ #include <string.h>
+ 
+diff --git a/library/libxlsxwriter/third_party/md5/md5.h b/library/libxlsxwriter/third_party/md5/md5.h
+index 2da44bf..3cb0a98 100644
+--- a/library/libxlsxwriter/third_party/md5/md5.h
++++ b/library/libxlsxwriter/third_party/md5/md5.h
+@@ -23,7 +23,7 @@
+  * See md5.c for more information.
+  */
+ 
+-#ifdef HAVE_OPENSSL
++#ifdef HAVE_OPENSSL_EXT
+ #include <openssl/md5.h>
+ #elif !defined(_MD5_H)
+ #define _MD5_H

--- a/src/globals/test-extensions.php
+++ b/src/globals/test-extensions.php
@@ -46,7 +46,7 @@ $prefer_pre_built = false;
 // If you want to test your added extensions and libs, add below (comma separated, example `bcmath,openssl`).
 $extensions = match (PHP_OS_FAMILY) {
     'Linux', 'Darwin' => 'pgsql',
-    'Windows' => 'xlswriter',
+    'Windows' => 'xlswriter,openssl',
 };
 
 // If you want to test shared extensions, add them below (comma separated, example `bcmath,openssl`).


### PR DESCRIPTION
## What does this PR do?

Fix windows xlswriter duplicate md5 symbol bug, fixes #716 .

This also includes:

- Fix cmake toolchain missing source dir bug when calling makeCmakeToolchain individually
- Fix `SourcePatcher::patchFile`, add patch detection

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [X] If you modified `*.php`, run `composer cs-fix` at local machine.
- [X] If it's an extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
