### PR TITLE
Patch pkg-config and la files with placeholder when packing pre-built content

### DIFF
--- a/src/SPC/builder/LibraryBase.php
+++ b/src/SPC/builder/LibraryBase.php
@@ -350,7 +350,27 @@ abstract class LibraryBase
 
     protected function install(): void
     {
-        // do something after extracting pre-built files, default do nothing. overwrite this method to do something
+        // replace placeholders if BUILD_ROOT_PATH/.spc-extract-placeholder.json exists
+        $placeholder_file = BUILD_ROOT_PATH . '/.spc-extract-placeholder.json';
+        if (!file_exists($placeholder_file)) {
+            return;
+        }
+        $placeholder = json_decode(file_get_contents($placeholder_file), true);
+        if (!is_array($placeholder)) {
+            throw new RuntimeException('Invalid placeholder file: ' . $placeholder_file);
+        }
+        $placeholder = get_pack_placehoder();
+        // replace placeholders in BUILD_ROOT_PATH
+        foreach ($placeholder as $item) {
+            $filepath = BUILD_ROOT_PATH . "/{$item}";
+            FileSystem::replaceFileStr(
+                $filepath,
+                array_values($placeholder),
+                array_keys($placeholder),
+            );
+        }
+        // remove placeholder file
+        unlink($placeholder_file);
     }
 
     /**

--- a/src/SPC/builder/linux/library/openssl.php
+++ b/src/SPC/builder/linux/library/openssl.php
@@ -67,8 +67,7 @@ class openssl extends LinuxLibraryBase
         shell()->cd($this->source_dir)->initializeEnv($this)
             ->exec(
                 "{$env} ./Configure no-shared {$extra} " .
-                '--prefix=/ ' .
-                '--libdir=lib ' .
+                '--prefix=' . BUILD_ROOT_PATH . ' ' .
                 '--openssldir=/etc/ssl ' .
                 "{$zlib_extra}" .
                 'no-legacy ' .
@@ -76,17 +75,17 @@ class openssl extends LinuxLibraryBase
             )
             ->exec('make clean')
             ->exec("make -j{$this->builder->concurrency} CNF_EX_LIBS=\"{$ex_lib}\"")
-            ->exec("make install_sw DESTDIR={$destdir}");
+            ->exec('make install_sw');
         $this->patchPkgconfPrefix(['libssl.pc', 'openssl.pc', 'libcrypto.pc']);
         // patch for openssl 3.3.0+
         if (!str_contains($file = FileSystem::readFile(BUILD_LIB_PATH . '/pkgconfig/libssl.pc'), 'prefix=')) {
-            FileSystem::writeFile(BUILD_LIB_PATH . '/pkgconfig/libssl.pc', 'prefix=${pcfiledir}/../..' . "\n" . $file);
+            FileSystem::writeFile(BUILD_LIB_PATH . '/pkgconfig/libssl.pc', 'prefix=' . BUILD_ROOT_PATH . "\n" . $file);
         }
         if (!str_contains($file = FileSystem::readFile(BUILD_LIB_PATH . '/pkgconfig/openssl.pc'), 'prefix=')) {
-            FileSystem::writeFile(BUILD_LIB_PATH . '/pkgconfig/openssl.pc', 'prefix=${pcfiledir}/../..' . "\n" . $file);
+            FileSystem::writeFile(BUILD_LIB_PATH . '/pkgconfig/openssl.pc', 'prefix=' . BUILD_ROOT_PATH . "\n" . $file);
         }
         if (!str_contains($file = FileSystem::readFile(BUILD_LIB_PATH . '/pkgconfig/libcrypto.pc'), 'prefix=')) {
-            FileSystem::writeFile(BUILD_LIB_PATH . '/pkgconfig/libcrypto.pc', 'prefix=${pcfiledir}/../..' . "\n" . $file);
+            FileSystem::writeFile(BUILD_LIB_PATH . '/pkgconfig/libcrypto.pc', 'prefix=' . BUILD_ROOT_PATH . "\n" . $file);
         }
         FileSystem::replaceFileRegex(BUILD_LIB_PATH . '/pkgconfig/libcrypto.pc', '/Libs.private:.*/m', 'Libs.private: ${libdir}/libz.a');
         FileSystem::replaceFileRegex(BUILD_LIB_PATH . '/cmake/OpenSSL/OpenSSLConfig.cmake', '/set\(OPENSSL_LIBCRYPTO_DEPENDENCIES .*\)/m', 'set(OPENSSL_LIBCRYPTO_DEPENDENCIES "${OPENSSL_LIBRARY_DIR}/libz.a")');

