### PR TITLE
move -lstdc++ to the end of the libraries

### DIFF
--- a/src/SPC/builder/extension/redis.php
+++ b/src/SPC/builder/extension/redis.php
@@ -16,9 +16,11 @@ class redis extends Extension
         if ($this->isBuildStatic()) {
             $arg .= $this->builder->getExt('session')?->isBuildStatic() ? ' --enable-redis-session' : ' --disable-redis-session';
             $arg .= $this->builder->getExt('igbinary')?->isBuildStatic() ? ' --enable-redis-igbinary' : ' --disable-redis-igbinary';
+            $arg .= $this->builder->getExt('msgpack')?->isBuildStatic() ? ' --enable-redis-msgpack' : ' --disable-redis-msgpack';
         } else {
             $arg .= $this->builder->getExt('session') ? ' --enable-redis-session' : ' --disable-redis-session';
             $arg .= $this->builder->getExt('igbinary') ? ' --enable-redis-igbinary' : ' --disable-redis-igbinary';
+            $arg .= $this->builder->getExt('msgpack') ? ' --enable-redis-msgpack' : ' --disable-redis-msgpack';
         }
         if ($this->builder->getLib('zstd')) {
             $arg .= ' --enable-redis-zstd --with-libzstd="' . BUILD_ROOT_PATH . '"';

--- a/src/SPC/util/SPCConfigUtil.php
+++ b/src/SPC/util/SPCConfigUtil.php
@@ -80,9 +80,7 @@ class SPCConfigUtil
         }
         if ($this->builder->hasCpp()) {
             $libcpp = SPCTarget::getTargetOS() === 'Darwin' ? '-lc++' : '-lstdc++';
-            if (!str_contains($libs, $libcpp)) {
-                $libs .= " {$libcpp}";
-            }
+            $libs = str_replace($libcpp, '', $libs) . " {$libcpp}";
         }
 
         if ($this->libs_only_deps) {


### PR DESCRIPTION
## What does this PR do?
https://github.com/static-php/spc-packages/actions/runs/17057743582/job/48358419331#step:10:54

libjxl requests -lstdc++ in pkgconfig, so it's not added at the end again. icu comes later and also needs -lstdc++ though, so that leads to undefined references during linking

closes https://github.com/crazywhalecc/static-php-cli/pull/843