### PR TITLE
remove disabling of asm arithmetic

### DIFF
--- a/src/SPC/store/SourcePatcher.php
+++ b/src/SPC/store/SourcePatcher.php
@@ -99,9 +99,6 @@ class SourcePatcher
         }
         // patch capstone
         FileSystem::replaceFileRegex(SOURCE_PATH . '/php-src/configure', '/have_capstone="yes"/', 'have_capstone="no"');
-        if ($builder instanceof LinuxBuilder && getenv('SPC_LIBC') === 'glibc') {
-            FileSystem::replaceFileStr(SOURCE_PATH . '/php-src/Zend/zend_operators.h', '# define ZEND_USE_ASM_ARITHMETIC 1', '# define ZEND_USE_ASM_ARITHMETIC 0');
-        }
     }
 
     /**


### PR DESCRIPTION
## What does this PR do?

why did we need this? asm goto's should be perfectly fine on linux

was this specifically for glibc 2.17?

