### PR TITLE
Add snmp and net-snmp support for macOS and Linux

### DIFF
--- a/config/ext.json
+++ b/config/ext.json
@@ -13,6 +13,14 @@
             "openssl"
         ]
     },
+    "snmp": {
+        "type": "builtin",
+        "arg-type-unix": "with-path",
+        "arg-type-windows": "with",
+        "lib-depends": [
+            "net-snmp"
+        ]
+    },
     "apcu": {
         "type": "external",
         "source": "apcu"

--- a/config/lib.json
+++ b/config/lib.json
@@ -664,6 +664,17 @@
             "libncurses.a"
         ]
     },
+    "net-snmp": {
+        "source": "net-snmp",
+        "pkg-configs": [
+            "netsnmp",
+            "netsnmp-agent"
+        ],
+        "lib-depends": [
+            "openssl",
+            "zlib"
+        ]
+    },
     "nghttp2": {
         "source": "nghttp2",
         "static-libs-unix": [

--- a/config/source.json
+++ b/config/source.json
@@ -781,6 +781,14 @@
             "path": "COPYING"
         }
     },
+    "net-snmp": {
+        "type": "ghtagtar",
+        "repo": "net-snmp/net-snmp",
+        "license": {
+            "type": "file",
+            "path": "COPYING"
+        }
+    },
     "nghttp2": {
         "type": "ghrel",
         "repo": "nghttp2/nghttp2",

--- a/src/SPC/builder/linux/library/net_snmp.php
+++ b/src/SPC/builder/linux/library/net_snmp.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\linux\library;
+
+class net_snmp extends LinuxLibraryBase
+{
+    use \SPC\builder\unix\library\net_snmp;
+
+    public const NAME = 'net-snmp';
+}

--- a/src/SPC/builder/linux/library/openssl.php
+++ b/src/SPC/builder/linux/library/openssl.php
@@ -78,7 +78,7 @@ class openssl extends LinuxLibraryBase
         if (!str_contains($file = FileSystem::readFile(BUILD_LIB_PATH . '/pkgconfig/libcrypto.pc'), 'prefix=')) {
             FileSystem::writeFile(BUILD_LIB_PATH . '/pkgconfig/libcrypto.pc', 'prefix=' . BUILD_ROOT_PATH . "\n" . $file);
         }
-        FileSystem::replaceFileRegex(BUILD_LIB_PATH . '/pkgconfig/libcrypto.pc', '/Libs.private:.*/m', 'Libs.private: ${libdir}/libz.a');
+        FileSystem::replaceFileRegex(BUILD_LIB_PATH . '/pkgconfig/libcrypto.pc', '/Libs.private:.*/m', 'Requires.private: zlib');
         FileSystem::replaceFileRegex(BUILD_LIB_PATH . '/cmake/OpenSSL/OpenSSLConfig.cmake', '/set\(OPENSSL_LIBCRYPTO_DEPENDENCIES .*\)/m', 'set(OPENSSL_LIBCRYPTO_DEPENDENCIES "${OPENSSL_LIBRARY_DIR}/libz.a")');
     }
 }

--- a/src/SPC/builder/macos/library/net_snmp.php
+++ b/src/SPC/builder/macos/library/net_snmp.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\macos\library;
+
+class net_snmp extends MacOSLibraryBase
+{
+    use \SPC\builder\unix\library\net_snmp;
+
+    public const NAME = 'net-snmp';
+}

--- a/src/SPC/builder/macos/library/openssl.php
+++ b/src/SPC/builder/macos/library/openssl.php
@@ -63,7 +63,7 @@ class openssl extends MacOSLibraryBase
         if (!str_contains($file = FileSystem::readFile(BUILD_LIB_PATH . '/pkgconfig/libcrypto.pc'), 'prefix=')) {
             FileSystem::writeFile(BUILD_LIB_PATH . '/pkgconfig/libcrypto.pc', 'prefix=' . BUILD_ROOT_PATH . "\n" . $file);
         }
-        FileSystem::replaceFileRegex(BUILD_LIB_PATH . '/pkgconfig/libcrypto.pc', '/Libs.private:.*/m', 'Libs.private: ${libdir}/libz.a');
+        FileSystem::replaceFileRegex(BUILD_LIB_PATH . '/pkgconfig/libcrypto.pc', '/Libs.private:.*/m', 'Requires.private: zlib');
         FileSystem::replaceFileRegex(BUILD_LIB_PATH . '/cmake/OpenSSL/OpenSSLConfig.cmake', '/set\(OPENSSL_LIBCRYPTO_DEPENDENCIES .*\)/m', 'set(OPENSSL_LIBCRYPTO_DEPENDENCIES "${OPENSSL_LIBRARY_DIR}/libz.a")');
     }
 }

