### PR TITLE
Remove spc.env.log due to potential secret leaks

### DIFF
--- a/src/SPC/exception/ExceptionHandler.php
+++ b/src/SPC/exception/ExceptionHandler.php
@@ -125,15 +125,6 @@ class ExceptionHandler
 
         self::logError("\n----------------------------------------\n");
 
-        // put getenv info to log
-        $env_log = fopen(SPC_ENV_LOG, 'a');
-        $env_info = getenv();
-        if ($env_info) {
-            foreach ($env_info as $k => $v) {
-                fwrite($env_log, $k . ' = ' . $v . PHP_EOL);
-            }
-        }
-
         self::logError('⚠ The ' . ConsoleColor::cyan('console output log') . ConsoleColor::red(' is saved in ') . ConsoleColor::none(SPC_OUTPUT_LOG));
         if (file_exists(SPC_SHELL_LOG)) {
             self::logError('⚠ The ' . ConsoleColor::cyan('shell output log') . ConsoleColor::red(' is saved in ') . ConsoleColor::none(SPC_SHELL_LOG));

--- a/src/globals/defines.php
+++ b/src/globals/defines.php
@@ -94,7 +94,6 @@ const SPC_SOURCE_LOCAL = 'local'; // download as local directory
 const SPC_LOGS_DIR = WORKING_DIR . DIRECTORY_SEPARATOR . 'log';
 const SPC_OUTPUT_LOG = SPC_LOGS_DIR . DIRECTORY_SEPARATOR . 'spc.output.log';
 const SPC_SHELL_LOG = SPC_LOGS_DIR . DIRECTORY_SEPARATOR . 'spc.shell.log';
-const SPC_ENV_LOG = SPC_LOGS_DIR . DIRECTORY_SEPARATOR . 'spc.env.log';
 
 ConsoleLogger::$date_format = 'H:i:s';
 ConsoleLogger::$format = '[%date%] [%level_short%] %body%';


### PR DESCRIPTION
## What does this PR do?

Remove spc.env.log due to potential secret leaks.

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- If you modified `*.php` or `*.json`, run them locally to ensure your changes are valid:
  - [ ] `composer cs-fix`
  - [ ] `composer analyse`
  - [ ] `composer test`
  - [ ] `bin/spc dev:sort-config`
- If it's an extension or dependency update, please ensure the following:
  - [ ] Add your test combination to `src/globals/test-extensions.php`.
  - [ ] If adding new or fixing bugs, add commit message containing `extension test` or `test extensions` to trigger full test suite.
