### PR TITLE
ah, the infamous arm64 bug with -fpic vs -fPIC

### DIFF
--- a/config/env.ini
+++ b/config/env.ini
@@ -68,8 +68,8 @@ CXX=${SPC_LINUX_DEFAULT_CXX}
 AR=${SPC_LINUX_DEFAULT_AR}
 LD=ld.gold
 ; default compiler flags, used in CMake toolchain file, openssl and pkg-config build
-SPC_DEFAULT_C_FLAGS="-fpic -Os"
-SPC_DEFAULT_CXX_FLAGS="-fpic -Os"
+SPC_DEFAULT_C_FLAGS="-fPIC -Os"
+SPC_DEFAULT_CXX_FLAGS="-fPIC -Os"
 ; extra libs for building php executable, used in `make` command for building php (this value may changed by extension build process, space separated)
 SPC_EXTRA_LIBS=
 ; upx executable path
@@ -89,7 +89,7 @@ SPC_CMD_VAR_PHP_EMBED_TYPE="static"
 
 ; *** default build vars for building php ***
 ; CFLAGS for configuring php
-SPC_CMD_VAR_PHP_CONFIGURE_CFLAGS="${SPC_DEFAULT_C_FLAGS} -fpie"
+SPC_CMD_VAR_PHP_CONFIGURE_CFLAGS="${SPC_DEFAULT_C_FLAGS} -fPIE"
 ; CPPFLAGS for configuring php
 SPC_CMD_VAR_PHP_CONFIGURE_CPPFLAGS="-I${BUILD_INCLUDE_PATH}"
 ; LDFLAGS for configuring php
@@ -97,7 +97,7 @@ SPC_CMD_VAR_PHP_CONFIGURE_LDFLAGS="-L${BUILD_LIB_PATH}"
 ; LIBS for configuring php
 SPC_CMD_VAR_PHP_CONFIGURE_LIBS="-ldl -lpthread -lm"
 ; EXTRA_CFLAGS for `make` php
-SPC_CMD_VAR_PHP_MAKE_EXTRA_CFLAGS="-g -fstack-protector-strong -fno-ident -fpie ${SPC_DEFAULT_C_FLAGS}"
+SPC_CMD_VAR_PHP_MAKE_EXTRA_CFLAGS="-g -fstack-protector-strong -fno-ident -fPIE ${SPC_DEFAULT_C_FLAGS}"
 ; EXTRA_LIBS for `make` php
 SPC_CMD_VAR_PHP_MAKE_EXTRA_LIBS="-ldl -lpthread -lm"
 ; EXTRA_LDFLAGS for `make` php, can use -release to set a soname for libphp.so


### PR DESCRIPTION
it's a bit slower, but oh well

## What does this PR do?

fixes a rare relocation limit bug on arm64 musl where too many GOT relocations are attempted for -fpic