--- a/src/SPC/builder/unix/library/net_snmp.php
+++ b/src/SPC/builder/unix/library/net_snmp.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\unix\library;
+
+use SPC\util\executor\UnixAutoconfExecutor;
+
+trait net_snmp
+{
+    protected function build(): void
+    {
+        // use --static for PKG_CONFIG
+        UnixAutoconfExecutor::create($this)
+            ->setEnv(['PKG_CONFIG' => getenv('PKG_CONFIG') . ' --static'])
+            ->configure(
+                '--with-default-snmp-version="3"',
+                '--with-sys-contact="@@no.where"',
+                '--with-sys-location="Unknown"',
+                '--with-logfile="/var/log/snmpd.log"',
+                '--with-persistent-directory="/var/ne-snmp"',
+                '--with-openssl=' . BUILD_ROOT_PATH,
+                '--with-zlib=' . BUILD_ROOT_PATH,
+            )->make();
+        $this->patchPkgconfPrefix();
+    }
+}

--- a/src/SPC/util/executor/UnixAutoconfExecutor.php
+++ b/src/SPC/util/executor/UnixAutoconfExecutor.php
@@ -117,6 +117,12 @@ class UnixAutoconfExecutor extends Executor
         return $this;
     }
 
+    public function setEnv(array $env): static
+    {
+        $this->shell->setEnv($env);
+        return $this;
+    }
+
     /**
      * Returns the default autoconf ./configure arguments
      */

--- a/src/globals/test-extensions.php
+++ b/src/globals/test-extensions.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 // test php version (8.1 ~ 8.4 available, multiple for matrix)
 $test_php_version = [
-    // '8.1',
-    // '8.2',
-    // '8.3',
+    '8.1',
+    '8.2',
+    '8.3',
     '8.4',
     // '8.5',
     'git',
@@ -23,11 +23,11 @@ $test_php_version = [
 
 // test os (macos-13, macos-14, macos-15, ubuntu-latest, windows-latest are available)
 $test_os = [
-    // 'macos-13', // bin/spc for x86_64
+    'macos-13', // bin/spc for x86_64
     // 'macos-14',  // bin/spc for arm64
-    // 'macos-15', // bin/spc for arm64
+    'macos-15', // bin/spc for arm64
     'ubuntu-latest', // bin/spc-alpine-docker for x86_64
-    // 'ubuntu-22.04', // bin/spc-gnu-docker for x86_64
+    'ubuntu-22.04', // bin/spc-gnu-docker for x86_64
     'ubuntu-24.04', // bin/spc for x86_64
     'ubuntu-22.04-arm', // bin/spc-gnu-docker for arm64
     'ubuntu-24.04-arm', // bin/spc for arm64
@@ -50,8 +50,8 @@ $prefer_pre_built = false;
 
 // If you want to test your added extensions and libs, add below (comma separated, example `bcmath,openssl`).
 $extensions = match (PHP_OS_FAMILY) {
-    'Linux', 'Darwin' => 'bcmath,bz2,calendar,ctype,curl,dom,exif,fileinfo,filter,ftp,iconv,xml,mbstring,mbregex,mysqlnd,openssl,pdo,pdo_mysql,pdo_sqlite,phar,session,simplexml,soap,sockets,sqlite3,tokenizer,xmlwriter,xmlreader,zlib,zip',
-    'Windows' => 'bcmath,bz2,calendar,ctype,curl,dom,exif,fileinfo,filter,ftp,iconv,xml,mbstring,mbregex,mysqlnd,openssl,pdo,pdo_mysql,pdo_sqlite,phar,session,simplexml,soap,sockets,sqlite3,tokenizer,xmlwriter,xmlreader,zlib,zip',
+    'Linux', 'Darwin' => 'snmp',
+    'Windows' => 'snmp',
 };
 
 // If you want to test shared extensions, add them below (comma separated, example `bcmath,openssl`).
@@ -74,7 +74,7 @@ $with_libs = match (PHP_OS_FAMILY) {
 // You can use `common`, `bulk`, `minimal` or `none`.
 // note: combination is only available for *nix platform. Windows must use `none` combination
 $base_combination = match (PHP_OS_FAMILY) {
-    'Linux', 'Darwin' => 'none',
+    'Linux', 'Darwin' => 'minimal',
     'Windows' => 'none',
 };
 


### PR DESCRIPTION
## What does this PR do?

Fix #841 

Windows support seems a little complicated. The official php group is maintaining winlibs/net-snmp. Haven't tried yet. 

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- If you modified `*.php` or `*.json`, run them locally to ensure your changes are valid:
  - [ ] `composer cs-fix`
  - [ ] `composer analyse`
  - [ ] `composer test`
  - [ ] `bin/spc dev:sort-config`
- If it's an extension or dependency update, please ensure the following:
  - [ ] Add your test combination to `src/globals/test-extensions.php`.
  - [ ] If adding new or fixing bugs, add commit message containing `extension test` or `test extensions` to trigger full test suite.