--- a/src/SPC/builder/linux/library/openssl.php
+++ b/src/SPC/builder/linux/library/openssl.php
@@ -68,6 +68,7 @@ class openssl extends LinuxLibraryBase
             ->exec(
                 "{$env} ./Configure no-shared {$extra} " .
                 '--prefix=' . BUILD_ROOT_PATH . ' ' .
+                '--libdir=' . BUILD_LIB_PATH . ' ' .
                 '--openssldir=/etc/ssl ' .
                 "{$zlib_extra}" .
                 'no-legacy ' .

--- a/src/SPC/builder/traits/UnixLibraryTrait.php
+++ b/src/SPC/builder/traits/UnixLibraryTrait.php
@@ -75,7 +75,7 @@ trait UnixLibraryTrait
             logger()->debug('Patching ' . $realpath);
             // replace prefix
             $file = FileSystem::readFile($realpath);
-            $file = ($patch_option & PKGCONF_PATCH_PREFIX) === PKGCONF_PATCH_PREFIX ? preg_replace('/^prefix\s*=.*$/m', 'prefix=${pcfiledir}/../..', $file) : $file;
+            $file = ($patch_option & PKGCONF_PATCH_PREFIX) === PKGCONF_PATCH_PREFIX ? preg_replace('/^prefix\s*=.*$/m', 'prefix=' . BUILD_ROOT_PATH, $file) : $file;
             $file = ($patch_option & PKGCONF_PATCH_EXEC_PREFIX) === PKGCONF_PATCH_EXEC_PREFIX ? preg_replace('/^exec_prefix\s*=.*$/m', 'exec_prefix=${prefix}', $file) : $file;
             $file = ($patch_option & PKGCONF_PATCH_LIBDIR) === PKGCONF_PATCH_LIBDIR ? preg_replace('/^libdir\s*=.*$/m', 'libdir=${prefix}/lib', $file) : $file;
             $file = ($patch_option & PKGCONF_PATCH_INCLUDEDIR) === PKGCONF_PATCH_INCLUDEDIR ? preg_replace('/^includedir\s*=.*$/m', 'includedir=${prefix}/include', $file) : $file;

--- a/src/SPC/builder/unix/library/icu.php
+++ b/src/SPC/builder/unix/library/icu.php
@@ -17,6 +17,7 @@ trait icu
 
     protected function install(): void
     {
+        parent::install();
         $icu_config = BUILD_ROOT_PATH . '/bin/icu-config';
         FileSystem::replaceFileStr($icu_config, '{BUILD_ROOT_PATH}', BUILD_ROOT_PATH);
     }

--- a/src/SPC/builder/unix/library/libevent.php
+++ b/src/SPC/builder/unix/library/libevent.php
@@ -68,6 +68,7 @@ trait libevent
 
     protected function install(): void
     {
+        parent::install();
         FileSystem::replaceFileStr(
             BUILD_LIB_PATH . '/cmake/libevent/LibeventTargets-static.cmake',
             '{BUILD_ROOT_PATH}',

--- a/src/globals/functions.php
+++ b/src/globals/functions.php
@@ -232,3 +232,13 @@ function ac_with_args(string $arg_name, bool $use_value = false): array
 {
     return $use_value ? ["--with-{$arg_name}=yes", "--with-{$arg_name}=no"] : ["--with-{$arg_name}", "--without-{$arg_name}"];
 }
+
+function get_pack_placehoder(): array
+{
+    return [
+        BUILD_LIB_PATH => '@build_lib_path@',
+        BUILD_BIN_PATH => '@build_bin_path@',
+        BUILD_INCLUDE_PATH => '@build_include_path@',
+        BUILD_ROOT_PATH => '@build_root_path@',
+    ];
+}


### PR DESCRIPTION
## What does this PR do?

Patch pkg-config and la files with placeholder when packing pre-built content, fixes #829 

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- If you modified `*.php` or `*.json`, run them locally to ensure your changes are valid:
  - [X] `PHP_CS_FIXER_IGNORE_ENV=1 composer cs-fix`
  - [X] `composer analyse`
  - [X] `composer test`
  - [X] `bin/spc dev:sort-config`
- If it's an extension or dependency update, please ensure the following:
  - [ ] Add your test combination to `src/globals/test-extensions.php`.
  - [ ] If adding new or fixing bugs, add commit message containing `extension test` or `test extensions` to trigger full test suite.
