### PR TITLE
don't rebuild depended on shared extensions

### DIFF
--- a/src/SPC/builder/Extension.php
+++ b/src/SPC/builder/Extension.php
@@ -342,6 +342,9 @@ class Extension
                 return;
             }
         }
+        if (file_exists(BUILD_MODULES_PATH . '/' . $this->getName() . '.so')) {
+            logger()->info('Shared extension [' . $this->getName() . '] was already built, skipping (' . $this->getName() . '.so)');
+        }
         logger()->info('Building extension [' . $this->getName() . '] as shared extension (' . $this->getName() . '.so)');
         foreach ($this->dependencies as $dependency) {
             if (!$dependency instanceof Extension) {


### PR DESCRIPTION
since we explicitly delete module folder before building, we should reintroduce this check

otherwise shared extensions that other shared extensions depend on will be built multiple times
