### PR TITLE
-release (soname) compilation support for linux shared embed

### DIFF
--- a/config/env.ini
+++ b/config/env.ini
@@ -100,6 +100,8 @@ SPC_CMD_VAR_PHP_CONFIGURE_LIBS="-ldl -lpthread -lm"
 SPC_CMD_VAR_PHP_MAKE_EXTRA_CFLAGS="-g -fstack-protector-strong -fpic -fpie -Os -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -fno-ident -fPIE -fPIC"
 ; EXTRA_LIBS for `make` php
 SPC_CMD_VAR_PHP_MAKE_EXTRA_LIBS="-ldl -lpthread -lm"
+; EXTRA_LDFLAGS for `make` php, can use -release to set a soname for libphp.so
+SPC_CMD_VAR_PHP_MAKE_EXTRA_LDFLAGS=""
 ; EXTRA_LDFLAGS_PROGRAM for `make` php
 SPC_CMD_VAR_PHP_MAKE_EXTRA_LDFLAGS_PROGRAM="-all-static -Wl,-O1 -pie"
 

--- a/src/SPC/builder/linux/LinuxBuilder.php
+++ b/src/SPC/builder/linux/LinuxBuilder.php
@@ -311,6 +311,18 @@ class LinuxBuilder extends UnixBuilderBase
         shell()->cd(SOURCE_PATH . '/php-src')
             ->exec('sed -i "s|//lib|/lib|g" Makefile')
             ->exec(getenv('SPC_CMD_PREFIX_PHP_MAKE') . ' INSTALL_ROOT=' . BUILD_ROOT_PATH . " {$vars} install");
+
+        $ldflags = getenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_LDFLAGS');
+        if (preg_match('/-release\s+(\S+)/', $ldflags, $matches)) {
+            $release = $matches[1];
+            $realLibName = 'libphp-' . $release . '.so';
+            $realLib = BUILD_LIB_PATH . '/' . $realLibName;
+            rename(BUILD_LIB_PATH . '/libphp.so', $realLib);
+            $cwd = getcwd();
+            chdir(BUILD_LIB_PATH);
+            symlink($realLibName, 'libphp.so');
+            chdir($cwd);
+        }
         $this->patchPhpScripts();
     }
 
@@ -319,6 +331,7 @@ class LinuxBuilder extends UnixBuilderBase
         return [
             'EXTRA_CFLAGS' => getenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_CFLAGS'),
             'EXTRA_LIBS' => getenv('SPC_EXTRA_LIBS') . ' ' . getenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_LIBS'),
+            'EXTRA_LDFLAGS' => getenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_LDFLAGS'),
             'EXTRA_LDFLAGS_PROGRAM' => getenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_LDFLAGS_PROGRAM'),
         ];
     }


### PR DESCRIPTION
## What does this PR do?

add support for building libphp.so with soname for packaging

`EXTRA_LDFLAGS="-release zts-8.4"` builds libphp.so with soname `libphp-zts-8.4.so` and creates a symlink_:
`libphp.so` -> `libphp-zts-8.4.so`

applications can then link against libphp.so and end up with a link against libphp-zts-8.4.so.
