### PR TITLE
Change the patch position for `-release` module suffix

### DIFF
--- a/src/SPC/builder/LibraryBase.php
+++ b/src/SPC/builder/LibraryBase.php
@@ -215,19 +215,6 @@ abstract class LibraryBase
      */
     public function tryBuild(bool $force_build = false): int
     {
-        if (str_contains((string) getenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_LDFLAGS'), '-release')) {
-            FileSystem::replaceFileLineContainsString(
-                SOURCE_PATH . '/php-src/ext/standard/info.c',
-                '#ifdef CONFIGURE_COMMAND',
-                '#ifdef NO_CONFIGURE_COMMAND',
-            );
-        } else {
-            FileSystem::replaceFileLineContainsString(
-                SOURCE_PATH . '/php-src/ext/standard/info.c',
-                '#ifdef NO_CONFIGURE_COMMAND',
-                '#ifdef CONFIGURE_COMMAND',
-            );
-        }
         if (file_exists($this->source_dir . '/.spc.patched')) {
             $this->patched = true;
         }

--- a/src/SPC/store/SourcePatcher.php
+++ b/src/SPC/store/SourcePatcher.php
@@ -287,6 +287,20 @@ class SourcePatcher
                 logger()->info('Library [' . $lib->getName() . '] patched before make');
             }
         }
+
+        if (str_contains((string) getenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_LDFLAGS'), '-release')) {
+            FileSystem::replaceFileLineContainsString(
+                SOURCE_PATH . '/php-src/ext/standard/info.c',
+                '#ifdef CONFIGURE_COMMAND',
+                '#ifdef NO_CONFIGURE_COMMAND',
+            );
+        } else {
+            FileSystem::replaceFileLineContainsString(
+                SOURCE_PATH . '/php-src/ext/standard/info.c',
+                '#ifdef NO_CONFIGURE_COMMAND',
+                '#ifdef CONFIGURE_COMMAND',
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
## What does this PR do?

Fix #788 

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- If you modified `*.php` or `*.json`, run them locally to ensure your changes are valid:
  - [X] `PHP_CS_FIXER_IGNORE_ENV=1 composer cs-fix`
  - [X] `composer analyse`
  - [X] `composer test`
  - [X] `bin/spc dev:sort-config`
- If it's an extension or dependency update, please ensure the following:
  - [ ] Add your test combination to `src/globals/test-extensions.php`.
  - [ ] If adding new or fixing bugs, add commit message containing `extension test` or `test extensions` to trigger full test suite.
