### PR TITLE
Fix CraftCommand ignoring build-options during build

### DIFF
--- a/src/SPC/command/CraftCommand.php
+++ b/src/SPC/command/CraftCommand.php
@@ -79,20 +79,7 @@ class CraftCommand extends BaseCommand
                     $craft['download-options']['ignore-cache-sources'] .= ',php-src';
                 }
             }
-            $download_options = $craft['download-options'];
-            foreach ($download_options as $option => $val) {
-                if (is_bool($val) && $val || is_null($val)) {
-                    $args[] = "--{$option}";
-                } elseif (is_string($val)) {
-                    $args[] = "--{$option}={$val}";
-                } elseif (is_array($val)) {
-                    foreach ($val as $v) {
-                        if (is_string($v)) {
-                            $args[] = "--{$option}={$v}";
-                        }
-                    }
-                }
-            }
+            $this->optionsToArguments($craft['download-options'], $args);
             $retcode = $this->runCommand('download', ...$args);
             if ($retcode !== 0) {
                 $this->output->writeln('<error>craft download failed</error>');
@@ -104,6 +91,7 @@ class CraftCommand extends BaseCommand
         // craft build
         if ($craft['craft-options']['build']) {
             $args = [$extensions, "--with-libs={$libs}", ...array_map(fn ($x) => "--build-{$x}", $craft['sapi'])];
+            $this->optionsToArguments($craft['build-options'], $args);
             $retcode = $this->runCommand('build', ...$args);
             if ($retcode !== 0) {
                 $this->output->writeln('<error>craft build failed</error>');
@@ -163,5 +151,28 @@ class CraftCommand extends BaseCommand
         // $process->setTty(true);
         $process->run([$this, 'processLogCallback']);
         return $process->getExitCode();
+    }
+
+    private function optionsToArguments(array $options, array &$args): void
+    {
+        foreach ($options as $option => $val) {
+            if ((is_bool($val) && $val) || $val === null) {
+                $args[] = "--{$option}";
+
+                continue;
+            }
+            if (is_string($val)) {
+                $args[] = "--{$option}={$val}";
+
+                continue;
+            }
+            if (is_array($val)) {
+                foreach ($val as $v) {
+                    if (is_string($v)) {
+                        $args[] = "--{$option}={$v}";
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## What does this PR do?

At the moment, it's impossible to pass build-options when using `spc craft` (see #732). This PR fixes that, allowing the following use cases:

- boolean `true` values such as `--with-suggested-libs` are passed without parameters, assuming `InputOption::VALUE_NONE` behaviour.
- boolean `false` values (e.g. when setting `with-suggested-libs: false` in `yaml`) are omitted since Symfony console treats those values as opt-in only.
- array values are treated as "add this option multiple times". Tested with `with-hardcoded-ini`.
- everything else is passed as `--param=value`.

Works fine locally both with `spc` as well as `spc-alpine-docker`.

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [x] If you modified `*.php`, run `composer cs-fix` at local machine.
- [ ] If it's an extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [ ] If you changed the behavior of static-php-cli, update docs in `./docs/`.
- [ ] If you updated `config/xxx.json` content, run `bin/spc dev:sort-config xxx`.

Closes #732 