### PR TITLE
Revert build-embed option as boolean

### DIFF
--- a/src/SPC/command/BuildPHPCommand.php
+++ b/src/SPC/command/BuildPHPCommand.php
@@ -31,7 +31,7 @@ class BuildPHPCommand extends BuildCommand
         $this->addOption('build-micro', null, null, 'Build micro SAPI');
         $this->addOption('build-cli', null, null, 'Build cli SAPI');
         $this->addOption('build-fpm', null, null, 'Build fpm SAPI (not available on Windows)');
-        $this->addOption('build-embed', null, InputOption::VALUE_OPTIONAL, 'Build embed SAPI (not available on Windows)');
+        $this->addOption('build-embed', null, null, 'Build embed SAPI (not available on Windows)');
         $this->addOption('build-frankenphp', null, null, 'Build FrankenPHP SAPI (not available on Windows)');
         $this->addOption('build-all', null, null, 'Build all SAPI');
         $this->addOption('no-strip', null, null, 'build without strip, keep symbols to debug');
@@ -289,18 +289,7 @@ class BuildPHPCommand extends BuildCommand
         $rule |= ($this->getOption('build-cli') ? BUILD_TARGET_CLI : BUILD_TARGET_NONE);
         $rule |= ($this->getOption('build-micro') ? BUILD_TARGET_MICRO : BUILD_TARGET_NONE);
         $rule |= ($this->getOption('build-fpm') ? BUILD_TARGET_FPM : BUILD_TARGET_NONE);
-        $embed = $this->getOption('build-embed');
-        $embed = match ($embed) {
-            null => getenv('SPC_CMD_VAR_PHP_EMBED_TYPE') ?: 'static',
-            'static' => 'static',
-            'shared' => 'shared',
-            false => false,
-            default => throw new WrongUsageException('Invalid --build-embed option, please use --build-embed[=static|shared]'),
-        };
-        if ($embed) {
-            $rule |= BUILD_TARGET_EMBED;
-            f_putenv('SPC_CMD_VAR_PHP_EMBED_TYPE=' . ($embed === 'static' ? 'static' : 'shared'));
-        }
+        $rule |= $this->getOption('build-embed') || !empty($shared_extensions) ? BUILD_TARGET_EMBED : BUILD_TARGET_NONE;
         $rule |= ($this->getOption('build-frankenphp') ? (BUILD_TARGET_FRANKENPHP | BUILD_TARGET_EMBED) : BUILD_TARGET_NONE);
         $rule |= ($this->getOption('build-all') ? BUILD_TARGET_ALL : BUILD_TARGET_NONE);
         return $rule;


### PR DESCRIPTION
## What does this PR do?

Revert build-embed option as boolean. Related: https://github.com/php/frankenphp/pull/1651#issuecomment-2988744303

This should not be a bug, but this would be misleading. Although docopt requires options to support space reading, it will cause some confusion according to our habits, especially in other SAPIs `--build-XXX` does not accept values.

But I think it is acceptable to use another option to override the default environment variable (such as `--with-embed-type=shared`, if you still feel it is necessary to override it with the command.

Otherwise, we consider it a bad practice to encourage others to put all parameters after the extensions.

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- If you modified `*.php` or `*.json`, run them locally to ensure your changes are valid:
  - [ ] `PHP_CS_FIXER_IGNORE_ENV=1 composer cs-fix`
  - [ ] `composer analyse`
  - [ ] `composer test`
  - [ ] `bin/spc dev:sort-config`
- If it's an extension or dependency update, please ensure the following:
  - [ ] Add your test combination to `src/globals/test-extensions.php`.
  - [ ] If adding new or fixing bugs, add commit message containing `extension test` or `test extensions` to trigger full test suite.
