### PR TITLE
rebuild shared extensions even if they already exist

### DIFF
--- a/src/SPC/builder/Extension.php
+++ b/src/SPC/builder/Extension.php
@@ -329,10 +329,6 @@ class Extension
     public function buildShared(): void
     {
         logger()->info('Building extension [' . $this->getName() . '] as shared extension (' . $this->getName() . '.so)');
-        if (file_exists(BUILD_MODULES_PATH . '/' . $this->getName() . '.so')) {
-            logger()->info('extension ' . $this->getName() . ' already built, skipping');
-            return;
-        }
         foreach ($this->dependencies as $dependency) {
             if (!$dependency instanceof Extension) {
                 continue;


### PR DESCRIPTION
## What does this PR do?

removes a build skip if an extension was already built