### PR TITLE
Fix alpine-docker build in different arch issue

### DIFF
--- a/bin/spc-alpine-docker
+++ b/bin/spc-alpine-docker
@@ -1,12 +1,14 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
+
+set -e
 
 # This file is using docker to run commands
-SPC_DOCKER_VERSION=v3
+SPC_DOCKER_VERSION=v4
 
 # Detect docker can run
 if ! which docker >/dev/null; then
-  echo "Docker is not installed, please install docker first !"
-  exit 1
+    echo "Docker is not installed, please install docker first !"
+    exit 1
 fi
 DOCKER_EXECUTABLE="docker"
 # shellcheck disable=SC2046
@@ -22,27 +24,48 @@ if [ $(id -u) -ne 0 ]; then
     fi
 fi
 
-
-
-# to check if qemu-docker run
-if [ "$SPC_USE_ARCH" = "" ]; then
-    SPC_USE_ARCH=x86_64
+# Convert uname to gnu arch
+CURRENT_ARCH=$(uname -m)
+if [ "$CURRENT_ARCH" = "arm64" ]; then
+    CURRENT_ARCH=aarch64
 fi
+if [ -z "$SPC_USE_ARCH" ]; then
+    SPC_USE_ARCH=$CURRENT_ARCH
+fi
+# parse SPC_USE_ARCH
 case $SPC_USE_ARCH in
-x86_64)
-    ALPINE_FROM=alpine:edge
+x86_64|amd64)
+    SPC_USE_ARCH=x86_64
+    if [ "$CURRENT_ARCH" != "x86_64" ]; then
+        PLATFORM_ARG="--platform linux/amd64"
+        ALPINE_FROM=multiarch/alpine:x86_64-edge
+    fi
     ;;
-aarch64)
-    ALPINE_FROM=multiarch/alpine:aarch64-edge
-    # shellcheck disable=SC2039
-    echo -e "\e[033m* Using different arch needs to setup qemu-static for docker !\e[0m"
-    $DOCKER_EXECUTABLE run --rm --privileged multiarch/qemu-user-static:register --reset > /dev/null
+aarch64|arm64)
+    SPC_USE_ARCH=aarch64
+    if [ "$CURRENT_ARCH" != "aarch64" ]; then
+        PLATFORM_ARG="--platform linux/arm64"
+        ALPINE_FROM=multiarch/alpine:aarch64-edge
+    fi
     ;;
 *)
     echo "Current arch is not supported to run in docker: $SPC_USE_ARCH"
     exit 1
     ;;
 esac
+# if ALPINE_FROM is not set, use alpine:edge
+if [ -z "$ALPINE_FROM" ]; then
+    ALPINE_FROM=alpine:edge
+fi
+if [ "$SPC_USE_ARCH" != "$CURRENT_ARCH" ]; then
+    echo "* Using different arch needs to setup qemu-static for docker !"
+    ALPINE_FROM=multiarch/alpine:$SPC_USE_ARCH-edge
+    if [ "$(uname -s)" = "Linux" ]; then
+        $DOCKER_EXECUTABLE run --rm --privileged multiarch/qemu-user-static:register --reset > /dev/null
+    fi
+else
+    ALPINE_FROM=alpine:edge
+fi
 
 if [ "$SPC_USE_MIRROR" = "yes" ]; then
     SPC_USE_MIRROR="RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories"
@@ -53,7 +76,7 @@ fi
 # Detect docker env is setup
 if ! $DOCKER_EXECUTABLE images | grep -q cwcc-spc-$SPC_USE_ARCH-$SPC_DOCKER_VERSION; then
     echo "Docker container does not exist. Building docker image ..."
-    $DOCKER_EXECUTABLE build -t cwcc-spc-$SPC_USE_ARCH-$SPC_DOCKER_VERSION -f- . <<EOF
+    $DOCKER_EXECUTABLE build $PLATFORM_ARG -t cwcc-spc-$SPC_USE_ARCH-$SPC_DOCKER_VERSION -f- . <<EOF
 FROM $ALPINE_FROM
 $SPC_USE_MIRROR
 RUN apk update; \
@@ -148,7 +171,7 @@ if [ "$SPC_DOCKER_DEBUG" = "yes" ]; then
     echo "*    ./pkgroot:   $(pwd)/pkgroot"
     echo "*"
     set -ex
