### PR TITLE
Add source hash comparator & refactor download lock

### DIFF
--- a/src/SPC/builder/LibraryBase.php
+++ b/src/SPC/builder/LibraryBase.php
@@ -51,7 +51,7 @@ abstract class LibraryBase
         // if source is locked as pre-built, we just tryInstall it
         $pre_built_name = Downloader::getPreBuiltLockName($source);
         if (isset($lock[$pre_built_name]) && ($lock[$pre_built_name]['lock_as'] ?? SPC_DOWNLOAD_SOURCE) === SPC_DOWNLOAD_PRE_BUILT) {
-            return $this->tryInstall($lock[$pre_built_name]['filename'], $force);
+            return $this->tryInstall($lock[$pre_built_name], $force);
         }
         return $this->tryBuild($force);
     }
@@ -166,14 +166,15 @@ abstract class LibraryBase
      * @throws WrongUsageException
      * @throws FileSystemException
      */
-    public function tryInstall(string $install_file, bool $force_install = false): int
+    public function tryInstall(array $lock, bool $force_install = false): int
     {
+        $install_file = $lock['filename'];
         if ($force_install) {
             logger()->info('Installing required library [' . static::NAME . '] from pre-built binaries');
 
             // Extract files
             try {
-                FileSystem::extractPackage($install_file, DOWNLOAD_PATH . '/' . $install_file, BUILD_ROOT_PATH);
+                FileSystem::extractPackage($install_file, $lock['source_type'], DOWNLOAD_PATH . '/' . $install_file, BUILD_ROOT_PATH);
                 $this->install();
                 return LIB_STATUS_OK;
             } catch (FileSystemException|RuntimeException $e) {
@@ -183,19 +184,19 @@ abstract class LibraryBase
         }
         foreach ($this->getStaticLibs() as $name) {
             if (!file_exists(BUILD_LIB_PATH . "/{$name}")) {
-                $this->tryInstall($install_file, true);
+                $this->tryInstall($lock, true);
                 return LIB_STATUS_OK;
             }
         }
         foreach ($this->getHeaders() as $name) {
             if (!file_exists(BUILD_INCLUDE_PATH . "/{$name}")) {
-                $this->tryInstall($install_file, true);
+                $this->tryInstall($lock, true);
                 return LIB_STATUS_OK;
             }
         }
         // pkg-config is treated specially. If it is pkg-config, check if the pkg-config binary exists
         if (static::NAME === 'pkg-config' && !file_exists(BUILD_ROOT_PATH . '/bin/pkg-config')) {
-            $this->tryInstall($install_file, true);
+            $this->tryInstall($lock, true);
             return LIB_STATUS_OK;
         }
         return LIB_STATUS_ALREADY;

--- a/src/SPC/command/DeleteDownloadCommand.php
+++ b/src/SPC/command/DeleteDownloadCommand.php
@@ -60,7 +60,7 @@ class DeleteDownloadCommand extends BaseCommand
 
             foreach ($deleted_sources as $lock_name) {
                 // remove download file/dir if exists
-                if ($lock[$lock_name]['source_type'] === 'archive') {
+                if ($lock[$lock_name]['source_type'] === SPC_SOURCE_ARCHIVE) {
                     if (file_exists($path = FileSystem::convertPath(DOWNLOAD_PATH . '/' . $lock[$lock_name]['filename']))) {
                         logger()->info('Deleting file ' . $path);
                         unlink($path);

--- a/src/SPC/doctor/item/LinuxMuslCheck.php
+++ b/src/SPC/doctor/item/LinuxMuslCheck.php
@@ -78,7 +78,7 @@ class LinuxMuslCheck
             ];
             logger()->info('Downloading ' . $musl_source['url']);
             Downloader::downloadSource($musl_version_name, $musl_source);
-            FileSystem::extractSource($musl_version_name, DOWNLOAD_PATH . "/{$musl_version_name}.tar.gz");
+            FileSystem::extractSource($musl_version_name, SPC_SOURCE_ARCHIVE, DOWNLOAD_PATH . "/{$musl_version_name}.tar.gz");
 
             // Apply CVE-2025-26519 patch
             SourcePatcher::patchFile('musl-1.2.5_CVE-2025-26519_0001.patch', SOURCE_PATH . "/{$musl_version_name}");

--- a/src/SPC/store/PackageManager.php
+++ b/src/SPC/store/PackageManager.php
@@ -34,9 +34,10 @@ class PackageManager
         Downloader::downloadPackage($pkg_name, $config, $force);
         // After download, read lock file name
         $lock = json_decode(FileSystem::readFile(DOWNLOAD_PATH . '/.lock.json'), true);
+        $source_type = $lock[$pkg_name]['source_type'];
         $filename = DOWNLOAD_PATH . '/' . ($lock[$pkg_name]['filename'] ?? $lock[$pkg_name]['dirname']);
         $extract = $lock[$pkg_name]['move_path'] === null ? (PKG_ROOT_PATH . '/' . $pkg_name) : $lock[$pkg_name]['move_path'];
-        FileSystem::extractPackage($pkg_name, $filename, $extract);
+        FileSystem::extractPackage($pkg_name, $source_type, $filename, $extract);
 
         // if contains extract-files, we just move this file to destination, and remove extract dir
         if (is_array($config['extract-files'] ?? null) && is_assoc_array($config['extract-files'])) {

--- a/src/globals/defines.php
+++ b/src/globals/defines.php
@@ -40,7 +40,7 @@ const SPC_EXTENSION_ALIAS = [
     'zendopcache' => 'opcache',
 ];
 
-// spc lock type
+// spc download lock type
 const SPC_DOWNLOAD_SOURCE = 1;      // lock source
 const SPC_DOWNLOAD_PRE_BUILT = 2;   // lock pre-built
 const SPC_DOWNLOAD_PACKAGE = 3; // lock as package
@@ -83,6 +83,11 @@ const AUTOCONF_CFLAGS = 2;
 const AUTOCONF_CPPFLAGS = 4;
 const AUTOCONF_LDFLAGS = 8;
 const AUTOCONF_ALL = 15;
+
+// spc download source type
+const SPC_SOURCE_ARCHIVE = 'archive'; // download as archive
+const SPC_SOURCE_GIT = 'git'; // download as git repository
+const SPC_SOURCE_LOCAL = 'local'; // download as local directory
 
 ConsoleLogger::$date_format = 'H:i:s';
 ConsoleLogger::$format = '[%date%] [%level_short%] %body%';

--- a/tests/SPC/store/DownloaderTest.php
+++ b/tests/SPC/store/DownloaderTest.php
@@ -57,7 +57,7 @@ class DownloaderTest extends TestCase
 
     public function testLockSource()
     {
-        Downloader::lockSource('fake-file', ['source_type' => 'archive', 'filename' => 'fake-file-name', 'move_path' => 'fake-path', 'lock_as' => 'fake-lock-as']);
+        Downloader::lockSource('fake-file', ['source_type' => SPC_SOURCE_ARCHIVE, 'filename' => 'fake-file-name', 'move_path' => 'fake-path', 'lock_as' => 'fake-lock-as']);
         $this->assertFileExists(DOWNLOAD_PATH . '/.lock.json');
         $json = json_decode(file_get_contents(DOWNLOAD_PATH . '/.lock.json'), true);
         $this->assertIsArray($json);
@@ -66,7 +66,7 @@ class DownloaderTest extends TestCase
         $this->assertArrayHasKey('filename', $json['fake-file']);
         $this->assertArrayHasKey('move_path', $json['fake-file']);
         $this->assertArrayHasKey('lock_as', $json['fake-file']);
-        $this->assertEquals('archive', $json['fake-file']['source_type']);
+        $this->assertEquals(SPC_SOURCE_ARCHIVE, $json['fake-file']['source_type']);
         $this->assertEquals('fake-file-name', $json['fake-file']['filename']);
         $this->assertEquals('fake-path', $json['fake-file']['move_path']);
         $this->assertEquals('fake-lock-as', $json['fake-file']['lock_as']);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,5 +2,7 @@
 
 declare(strict_types=1);
 
+putenv('SPC_IGNORE_BAD_HASH=yes');
+
 require_once __DIR__ . '/../src/globals/internal-env.php';
 require_once __DIR__ . '/mock/SPC_store.php';


### PR DESCRIPTION
## What does this PR do?

- Add download type `local`
- After downloading different version, extraction will be triggered if hash does not match
- Change `dir` type to `git`

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- [X] If you modified `*.php`, run `composer cs-fix` at local machine.
- [ ] If it's an extension or dependency update, make sure adding related extensions in `src/global/test-extensions.php`.
- [ ] If you changed the behavior of static-php-cli, update docs in `./docs/`.
- [ ] If you updated `config/xxx.json` content, run `bin/spc dev:sort-config xxx`.
