### PR TITLE
fix gcc version detection

### DIFF
--- a/src/SPC/builder/unix/UnixBuilderBase.php
+++ b/src/SPC/builder/unix/UnixBuilderBase.php
@@ -282,8 +282,8 @@ abstract class UnixBuilderBase extends BuilderBase
         $config = (new SPCConfigUtil($this))->config($this->ext_list, $this->lib_list);
         $env = [
             'CGO_ENABLED' => '1',
-            'CGO_CFLAGS' => $config['cflags'],
-            'CGO_LDFLAGS' => "{$staticFlags} {$config['ldflags']} {$config['libs']} {$lrt}",
+            'CGO_CFLAGS' => $this->arch_c_flags . ' ' . $config['cflags'],
+            'CGO_LDFLAGS' => $this->arch_ld_flags . " {$staticFlags} {$config['ldflags']} {$config['libs']} {$lrt} -lgcov",
             'XCADDY_GO_BUILD_FLAGS' => '-buildmode=pie ' .
                 '-ldflags \"-linkmode=external ' . $extLdFlags . ' ' . $debugFlags .
                 '-X \'github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP ' .

--- a/src/SPC/toolchain/GccNativeToolchain.php
+++ b/src/SPC/toolchain/GccNativeToolchain.php
@@ -42,7 +42,7 @@ class GccNativeToolchain implements ToolchainInterface
         $compiler = getenv('CC') ?: 'gcc';
         $version = shell(false)->execWithResult("{$compiler} --version", false);
         $head = pathinfo($compiler, PATHINFO_BASENAME);
-        if ($version[0] === 0 && preg_match('/gcc.*(\d+.\d+.\d+)/', $version[1][0], $match)) {
+        if ($version[0] === 0 && preg_match('/gcc.*?(\d+\.\d+\.\d+)/', $version[1][0], $match)) {
             return "{$head} {$match[1]}";
         }
         return $head;


### PR DESCRIPTION
## What does this PR do?
the regex was greedy and didn't escape the dots, so from 

`gcc 14.2.1-7` it matched `2.1-7`