### PR TITLE
Add --no-alt and --skip-extract option to install-pkg command

### DIFF
--- a/src/SPC/command/DownloadCommand.php
+++ b/src/SPC/command/DownloadCommand.php
@@ -248,9 +248,9 @@ class DownloadCommand extends BaseCommand
                         $alt_sources = Config::getSource($source)['alt'] ?? null;
                         if ($alt_sources === null) {
                             logger()->warning("No alternative sources found for {$source}, using default alternative source");
-                            $alt_config = array_merge($config, $this->getDefaultAlternativeSource($source));
+                            $alt_config = array_merge($config, Downloader::getDefaultAlternativeSource($source));
                         } elseif ($alt_sources === false) {
-                            logger()->warning("No alternative sources found for {$source}, skipping alternative download");
+                            logger()->error("No alternative sources found for {$source}, skipping alternative download");
                             throw $e;
                         } else {
                             logger()->notice("Trying to download alternative sources for {$source}");
@@ -398,28 +398,5 @@ class DownloadCommand extends BaseCommand
             f_passthru('rm -rf ' . BUILD_ROOT_PATH . '/*');
         }
         return static::FAILURE;
-    }
-
-    private function getDefaultAlternativeSource(string $source_name): array
-    {
-        return [
-            'type' => 'custom',
-            'func' => function (bool $force, array $source, int $download_as) use ($source_name) {
-                logger()->debug("Fetching alternative source for {$source_name}");
-                // get from dl.static-php.dev
-                $url = "https://dl.static-php.dev/static-php-cli/deps/spc-download-mirror/{$source_name}/?format=json";
-                $json = json_decode(Downloader::curlExec(url: $url, retries: intval(getenv('SPC_DOWNLOAD_RETRIES') ?: 0)), true);
-                if (!is_array($json)) {
-                    throw new RuntimeException('failed http fetch');
-                }
-                $item = $json[0] ?? null;
-                if ($item === null) {
-                    throw new RuntimeException('failed to parse json');
-                }
-                $full_url = 'https://dl.static-php.dev' . $item['full_path'];
-                $filename = basename($item['full_path']);
-                Downloader::downloadFile($source_name, $full_url, $filename, $source['path'] ?? null, $download_as);
-            },
-        ];
     }
 }

