### PR TITLE
change swoole to version 6.x because 5.x is not compatible with php 8.4+

### DIFF
--- a/config/source.json
+++ b/config/source.json
@@ -998,6 +998,7 @@
         "path": "php-src/ext/swoole",
         "type": "ghtar",
         "repo": "swoole/swoole-src",
+        "match": "v6\\.+",
         "prefer-stable": true,
         "license": {
             "type": "file",


### PR DESCRIPTION
## What does this PR do?
swoole released 5.18 two days ago, now the downloader uses that one instead of the "older" 6.0.2 which we want.

