### PR TITLE
force curl to respect SSL_CERT_FILE

### DIFF
--- a/src/SPC/builder/unix/library/curl.php
+++ b/src/SPC/builder/unix/library/curl.php
@@ -18,7 +18,15 @@ trait curl
     {
         $extra = '';
         // lib:openssl
-        $extra .= $this->builder->getLib('openssl') ? '-DCURL_USE_OPENSSL=ON ' : '-DCURL_USE_OPENSSL=OFF -DCURL_ENABLE_SSL=OFF ';
+        if ($this->builder->getLib('openssl')) {
+            $extra .=
+                '-DCURL_USE_OPENSSL=ON ' .
+                '-DCURL_CA_BUNDLE=OFF ' .
+                '-DCURL_CA_PATH=OFF ' .
+                '-DCURL_CA_FALLBACK=ON ';
+        } else {
+            $extra .= '-DCURL_USE_OPENSSL=OFF -DCURL_ENABLE_SSL=OFF ';
+        }
         // lib:brotli
         $extra .= $this->builder->getLib('brotli') ? '-DCURL_BROTLI=ON ' : '-DCURL_BROTLI=OFF ';
         // lib:libssh2


### PR DESCRIPTION
## What does this PR do?

There has been a problem in recent versions where SSL_CERT_FILE, SSL_CERT_DIR and CURL_CA_BUNDLE are not respected.
Even though it's not documented, it seems like it's no longer possible to let openssl handle the location unless the paths are disabled in the curl build.

For what it's worth, it still finds the ca bundle even if the environment variables are not set, I believe due to openssl's logic around it.