### PR TITLE
remove incorrect space after --enable-yac

### DIFF
--- a/src/SPC/builder/extension/yac.php
+++ b/src/SPC/builder/extension/yac.php
@@ -21,6 +21,6 @@ class yac extends Extension
 
     public function getUnixConfigureArg(bool $shared = false): string
     {
-        return '--enable-yac ' . ($shared ? '=shared' : '') . ' --enable-igbinary --enable-json --with-system-fastlz';
+        return '--enable-yac' . ($shared ? '=shared' : '') . ' --enable-igbinary --enable-json --with-system-fastlz';
     }
 }


### PR DESCRIPTION
## What does this PR do?

fix shared build error for yac