### PR TITLE
revert perl-IPC-Cmd

### DIFF
--- a/src/SPC/doctor/item/LinuxToolCheckList.php
+++ b/src/SPC/doctor/item/LinuxToolCheckList.php
@@ -61,7 +61,8 @@ class LinuxToolCheckList
 
         $required = match ($distro['dist']) {
             'alpine' => self::TOOLS_ALPINE,
-            'redhat', 'centos' => self::TOOLS_RHEL,
+            'redhat' => self::TOOLS_RHEL,
+            'centos' => array_merge(self::TOOLS_RHEL, ['perl-IPC-Cmd']),
             'arch' => self::TOOLS_ARCH,
             default => self::TOOLS_DEBIAN,
         };


### PR DESCRIPTION
## What does this PR do?

add back perl-IPC-Cmd for spc-gnu-docker (not included in perl package on aarch64, apparently)
