### PR TITLE
Fix/micro patches

### DIFF
--- a/config/env.ini
+++ b/config/env.ini
@@ -78,7 +78,7 @@ SPC_EXTRA_LIBS=
 ; upx executable path
 UPX_EXEC=${PKG_ROOT_PATH}/bin/upx
 ; phpmicro patches, for more info, see: https://github.com/easysoft/phpmicro/tree/master/patches
-SPC_MICRO_PATCHES=static_extensions_win32,cli_checks,disable_huge_page,vcruntime140,win32,zend_stream
+SPC_MICRO_PATCHES=cli_checks,disable_huge_page
 
 ; *** default build command for building php ***
 ; buildconf command
@@ -118,7 +118,7 @@ SPC_DEFAULT_CXX_FLAGS="--target=${MAC_ARCH}-apple-darwin -Os"
 ; extra libs for building php executable, used in `make` command for building php (this value may changed by extension build process, space separated)
 SPC_EXTRA_LIBS=
 ; phpmicro patches, for more info, see: https://github.com/easysoft/phpmicro/tree/master/patches
-SPC_MICRO_PATCHES=static_extensions_win32,cli_checks,disable_huge_page,vcruntime140,win32,zend_stream,macos_iconv
+SPC_MICRO_PATCHES=cli_checks,macos_iconv
 
 ; *** default build command for building php ***
 ; buildconf command

--- a/src/SPC/builder/BuilderBase.php
+++ b/src/SPC/builder/BuilderBase.php
@@ -14,6 +14,7 @@ use SPC\store\Config;
 use SPC\store\FileSystem;
 use SPC\store\LockFile;
 use SPC\store\SourceManager;
+use SPC\store\SourcePatcher;
 use SPC\util\CustomExt;
 
 abstract class BuilderBase
@@ -203,6 +204,8 @@ abstract class BuilderBase
             $this->emitPatchPoint('before-exts-extract');
             SourceManager::initSource(exts: [...$static_extensions, ...$shared_extensions]);
             $this->emitPatchPoint('after-exts-extract');
+            // patch micro
+            SourcePatcher::patchMicro();
         }
 
         foreach ([...$static_extensions, ...$shared_extensions] as $extension) {

--- a/src/SPC/store/SourcePatcher.php
+++ b/src/SPC/store/SourcePatcher.php
@@ -177,6 +177,9 @@ class SourcePatcher
         }
 
         $patch_str = FileSystem::convertPath($patch_file);
