### PR TITLE
bring back http3 support for curl

### DIFF
--- a/src/SPC/builder/unix/library/curl.php
+++ b/src/SPC/builder/unix/library/curl.php
@@ -24,13 +24,14 @@ trait curl
             ->optionalLib('libssh2', fn ($lib) => "-DLIBSSH2_LIBRARY=\"{$lib->getStaticLibFiles(style: 'cmake')}\" -DLIBSSH2_INCLUDE_DIR={$lib->getIncludeDir()}", '-DCURL_USE_LIBSSH2=OFF')
             ->optionalLib('nghttp2', fn ($lib) => "-DUSE_NGHTTP2=ON -DNGHTTP2_LIBRARY=\"{$lib->getStaticLibFiles(style: 'cmake')}\" -DNGHTTP2_INCLUDE_DIR={$lib->getIncludeDir()}", '-DUSE_NGHTTP2=OFF')
             ->optionalLib('nghttp3', fn ($lib) => "-DUSE_NGHTTP3=ON -DNGHTTP3_LIBRARY=\"{$lib->getStaticLibFiles(style: 'cmake')}\" -DNGHTTP3_INCLUDE_DIR={$lib->getIncludeDir()}", '-DUSE_NGHTTP3=OFF')
+            ->optionalLib('ngtcp2', fn ($lib) => "-DUSE_NGTCP2=ON -DNGNGTCP2_LIBRARY=\"{$lib->getStaticLibFiles(style: 'cmake')}\" -DNGNGTCP2_INCLUDE_DIR={$lib->getIncludeDir()}", '-DUSE_NGTCP2=OFF')
             ->optionalLib('ldap', ...cmake_boolean_args('CURL_DISABLE_LDAP', true))
             ->optionalLib('zstd', ...cmake_boolean_args('CURL_ZSTD'))
             ->optionalLib('idn2', ...cmake_boolean_args('USE_LIBIDN2'))
             ->optionalLib('psl', ...cmake_boolean_args('CURL_USE_LIBPSL'))
             ->optionalLib('libcares', '-DENABLE_ARES=ON')
             ->addConfigureArgs(
-                '-DBUILD_CURL_EXE=OFF',
+                '-DBUILD_CURL_EXE=ON',
                 '-DBUILD_LIBCURL_DOCS=OFF',
             )
             ->build();

--- a/src/globals/ext-tests/curl.php
+++ b/src/globals/ext-tests/curl.php
@@ -16,3 +16,6 @@ if (stripos($curl_version['ssl_version'], 'schannel') !== false) {
     curl_close($curl);
     assert($data !== false);
 }
+if (phpversion() >= '8.2') {
+    assert(($curl_version['features'] & CURL_VERSION_HTTP3) === CURL_VERSION_HTTP3);
+}


### PR DESCRIPTION
## What does this PR do?
we accidentally lost h3 support in the cmake refactor, this brings it back


## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- If you modified `*.php` or `*.json`, run them locally to ensure your changes are valid:
  - [ ] `PHP_CS_FIXER_IGNORE_ENV=1 composer cs-fix`
  - [ ] `composer analyse`
  - [ ] `composer test`
  - [ ] `bin/spc dev:sort-config`
- If it's an extension or dependency update, please ensure the following:
  - [ ] Add your test combination to `src/globals/test-extensions.php`.
  - [ ] If adding new or fixing bugs, add commit message containing `extension test` or `test extensions` to trigger full test suite.