--- a/src/SPC/command/InstallPkgCommand.php
+++ b/src/SPC/command/InstallPkgCommand.php
@@ -24,6 +24,8 @@ class InstallPkgCommand extends BaseCommand
         $this->addArgument('packages', InputArgument::REQUIRED, 'The packages will be installed, comma separated');
         $this->addOption('shallow-clone', null, null, 'Clone shallow');
         $this->addOption('custom-url', 'U', InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Specify custom source download url, e.g "php-src:https://downloads.php.net/~eric/php-8.3.0beta1.tar.gz"');
+        $this->addOption('no-alt', null, null, 'Do not download alternative packages');
+        $this->addOption('skip-extract', null, null, 'Skip package extraction, just download the package archive');
     }
 
     /**
@@ -66,10 +68,20 @@ class InstallPkgCommand extends BaseCommand
                         $new_config['filename'] = $config['filename'];
                     }
                     logger()->info("Installing source {$pkg} from custom url [{$ni}/{$cnt}]");
-                    PackageManager::installPackage($pkg, $new_config);
+                    PackageManager::installPackage(
+                        $pkg,
+                        $new_config,
+                        allow_alt: false,
+                        extract: !$this->getOption('skip-extract')
+                    );
                 } else {
                     logger()->info("Fetching package {$pkg} [{$ni}/{$cnt}]");
-                    PackageManager::installPackage($pkg, Config::getPkg($pkg));
+                    PackageManager::installPackage(
+                        $pkg,
+                        Config::getPkg($pkg),
+                        allow_alt: !$this->getOption('no-alt'),
+                        extract: !$this->getOption('skip-extract')
+                    );
                 }
             }
             $time = round(microtime(true) - START_TIME, 3);

--- a/src/SPC/store/Downloader.php
+++ b/src/SPC/store/Downloader.php
@@ -608,6 +608,29 @@ class Downloader
         return "{$source}-{$os_family}-{$gnu_arch}-{$libc}-{$libc_version}";
     }
 
+    public static function getDefaultAlternativeSource(string $source_name): array
+    {
+        return [
+            'type' => 'custom',
+            'func' => function (bool $force, array $source, int $download_as) use ($source_name) {
+                logger()->debug("Fetching alternative source for {$source_name}");
+                // get from dl.static-php.dev
+                $url = "https://dl.static-php.dev/static-php-cli/deps/spc-download-mirror/{$source_name}/?format=json";
+                $json = json_decode(Downloader::curlExec(url: $url, retries: intval(getenv('SPC_DOWNLOAD_RETRIES') ?: 0)), true);
+                if (!is_array($json)) {
+                    throw new RuntimeException('failed http fetch');
+                }
+                $item = $json[0] ?? null;
+                if ($item === null) {
+                    throw new RuntimeException('failed to parse json');
+                }
+                $full_url = 'https://dl.static-php.dev' . $item['full_path'];
+                $filename = basename($item['full_path']);
+                Downloader::downloadFile($source_name, $full_url, $filename, $source['path'] ?? null, $download_as);
+            },
+        ];
+    }
+
     /**
      * Register CTRL+C event for different OS.
      *

--- a/src/SPC/store/PackageManager.php
+++ b/src/SPC/store/PackageManager.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace SPC\store;
 
+use SPC\exception\DownloaderException;
 use SPC\exception\FileSystemException;
 use SPC\exception\WrongUsageException;
 use SPC\store\pkg\CustomPackage;
 
 class PackageManager
 {
-    public static function installPackage(string $pkg_name, ?array $config = null, bool $force = false): void
+    public static function installPackage(string $pkg_name, ?array $config = null, bool $force = false, bool $allow_alt = true, bool $extract = true): void
     {
         if ($config === null) {
             $config = Config::getPkg($pkg_name);
@@ -32,7 +33,32 @@ class PackageManager
         }
 
         // Download package
-        Downloader::downloadPackage($pkg_name, $config, $force);
+        try {
+            Downloader::downloadPackage($pkg_name, $config, $force);
+        } catch (\Throwable $e) {
+            if (!$allow_alt) {
+                logger()->error("Download package {$pkg_name} failed: " . $e->getMessage());
+                throw new DownloaderException("Download package {$pkg_name} failed: " . $e->getMessage());
+            }
+            // if download failed, we will try to download alternative packages
+            logger()->warning("Download package {$pkg_name} failed: " . $e->getMessage());
+            $alt = $config['alt'] ?? null;
+            if ($alt === null) {
+                logger()->warning("No alternative package found for {$pkg_name}, using default mirror.");
+                $alt_config = array_merge($config, Downloader::getDefaultAlternativeSource($pkg_name));
+            } elseif ($alt === false) {
+                logger()->error("No alternative package found for {$pkg_name}.");
+                throw $e;
+            } else {
+                logger()->notice("Trying alternative package for {$pkg_name}.");
+                $alt_config = array_merge($config, $alt);
+            }
+            Downloader::downloadPackage($pkg_name, $alt_config, $force);
+        }
+        if (!$extract) {
+            logger()->info("Package [{$pkg_name}] downloaded, but extraction is skipped.");
+            return;
+        }
         if (Config::getPkg($pkg_name)['type'] === 'custom') {
             // Custom extract function
             $classes = FileSystem::getClassesPsr4(ROOT_DIR . '/src/SPC/store/pkg', 'SPC\store\pkg');


### PR DESCRIPTION
## What does this PR do?

Fix #832 .

The related file updated in static-php-cli-hosted also need reviewing: https://github.com/static-php/static-php-cli-hosted/blob/master/.github/workflows/download-cache.yml

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- If you modified `*.php` or `*.json`, run them locally to ensure your changes are valid:
  - [x] `PHP_CS_FIXER_IGNORE_ENV=1 composer cs-fix`
  - [x] `composer analyse`
  - [x] `composer test`
  - [x] `bin/spc dev:sort-config`
- If it's an extension or dependency update, please ensure the following:
  - [ ] Add your test combination to `src/globals/test-extensions.php`.
  - [ ] If adding new or fixing bugs, add commit message containing `extension test` or `test extensions` to trigger full test suite.