+        if (!file_exists($patch_str)) {
+            throw new RuntimeException("Patch file [{$patch_str}] does not exist");
+        }
 
         // Copy patch from phar
         if (str_starts_with($patch_str, 'phar://')) {

--- a/src/SPC/store/SourcePatcher.php
+++ b/src/SPC/store/SourcePatcher.php
@@ -181,7 +181,7 @@ class SourcePatcher
         // Copy patch from phar
         if (str_starts_with($patch_str, 'phar://')) {
             $filename = pathinfo($patch_file, PATHINFO_BASENAME);
-            file_put_contents(SOURCE_PATH . "{$filename}", file_get_contents($patch_file));
+            file_put_contents(SOURCE_PATH . "/{$filename}", file_get_contents($patch_file));
             $patch_str = FileSystem::convertPath(SOURCE_PATH . "/{$filename}");
         }
 

--- a/src/SPC/store/SourcePatcher.php
+++ b/src/SPC/store/SourcePatcher.php
@@ -17,7 +17,6 @@ class SourcePatcher
     public static function init(): void
     {
         // FileSystem::addSourceExtractHook('swow', [SourcePatcher::class, 'patchSwow']);
-        FileSystem::addSourceExtractHook('micro', [SourcePatcher::class, 'patchMicro']);
         FileSystem::addSourceExtractHook('openssl', [SourcePatcher::class, 'patchOpenssl11Darwin']);
         FileSystem::addSourceExtractHook('swoole', [SourcePatcher::class, 'patchSwoole']);
         FileSystem::addSourceExtractHook('php-src', [SourcePatcher::class, 'patchPhpLibxml212']);
@@ -105,7 +104,7 @@ class SourcePatcher
      * @throws RuntimeException
      * @throws FileSystemException
      */
-    public static function patchMicro(string $name = '', string $target = '', ?array $items = null): bool
+    public static function patchMicro(?array $items = null): bool
     {
         if (!file_exists(SOURCE_PATH . '/php-src/sapi/micro/php_micro.c')) {
             return false;
@@ -152,11 +151,7 @@ class SourcePatcher
 
         foreach ($patches as $patch) {
             logger()->info("Patching micro with {$patch}");
-            $patchesStr = str_replace('/', DIRECTORY_SEPARATOR, $patch);
-            f_passthru(
-                'cd ' . SOURCE_PATH . '/php-src && ' .
-                (PHP_OS_FAMILY === 'Windows' ? 'type' : 'cat') . ' ' . $patchesStr . ' | patch -p1 '
-            );
+            self::patchFile(SOURCE_PATH . "/php-src{$patch}", SOURCE_PATH . '/php-src');
         }
 
         return true;
@@ -165,24 +160,29 @@ class SourcePatcher
     /**
      * Use existing patch file for patching
      *
-     * @param  string           $patch_name Patch file name in src/globals/patch/
+     * @param  string           $patch_name Patch file name in src/globals/patch/ or absolute path
      * @param  string           $cwd        Working directory for patch command
      * @param  bool             $reverse    Reverse patches (default: False)
      * @throws RuntimeException
      */
     public static function patchFile(string $patch_name, string $cwd, bool $reverse = false): bool
     {
-        if (!file_exists(ROOT_DIR . "/src/globals/patch/{$patch_name}")) {
+        if (FileSystem::isRelativePath($patch_name)) {
+            $patch_file = ROOT_DIR . "/src/globals/patch/{$patch_name}";
+        } else {
+            $patch_file = $patch_name;
+        }
+        if (!file_exists($patch_file)) {
             return false;
         }
 
-        $patch_file = ROOT_DIR . "/src/globals/patch/{$patch_name}";
-        $patch_str = str_replace('/', DIRECTORY_SEPARATOR, $patch_file);
+        $patch_str = FileSystem::convertPath($patch_file);
 
         // Copy patch from phar
-        if (\Phar::running() !== '') {
-            file_put_contents(SOURCE_PATH . '/' . $patch_name, file_get_contents($patch_file));
-            $patch_str = str_replace('/', DIRECTORY_SEPARATOR, SOURCE_PATH . '/' . $patch_name);
+        if (str_starts_with($patch_str, 'phar://')) {
+            $filename = pathinfo($patch_file, PATHINFO_BASENAME);
+            file_put_contents(SOURCE_PATH . "{$filename}", file_get_contents($patch_file));
+            $patch_str = FileSystem::convertPath(SOURCE_PATH . "/{$filename}");
         }
 
         // detect

--- a/src/SPC/store/SourcePatcher.php
+++ b/src/SPC/store/SourcePatcher.php
@@ -151,7 +151,7 @@ class SourcePatcher
 
         foreach ($patches as $patch) {
             logger()->info("Patching micro with {$patch}");
-            self::patchFile(SOURCE_PATH . "/php-src{$patch}", SOURCE_PATH . '/php-src');
+            self::patchFile(SOURCE_PATH . "/php-src/{$patch}", SOURCE_PATH . '/php-src');
         }
 
         return true;


### PR DESCRIPTION
## What does this PR do?

Fix #803 .

This PR will put micro patches after init souces and reuse `patchFile` function to automatically skip the patched patches.

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- If you modified `*.php` or `*.json`, run them locally to ensure your changes are valid:
  - [X] `PHP_CS_FIXER_IGNORE_ENV=1 composer cs-fix`
  - [X] `composer analyse`
  - [X] `composer test`
  - [X] `bin/spc dev:sort-config`
- If it's an extension or dependency update, please ensure the following:
  - [ ] Add your test combination to `src/globals/test-extensions.php`.
  - [ ] If adding new or fixing bugs, add commit message containing `extension test` or `test extensions` to trigger full test suite.