-    $DOCKER_EXECUTABLE run --rm $INTERACT $ENV_LIST $MOUNT_LIST cwcc-spc-$SPC_USE_ARCH-$SPC_DOCKER_VERSION
+    $DOCKER_EXECUTABLE run $PLATFORM_ARG --rm $INTERACT $ENV_LIST $MOUNT_LIST cwcc-spc-$SPC_USE_ARCH-$SPC_DOCKER_VERSION /bin/bash
 else
-    $DOCKER_EXECUTABLE run --rm $INTERACT $ENV_LIST $MOUNT_LIST cwcc-spc-$SPC_USE_ARCH-$SPC_DOCKER_VERSION bin/spc $@
+    $DOCKER_EXECUTABLE run $PLATFORM_ARG --rm $INTERACT $ENV_LIST $MOUNT_LIST cwcc-spc-$SPC_USE_ARCH-$SPC_DOCKER_VERSION bin/spc $@
 fi

--- a/bin/spc-gnu-docker
+++ b/bin/spc-gnu-docker
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+set -e
+
+# This file is using docker to run commands
+SPC_DOCKER_VERSION=v4
+
 # Detect docker can run
 if ! which docker >/dev/null; then
   echo "Docker is not installed, please install docker first !"
@@ -19,35 +24,47 @@ if [ $(id -u) -ne 0 ]; then
     fi
 fi
 
-
-
-# to check if qemu-docker run
-if [ "$SPC_USE_ARCH" = "" ]; then
-    SPC_USE_ARCH=current
+# Convert uname to gnu arch
+CURRENT_ARCH=$(uname -m)
+if [ "$CURRENT_ARCH" = "arm64" ]; then
+    CURRENT_ARCH=aarch64
 fi
+if [ -z "$SPC_USE_ARCH" ]; then
+    SPC_USE_ARCH=$CURRENT_ARCH
+fi
+# parse SPC_USE_ARCH
 case $SPC_USE_ARCH in
-current)
-    BASE_ARCH=$(uname -m)
-    if [ "$BASE_ARCH" = "arm64" ]; then
-        BASE_ARCH=aarch64
+x86_64|amd64)
+    SPC_USE_ARCH=x86_64
+    SPC_USE_ARCH_DOCKER=amd64
+    if [ "$CURRENT_ARCH" != "x86_64" ]; then
+        PLATFORM_ARG="--platform linux/amd64"
     fi
     ;;
-aarch64)
-    BASE_ARCH=aarch64
-    # shellcheck disable=SC2039
-    echo -e "\e[033m* Using different arch needs to setup qemu-static for docker !\e[0m"
-    $DOCKER_EXECUTABLE run --rm --privileged multiarch/qemu-user-static:register --reset > /dev/null
+aarch64|arm64)
+    SPC_USE_ARCH=aarch64
+    SPC_USE_ARCH_DOCKER=arm64
+    if [ "$CURRENT_ARCH" != "aarch64" ]; then
+        PLATFORM_ARG="--platform linux/arm64"
+    fi
     ;;
 *)
     echo "Current arch is not supported to run in docker: $SPC_USE_ARCH"
     exit 1
     ;;
 esac
+# detect if we need to use qemu-static
+if [ "$SPC_USE_ARCH" != "$CURRENT_ARCH" ]; then
+    if [ "$(uname -s)" = "Linux" ]; then
+        echo "* Using different arch needs to setup qemu-static for docker !"
+        $DOCKER_EXECUTABLE run --rm --privileged multiarch/qemu-user-static --reset -p yes > /dev/null
+    fi
+fi
 
 # Detect docker env is setup
-if ! $DOCKER_EXECUTABLE images | grep -q cwcc-spc-gnu-$SPC_USE_ARCH; then
+if ! $DOCKER_EXECUTABLE images | grep -q cwcc-spc-gnu-$SPC_USE_ARCH-$SPC_DOCKER_VERSION; then
     echo "Docker container does not exist. Building docker image ..."
