### PR TITLE
fix uv missing pthread_atfork in aarch64 centos 7

### DIFF
--- a/src/SPC/builder/Extension.php
+++ b/src/SPC/builder/Extension.php
@@ -400,7 +400,7 @@ class Extension
             ->exec(BUILD_BIN_PATH . '/phpize');
 
         if ($this->patchBeforeSharedConfigure()) {
-            logger()->info('ext [ . ' . $this->getName() . '] patching before shared configure');
+            logger()->info('ext [' . $this->getName() . '] patching before shared configure');
         }
 
         shell()->cd($this->source_dir)
@@ -419,7 +419,7 @@ class Extension
         );
 
         if ($this->patchBeforeSharedMake()) {
-            logger()->info('ext [ . ' . $this->getName() . '] patching before shared make');
+            logger()->info('ext [' . $this->getName() . '] patching before shared make');
         }
 
         shell()->cd($this->source_dir)

--- a/src/SPC/builder/Extension.php
+++ b/src/SPC/builder/Extension.php
@@ -193,7 +193,7 @@ class Extension
      * If you need to patch some code, overwrite this
      * return true if you patched something, false if not
      */
-    public function patchBeforeSharedBuild(): bool
+    public function patchBeforeSharedPhpize(): bool
     {
         return false;
     }
@@ -394,13 +394,17 @@ class Extension
             'LD_LIBRARY_PATH' => BUILD_LIB_PATH,
         ];
 
+        if ($this->patchBeforeSharedPhpize()) {
+            logger()->info("Extension [{$this->getName()}] patched before shared phpize");
+        }
+
         // prepare configure args
         shell()->cd($this->source_dir)
             ->setEnv($env)
             ->exec(BUILD_BIN_PATH . '/phpize');
 
         if ($this->patchBeforeSharedConfigure()) {
-            logger()->info('ext [' . $this->getName() . '] patching before shared configure');
+            logger()->info("Extension [{$this->getName()}] patched before shared configure");
         }
 
         shell()->cd($this->source_dir)
@@ -419,7 +423,7 @@ class Extension
         );
 
         if ($this->patchBeforeSharedMake()) {
-            logger()->info('ext [' . $this->getName() . '] patching before shared make');
+            logger()->info("Extension [{$this->getName()}] patched before shared make");
         }
 
         shell()->cd($this->source_dir)

