### PR TITLE
Allow specifying submodules for git source

### DIFF
--- a/src/SPC/store/Downloader.php
+++ b/src/SPC/store/Downloader.php
@@ -242,7 +242,7 @@ class Downloader
             f_passthru("{$git} clone {$quiet} --config core.autocrlf=false --branch \"{$branch}\" {$shallow} {$recursive} \"{$url}\" \"{$download_path}\"");
             if ($submodules !== null) {
                 foreach ($submodules as $submodule) {
-                    f_passthru("cd \"{$download_path}\" && {$git} submodule update --init {$submodule}");
+                    f_passthru("cd \"{$download_path}\" && {$git} submodule update --init " . escapeshellarg($submodule));
                 }
             }
         } catch (RuntimeException $e) {

--- a/src/SPC/store/Downloader.php
+++ b/src/SPC/store/Downloader.php
@@ -230,7 +230,7 @@ class Downloader
         $quiet = !defined('DEBUG_MODE') ? '-q --quiet' : '';
         $git = SPC_GIT_EXEC;
         $shallow = defined('GIT_SHALLOW_CLONE') ? '--depth 1 --single-branch' : '';
-        $recursive = !is_array($submodules) ? '--recursive' : '';
+        $recursive = ($submodules === null) ? '--recursive' : '';
 
         try {
             self::registerCancelEvent(function () use ($download_path) {


### PR DESCRIPTION
## What does this PR do?

Solves #824 submodule pulling issue.

Usage:

```json
{
    "libjxl": {
        "type": "git",
        "rev": "v0.11.x",
        "url": "https://github.com/libjxl/libjxl.git",
        "submodules": [
            "third_party/highway",
            "third_party/sjpeg",
            "third_party/skcms"
        ],
        "license": {
            "type": "file",
            "path": "LICENSE"
        }
    }
}
```

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- If you modified `*.php` or `*.json`, run them locally to ensure your changes are valid:
  - [X] `PHP_CS_FIXER_IGNORE_ENV=1 composer cs-fix`
  - [X] `composer analyse`
  - [X] `composer test`
  - [X] `bin/spc dev:sort-config`
- If it's an extension or dependency update, please ensure the following:
  - [ ] Add your test combination to `src/globals/test-extensions.php`.
  - [ ] If adding new or fixing bugs, add commit message containing `extension test` or `test extensions` to trigger full test suite.
