### PR TITLE
Check lib-suggest before packing libs

### DIFF
--- a/src/SPC/command/dev/PackLibCommand.php
+++ b/src/SPC/command/dev/PackLibCommand.php
@@ -42,6 +42,15 @@ class PackLibCommand extends BuildCommand
 
             $builder->proveLibs($libraries);
             $builder->validateLibsAndExts();
+
+            // before pack, check if the dependency tree contains lib-suggests
+            foreach ($libraries as $lib) {
+                if (Config::getLib($lib, 'lib-suggests', []) !== []) {
+                    logger()->critical("The library {$lib} has lib-suggests, packing [{$lib_name}] is not safe, abort !");
+                    return static::FAILURE;
+                }
+            }
+
             foreach ($builder->getLibs() as $lib) {
                 if ($lib->getName() !== $lib_name) {
                     // other dependencies: install or build, both ok


### PR DESCRIPTION
## What does this PR do?

Check lib-suggest before packing libs. This will prevent packing alternative libs when someone uses different dependency tree.

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- If you modified `*.php` or `*.json`, run them locally to ensure your changes are valid:
  - [X] `PHP_CS_FIXER_IGNORE_ENV=1 composer cs-fix`
  - [X] `composer analyse`
  - [X] `composer test`
  - [X] `bin/spc dev:sort-config`
- If it's an extension or dependency update, please ensure the following:
  - [ ] Add your test combination to `src/globals/test-extensions.php`.
  - [ ] If adding new or fixing bugs, add commit message containing `extension test` or `test extensions` to trigger full test suite.
