### PR TITLE
protobuf and grpc don't conflict when they're built shared

### DIFF
--- a/src/SPC/builder/extension/protobuf.php
+++ b/src/SPC/builder/extension/protobuf.php
@@ -15,8 +15,9 @@ class protobuf extends Extension
         if ($this->builder->getPHPVersionID() < 80000 && getenv('SPC_SKIP_PHP_VERSION_CHECK') !== 'yes') {
             throw new \RuntimeException('The latest protobuf extension requires PHP 8.0 or later');
         }
+        $grpc = $this->builder->getExt('grpc');
         // protobuf conflicts with grpc
-        if ($this->builder->getExt('grpc') !== null) {
+        if ($grpc?->isBuildStatic()) {
             throw new \RuntimeException('protobuf conflicts with grpc, please remove grpc or protobuf extension');
         }
     }


### PR DESCRIPTION
## What does this PR do?

makes it possible to build protobuf and grpc as shared extensions in one go - since the shared library is built after php is built, and php doesn't contain grpc, we can build both modules