### PR TITLE
fix: conflict upload names when reusing workflow more then once

### DIFF
--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -235,7 +235,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         name: "Upload Build Metadata"
         with:
-          name: build-meta
+          name: build-meta-${{ inputs.php-version }}-${{ inputs.os }}
           path: |
             buildroot/build-extensions.json
             buildroot/build-libraries.json


### PR DESCRIPTION
## What does this PR do?
When using the workflow from within my own workflow, the upload of licenses from all libs etc is conflicted. I have a single workflow that creates a linux glibc, linux, and macos version seperately. Whenever the first step is done, other steps will fail due to conflicted file names being tried to upload.

All other artifacts are being uploaded using the `os` and `php-version` except the license files.

## Steps to reproduce:
The following example dispatches the workflow 3 times and tries to upload 3 "license-files" artifacts.
```yaml
steps:
  unix-all-static-builds:
    if: ${{ inputs.selectos == 'all' }}
    needs: builder
    uses: crazywhalecc/static-php-cli/.github/workflows/build-unix.yml
    strategy:
      matrix:
        selectos: [linux-x86_64-glibc, linux-x86_64, macos-aarch64]
    with:
      os: ${{ matrix.selectos }}
      php-version: ${{ inputs.php-version }}
      extensions: 'odbc,pdo_odbc,bcmath,calendar,ctype,curl,dba,exif,fileinfo,filter,gd,libxml,mbregex,mbstring,msgpack,mysqli,mysqlnd,opcache,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pdo_sqlsrv,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sodium,sqlite3,sqlsrv,tokenizer,xml,xmlreader,xmlwriter,zip,zlib'
      vendor-mode: true
```


## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- If you modified `*.php` or `*.json`, run them locally to ensure your changes are valid:
  - [ ] `PHP_CS_FIXER_IGNORE_ENV=1 composer cs-fix`
  - [ ] `composer analyse`
  - [ ] `composer test`
  - [ ] `bin/spc dev:sort-config`
- If it's an extension or dependency update, please ensure the following:
  - [ ] Add your test combination to `src/globals/test-extensions.php`.
  - [ ] If adding new or fixing bugs, add commit message containing `extension test` or `test extensions` to trigger full test suite.
