### PR TITLE
Allow deleting pre-built or source only for del-download

### DIFF
--- a/src/SPC/command/DeleteDownloadCommand.php
+++ b/src/SPC/command/DeleteDownloadCommand.php
@@ -22,6 +22,8 @@ class DeleteDownloadCommand extends BaseCommand
     {
         $this->addArgument('sources', InputArgument::REQUIRED, 'The sources/packages will be deleted, comma separated');
         $this->addOption('all', 'A', null, 'Delete all downloaded and locked sources/packages');
+        $this->addOption('pre-built-only', 'W', null, 'Delete only pre-built sources/packages, not the original ones');
+        $this->addOption('source-only', 'S', null, 'Delete only sources, not the pre-built packages');
     }
 
     public function initialize(InputInterface $input, OutputInterface $output): void
@@ -51,10 +53,11 @@ class DeleteDownloadCommand extends BaseCommand
             $deleted_sources = [];
             foreach ($chosen_sources as $source) {
                 $source = trim($source);
-                foreach ([$source, Downloader::getPreBuiltLockName($source)] as $name) {
-                    if (LockFile::get($name)) {
-                        $deleted_sources[] = $name;
-                    }
+                if (LockFile::get($source) && !$this->getOption('pre-built-only')) {
+                    $deleted_sources[] = $source;
+                }
+                if (LockFile::get(Downloader::getPreBuiltLockName($source)) && !$this->getOption('source-only')) {
+                    $deleted_sources[] = Downloader::getPreBuiltLockName($source);
                 }
             }
 


### PR DESCRIPTION
## What does this PR do?

Allow deleting pre-built or source only for del-download:

- `bin/spc del-download --pre-built-only XXX`
- `bin/spc del-download --source-only XXX`

Sometimes we need to test either source or pre-built at the same time. It's just a little function to help us simplify the download procedure. (sometimes download from another side of the earth is quite slow)

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- If you modified `*.php` or `*.json`, run them locally to ensure your changes are valid:
  - [ ] `PHP_CS_FIXER_IGNORE_ENV=1 composer cs-fix`
  - [ ] `composer analyse`
  - [ ] `composer test`
  - [ ] `bin/spc dev:sort-config`
- If it's an extension or dependency update, please ensure the following:
  - [ ] Add your test combination to `src/globals/test-extensions.php`.
  - [ ] If adding new or fixing bugs, add commit message containing `extension test` or `test extensions` to trigger full test suite.