--- a/src/SPC/builder/Extension.php
+++ b/src/SPC/builder/Extension.php
@@ -209,6 +209,16 @@ class Extension
     }
 
     /**
+     * Patch code before shared extension make
+     * If you need to patch some code, overwrite this
+     * return true if you patched something, false if not
+     */
+    public function patchBeforeSharedMake(): bool
+    {
+        return false;
+    }
+
+    /**
      * @return string
      *                returns a command line string with all required shared extensions to load
      *                i.e.; pdo_pgsql would return:
@@ -407,6 +417,10 @@ class Extension
             '/^(.*_SHARED_LIBADD\s*=.*)$/m',
             '$1 ' . $staticLibString
         );
+
+        if ($this->patchBeforeSharedMake()) {
+            logger()->info('ext [ . ' . $this->getName() . '] patching before shared make');
+        }
 
         shell()->cd($this->source_dir)
             ->setEnv($env)

--- a/src/SPC/builder/extension/intl.php
+++ b/src/SPC/builder/extension/intl.php
@@ -22,7 +22,7 @@ class intl extends Extension
         return true;
     }
 
-    public function patchBeforeSharedBuild(): bool
+    public function patchBeforeSharedPhpize(): bool
     {
         return $this->patchBeforeBuildconf();
     }

--- a/src/SPC/builder/extension/uv.php
+++ b/src/SPC/builder/extension/uv.php
@@ -21,7 +21,7 @@ class uv extends Extension
 
     public function patchBeforeSharedMake(): bool
     {
-        if (SystemUtil::getLibcVersionIfExists() >= '2.17') {
+        if (PHP_OS_FAMILY !== 'Linux' || php_uname('m') !== 'aarch64' || SystemUtil::getLibcVersionIfExists() > '2.17') {
             return false;
         }
         FileSystem::replaceFileRegex($this->source_dir . '/Makefile', '/^(LDFLAGS =.*)$/', '$1 -luv -ldl -lrt -pthread');

--- a/src/SPC/builder/extension/uv.php
+++ b/src/SPC/builder/extension/uv.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace SPC\builder\extension;
 
 use SPC\builder\Extension;
+use SPC\builder\linux\SystemUtil;
+use SPC\store\FileSystem;
 use SPC\util\CustomExt;
 
 #[CustomExt('uv')]
@@ -17,10 +19,12 @@ class uv extends Extension
         }
     }
 
-    public function getStaticAndSharedLibs(): array
+    public function patchBeforeSharedMake(): bool
     {
-        [$static, $shared] = parent::getStaticAndSharedLibs();
-        $shared .= ' -lpthread';
-        return [$static, $shared];
+        if (SystemUtil::getLibcVersionIfExists() >= '2.17') {
+            return false;
+        }
+        FileSystem::replaceFileRegex($this->source_dir . '/Makefile', '/^(LDFLAGS =.*)$/', '$1 -luv -ldl -lrt -pthread');
+        return true;
     }
 }

--- a/src/SPC/builder/extension/uv.php
+++ b/src/SPC/builder/extension/uv.php
@@ -16,4 +16,11 @@ class uv extends Extension
             throw new \RuntimeException('The latest uv extension requires PHP 8.0 or later');
         }
     }
+
+    public function getStaticAndSharedLibs(): array
+    {
+        [$static, $shared] = parent::getStaticAndSharedLibs();
+        $shared .= ' -lpthread';
+        return [$static, $shared];
+    }
 }

--- a/src/SPC/builder/extension/uv.php
+++ b/src/SPC/builder/extension/uv.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace SPC\builder\extension;
 
 use SPC\builder\Extension;
-use SPC\builder\linux\SystemUtil;
 use SPC\store\FileSystem;
 use SPC\util\CustomExt;
 
@@ -21,7 +20,7 @@ class uv extends Extension
 
     public function patchBeforeSharedMake(): bool
     {
-        if (PHP_OS_FAMILY !== 'Linux' || GNU_ARCH !== 'aarch64') {
+        if (PHP_OS_FAMILY !== 'Linux' || arch2gnu(php_uname('m')) !== 'aarch64') {
             return false;
         }
         FileSystem::replaceFileRegex($this->source_dir . '/Makefile', '/^(LDFLAGS =.*)$/m', '$1 -luv -ldl -lrt -pthread');

--- a/src/SPC/builder/extension/uv.php
+++ b/src/SPC/builder/extension/uv.php
@@ -21,10 +21,10 @@ class uv extends Extension
 
     public function patchBeforeSharedMake(): bool
     {
-        if (PHP_OS_FAMILY !== 'Linux' || php_uname('m') !== 'aarch64' || SystemUtil::getLibcVersionIfExists() > '2.17') {
+        if (PHP_OS_FAMILY !== 'Linux' || GNU_ARCH !== 'aarch64') {
             return false;
         }
-        FileSystem::replaceFileRegex($this->source_dir . '/Makefile', '/^(LDFLAGS =.*)$/', '$1 -luv -ldl -lrt -pthread');
+        FileSystem::replaceFileRegex($this->source_dir . '/Makefile', '/^(LDFLAGS =.*)$/m', '$1 -luv -ldl -lrt -pthread');
         return true;
     }
 }

--- a/src/SPC/command/BuildPHPCommand.php
+++ b/src/SPC/command/BuildPHPCommand.php
@@ -207,8 +207,6 @@ class BuildPHPCommand extends BuildCommand
             // start to build
             $builder->buildPHP($rule);
 
-            SourcePatcher::patchBeforeSharedBuild($builder);
-
             // build dynamic extensions if needed
             if (!empty($shared_extensions)) {
                 logger()->info('Building shared extensions ...');

--- a/src/SPC/doctor/item/LinuxToolCheckList.php
+++ b/src/SPC/doctor/item/LinuxToolCheckList.php
@@ -61,8 +61,7 @@ class LinuxToolCheckList
 
         $required = match ($distro['dist']) {
             'alpine' => self::TOOLS_ALPINE,
-            'redhat' => self::TOOLS_RHEL,
-            'centos' => array_merge(self::TOOLS_RHEL, ['perl-IPC-Cmd']),
+            'redhat', 'centos' => self::TOOLS_RHEL,
             'arch' => self::TOOLS_ARCH,
             default => self::TOOLS_DEBIAN,
         };

--- a/src/SPC/store/SourcePatcher.php
+++ b/src/SPC/store/SourcePatcher.php
@@ -46,12 +46,12 @@ class SourcePatcher
     {
         foreach ($builder->getExts() as $ext) {
             if ($ext->patchBeforeBuildconf() === true) {
-                logger()->info('Extension [' . $ext->getName() . '] patched before buildconf');
+                logger()->info("Extension [{$ext->getName()}] patched before buildconf");
             }
         }
         foreach ($builder->getLibs() as $lib) {
             if ($lib->patchBeforeBuildconf() === true) {
-                logger()->info('Library [' . $lib->getName() . '] patched before buildconf');
+                logger()->info("Library [{$lib->getName()}]patched before buildconf");
             }
         }
         // patch windows php 8.1 bug
@@ -79,15 +79,6 @@ class SourcePatcher
         }
     }
 
-    public static function patchBeforeSharedBuild(BuilderBase $builder): void
-    {
-        foreach ($builder->getExts() as $ext) {
-            if ($ext->patchBeforeSharedBuild() === true) {
-                logger()->info('Extension [' . $ext->getName() . '] patched before shared build');
-            }
-        }
-    }
-
     /**
      * Source patcher runner before configure
      *
@@ -98,12 +89,12 @@ class SourcePatcher
     {
         foreach ($builder->getExts() as $ext) {
             if ($ext->patchBeforeConfigure() === true) {
-                logger()->info('Extension [' . $ext->getName() . '] patched before configure');
+                logger()->info("Extension [{$ext->getName()}] patched before configure");
             }
         }
         foreach ($builder->getLibs() as $lib) {
             if ($lib->patchBeforeConfigure() === true) {
-                logger()->info('Library [' . $lib->getName() . '] patched before configure');
+                logger()->info("Library [{$lib->getName()}] patched before configure");
             }
         }
         // patch capstone
@@ -279,12 +270,12 @@ class SourcePatcher
         // call extension patch before make
         foreach ($builder->getExts(false) as $ext) {
             if ($ext->patchBeforeMake() === true) {
-                logger()->info('Extension [' . $ext->getName() . '] patched before make');
+                logger()->info("Extension [{$ext->getName()}] patched before make");
             }
         }
         foreach ($builder->getLibs() as $lib) {
             if ($lib->patchBeforeMake() === true) {
-                logger()->info('Library [' . $lib->getName() . '] patched before make');
+                logger()->info("Library [{$lib->getName()}] patched before make");
             }
         }
     }

--- a/src/globals/test-extensions.php
+++ b/src/globals/test-extensions.php
@@ -21,19 +21,19 @@ $test_php_version = [
 
 // test os (macos-13, macos-14, macos-15, ubuntu-latest, windows-latest are available)
 $test_os = [
-    'macos-13',
+    // 'macos-13',
     // 'macos-14',
-    'macos-15',
+    // 'macos-15',
     // 'ubuntu-latest',
     // 'ubuntu-22.04',
     // 'ubuntu-24.04',
-    // 'ubuntu-22.04-arm',
+    'ubuntu-22.04-arm',
     // 'ubuntu-24.04-arm',
     // 'windows-latest',
 ];
 
 // whether enable thread safe
-$zts = false;
+$zts = true;
 
 $no_strip = false;
 
@@ -54,13 +54,13 @@ $extensions = match (PHP_OS_FAMILY) {
 
 // If you want to test shared extensions, add them below (comma separated, example `bcmath,openssl`).
 $shared_extensions = match (PHP_OS_FAMILY) {
-    'Linux' => '',
+    'Linux' => 'uv',
     'Darwin' => '',
     'Windows' => '',
 };
 
 // If you want to test lib-suggests for all extensions and libraries, set it to true.
-$with_suggested_libs = true;
+$with_suggested_libs = false;
 
 // If you want to test extra libs for extensions, add them below (comma separated, example `libwebp,libavif`). Unnecessary, when $with_suggested_libs is true.
 $with_libs = match (PHP_OS_FAMILY) {


### PR DESCRIPTION
## What does this PR do?

uv needs to explicitly link -lpthread on centos 7 aarch64, fails to pthread_atfork unresolved otherwise. It's a symbols that's in the static library, but not in the shared library

not sure if this fixes it yet, still testing:

https://github.com/scipy/scipy/issues/11323