### PR TITLE
Add intl support for windows

### DIFF
--- a/config/ext.json
+++ b/config/ext.json
@@ -297,12 +297,14 @@
     },
     "intl": {
         "support": {
-            "Windows": "no",
             "BSD": "wip"
         },
         "type": "builtin",
-        "lib-depends": [
+        "lib-depends-unix": [
             "icu"
+        ],
+        "lib-depends-windows": [
+            "icu-static-win"
         ]
     },
     "ldap": {

--- a/config/lib.json
+++ b/config/lib.json
@@ -198,6 +198,18 @@
             "libicudata.a"
         ]
     },
+    "icu-static-win": {
+        "source": "icu-static-win",
+        "static-libs-windows": [
+            "icudt.lib",
+            "icuin.lib",
+            "icuio.lib",
+            "icuuc.lib"
+        ],
+        "headers-windows": [
+            "unicode"
+        ]
+    },
     "imagemagick": {
         "source": "imagemagick",
         "static-libs-unix": [

--- a/config/source.json
+++ b/config/source.json
@@ -312,6 +312,14 @@
             "path": "LICENSE"
         }
     },
+    "icu-static-win": {
+        "type": "url",
+        "url": "https://dl.static-php.dev/static-php-cli/deps/icu-static-windows-x64/icu-static-windows-x64.zip",
+        "license": {
+            "type": "text",
+            "text": "none"
+        }
+    },
     "igbinary": {
         "type": "url",
         "url": "https://pecl.php.net/get/igbinary",

--- a/src/SPC/builder/extension/intl.php
+++ b/src/SPC/builder/extension/intl.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SPC\builder\extension;
 
 use SPC\builder\Extension;
+use SPC\builder\windows\WindowsBuilder;
 use SPC\store\FileSystem;
 use SPC\util\CustomExt;
 
@@ -13,13 +14,21 @@ class intl extends Extension
 {
     public function patchBeforeBuildconf(): bool
     {
-        // TODO: remove the following line when https://github.com/php/php-src/pull/14002 will be released
-        FileSystem::replaceFileStr(SOURCE_PATH . '/php-src/ext/intl/config.m4', 'PHP_CXX_COMPILE_STDCXX(11', 'PHP_CXX_COMPILE_STDCXX(17');
-        // Also need to use clang++ -std=c++17 to force override the default C++ standard
-        if (is_string($env = getenv('CXX')) && !str_contains($env, 'std=c++17')) {
-            f_putenv('CXX=' . $env . ' -std=c++17');
+        if ($this->builder instanceof WindowsBuilder) {
+            FileSystem::replaceFileStr(
+                SOURCE_PATH . '/php-src/ext/intl/config.w32',
+                'EXTENSION("intl", "php_intl.c intl_convert.c intl_convertcpp.cpp intl_error.c ", true,',
+                'EXTENSION("intl", "php_intl.c intl_convert.c intl_convertcpp.cpp intl_error.c ", PHP_INTL_SHARED,'
+            );
         } else {
-            f_putenv('CXX=clang++ -std=c++17');
+            // TODO: remove the following line when https://github.com/php/php-src/pull/14002 will be released
+            FileSystem::replaceFileStr(SOURCE_PATH . '/php-src/ext/intl/config.m4', 'PHP_CXX_COMPILE_STDCXX(11', 'PHP_CXX_COMPILE_STDCXX(17');
+            // Also need to use clang++ -std=c++17 to force override the default C++ standard
+            if (is_string($env = getenv('CXX')) && !str_contains($env, 'std=c++17')) {
+                f_putenv('CXX=' . $env . ' -std=c++17');
+            } else {
+                f_putenv('CXX=clang++ -std=c++17');
+            }
         }
         return true;
     }

--- a/src/SPC/builder/windows/library/icu_static_win.php
+++ b/src/SPC/builder/windows/library/icu_static_win.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\windows\library;
+
+use SPC\store\FileSystem;
+
+class icu_static_win extends WindowsLibraryBase
+{
+    public const NAME = 'icu-static-win';
+
+    protected function build(): void
+    {
+        copy("{$this->source_dir}\\x64-windows-static\lib\icudt.lib", "{$this->getLibDir()}\icudt.lib");
+        copy("{$this->source_dir}\\x64-windows-static\lib\icuin.lib", "{$this->getLibDir()}\icuin.lib");
+        copy("{$this->source_dir}\\x64-windows-static\lib\icuio.lib", "{$this->getLibDir()}\icuio.lib");
+        copy("{$this->source_dir}\\x64-windows-static\lib\icuuc.lib", "{$this->getLibDir()}\icuuc.lib");
+
+        // create libpq folder in buildroot/includes/libpq
+        if (!file_exists("{$this->getIncludeDir()}\unicode")) {
+            mkdir("{$this->getIncludeDir()}\unicode");
+        }
+
+        FileSystem::copyDir("{$this->source_dir}\\x64-windows-static\include\unicode", "{$this->getIncludeDir()}\unicode");
+    }
+}

--- a/src/globals/test-extensions.php
+++ b/src/globals/test-extensions.php
@@ -21,15 +21,15 @@ $test_php_version = [
 
 // test os (macos-13, macos-14, macos-15, ubuntu-latest, windows-latest are available)
 $test_os = [
-    'macos-13',
+    // 'macos-13',
     // 'macos-14',
-    'macos-15',
-    'ubuntu-latest',
-    'ubuntu-22.04',
+    // 'macos-15',
+    // 'ubuntu-latest',
+    // 'ubuntu-22.04',
     // 'ubuntu-24.04',
-    'ubuntu-22.04-arm',
+    // 'ubuntu-22.04-arm',
     // 'ubuntu-24.04-arm',
-    // 'windows-latest',
+    'windows-latest',
 ];
 
 // whether enable thread safe
@@ -46,7 +46,7 @@ $prefer_pre_built = false;
 // If you want to test your added extensions and libs, add below (comma separated, example `bcmath,openssl`).
 $extensions = match (PHP_OS_FAMILY) {
     'Linux', 'Darwin' => 'curl',
-    'Windows' => 'xlswriter,openssl',
+    'Windows' => 'intl',
 };
 
 // If you want to test shared extensions, add them below (comma separated, example `bcmath,openssl`).
@@ -57,7 +57,7 @@ $shared_extensions = match (PHP_OS_FAMILY) {
 
 // If you want to test lib-suggests feature with extension, add them below (comma separated, example `libwebp,libavif`).
 $with_libs = match (PHP_OS_FAMILY) {
-    'Linux', 'Darwin' => 'brotli,curl,freetype,gmssl,libaom,libavif,libde265,libevent,libheif,libjpeg,librabbitmq,libssh2,libuuid,libuv,libwebp,libxml2,libyaml,libzip,mimalloc,snappy,tidy,zstd',
+    'Linux', 'Darwin' => '',
     'Windows' => '',
 };
 


### PR DESCRIPTION
## What does this PR do?

ICU is built using vcpkg from static-php-cli-hosted. Since vcpkg integration has not yet been implemented, use solution 1 to temporarily support intl extension.

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [X] If you modified `*.php`, run `composer cs-fix` at local machine.
- [X] If it's an extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [ ] If you changed the behavior of static-php-cli, update docs in `./docs/`.
- [X] If you updated `config/xxx.json` content, run `bin/spc dev:sort-config xxx`.