-    $DOCKER_EXECUTABLE build -t cwcc-spc-gnu-$SPC_USE_ARCH -f- . <<EOF
+    $DOCKER_EXECUTABLE buildx build $PLATFORM_ARG --no-cache -t cwcc-spc-gnu-$SPC_USE_ARCH-$SPC_DOCKER_VERSION -f- . <<EOF
 FROM centos:7
 RUN sed -i 's/mirror.centos.org/vault.centos.org/g' /etc/yum.repos.d/*.repo && \
     sed -i 's/^#.*baseurl=http/baseurl=http/g' /etc/yum.repos.d/*.repo && \
@@ -59,7 +76,7 @@ RUN yum clean all && \
 
 RUN yum install -y centos-release-scl
 
-RUN if [ "$BASE_ARCH" = "aarch64" ]; then \
+RUN if [ "$SPC_USE_ARCH" = "aarch64" ]; then \
         sed -i 's|mirror.centos.org/centos|vault.centos.org/altarch|g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo ; \
         sed -i 's|mirror.centos.org/centos|vault.centos.org/altarch|g' /etc/yum.repos.d/CentOS-SCLo-scl.repo ; \
     else \
@@ -74,12 +91,12 @@ RUN echo "source scl_source enable devtoolset-10" >> /etc/bashrc
 RUN source /etc/bashrc
 RUN yum install -y which
 
-RUN curl -fsSL -o patchelf.tgz https://github.com/NixOS/patchelf/releases/download/0.18.0/patchelf-0.18.0-$BASE_ARCH.tar.gz && \
+RUN curl -fsSL -o patchelf.tgz https://github.com/NixOS/patchelf/releases/download/0.18.0/patchelf-0.18.0-$SPC_USE_ARCH.tar.gz && \
     mkdir -p /patchelf && \
     tar -xzf patchelf.tgz -C /patchelf --strip-components=1 && \
     cp /patchelf/bin/patchelf /usr/bin/
 
-RUN curl -o cmake.tgz -fsSL https://github.com/Kitware/CMake/releases/download/v3.31.4/cmake-3.31.4-linux-$BASE_ARCH.tar.gz && \
+RUN curl -o cmake.tgz -fsSL https://github.com/Kitware/CMake/releases/download/v3.31.4/cmake-3.31.4-linux-$SPC_USE_ARCH.tar.gz && \
     mkdir /cmake && \
     tar -xzf cmake.tgz -C /cmake --strip-components 1
 
@@ -173,7 +190,7 @@ if [ "$SPC_DOCKER_DEBUG" = "yes" ]; then
     echo "*    ./pkgroot:   $(pwd)/pkgroot"
     echo "*"
     set -ex
-    $DOCKER_EXECUTABLE run --rm -it --privileged $INTERACT $ENV_LIST --env-file /tmp/spc-gnu-docker.env $MOUNT_LIST cwcc-spc-gnu-$SPC_USE_ARCH
+    $DOCKER_EXECUTABLE run $PLATFORM_ARG --privileged --rm -it $INTERACT $ENV_LIST --env-file /tmp/spc-gnu-docker.env $MOUNT_LIST cwcc-spc-gnu-$SPC_USE_ARCH-$SPC_DOCKER_VERSION /bin/bash
 else
-    $DOCKER_EXECUTABLE run --rm $INTERACT $ENV_LIST --env-file /tmp/spc-gnu-docker.env $MOUNT_LIST cwcc-spc-gnu-$SPC_USE_ARCH bin/spc $@
+    $DOCKER_EXECUTABLE run $PLATFORM_ARG --rm $INTERACT $ENV_LIST --env-file /tmp/spc-gnu-docker.env $MOUNT_LIST cwcc-spc-gnu-$SPC_USE_ARCH-$SPC_DOCKER_VERSION bin/spc $@
 fi


### PR DESCRIPTION
## What does this PR do?

Fix alpine-docker build in different arch issue.

For `spc-gnu-docker`, I need more time to implement. It's so weird that when I switch the arch (between host arch and emulated arch), docker will get segment fault (on mac) or /bin/sh not found(on linux) issue, unless removing all the docker things and re-install it. (prune not work)

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- If you modified `*.php` or `*.json`, run them locally to ensure your changes are valid:
  - [ ] `PHP_CS_FIXER_IGNORE_ENV=1 composer cs-fix`
  - [ ] `composer analyse`
  - [ ] `composer test`
  - [ ] `bin/spc dev:sort-config`
- If it's an extension or dependency update, please ensure the following:
  - [ ] Add your test combination to `src/globals/test-extensions.php`.
  - [ ] If adding new or fixing bugs, add commit message containing `extension test` or `test extensions` to trigger full test suite.
