### PR TITLE
build frankenphp and embed after shared extensions

### DIFF
--- a/src/SPC/builder/freebsd/BSDBuilder.php
+++ b/src/SPC/builder/freebsd/BSDBuilder.php
@@ -122,6 +122,11 @@ class BSDBuilder extends UnixBuilderBase
             }
             $this->buildEmbed();
         }
+        $shared_extensions = array_map('trim', array_filter(explode(',', $this->getOption('build-shared'))));
+        if (!empty($shared_extensions)) {
+            logger()->info('Building shared extensions ...');
+            $this->buildSharedExts();
+        }
         if ($enableFrankenphp) {
             logger()->info('building frankenphp');
             $this->buildFrankenphp();

--- a/src/SPC/builder/linux/LinuxBuilder.php
+++ b/src/SPC/builder/linux/LinuxBuilder.php
@@ -142,6 +142,12 @@ class LinuxBuilder extends UnixBuilderBase
             }
             $this->buildEmbed();
         }
+        // build dynamic extensions if needed, must happen before building FrankenPHP to make sure we export all necessary, undefined symbols
+        $shared_extensions = array_map('trim', array_filter(explode(',', $this->getOption('build-shared'))));
+        if (!empty($shared_extensions)) {
+            logger()->info('Building shared extensions ...');
+            $this->buildSharedExts();
+        }
         if ($enableFrankenphp) {
             logger()->info('building frankenphp');
             $this->buildFrankenphp();

--- a/src/SPC/builder/linux/LinuxBuilder.php
+++ b/src/SPC/builder/linux/LinuxBuilder.php
@@ -318,6 +318,8 @@ class LinuxBuilder extends UnixBuilderBase
         if (getenv('SPC_CMD_VAR_PHP_EMBED_TYPE') === 'static') {
             $AR = getenv('AR') ?: 'ar';
             f_passthru("{$AR} -t " . BUILD_LIB_PATH . "/libphp.a | grep '\\.a$' | xargs -n1 {$AR} d " . BUILD_LIB_PATH . '/libphp.a');
+            // export dynamic symbols
+            SystemUtil::exportDynamicSymbols(BUILD_LIB_PATH . '/libphp.a');
         }
 
         if (!$this->getOption('no-strip', false) && file_exists(BUILD_LIB_PATH . '/' . $realLibName)) {

--- a/src/SPC/builder/linux/library/liburing.php
+++ b/src/SPC/builder/linux/library/liburing.php
@@ -51,8 +51,7 @@ class liburing extends LinuxLibraryBase
                 $use_libc ? '--use-libc' : '',
             )
             ->configure()
-            ->make('library', with_clean: false)
-            ->exec("rm -rf {$this->getLibDir()}/liburing*.so*");
+            ->make('library', 'install ENABLE_SHARED=0', with_clean: false);
 
         $this->patchPkgconfPrefix();
     }

--- a/src/SPC/builder/macos/MacOSBuilder.php
+++ b/src/SPC/builder/macos/MacOSBuilder.php
@@ -156,6 +156,11 @@ class MacOSBuilder extends UnixBuilderBase
             }
             $this->buildEmbed();
         }
+        $shared_extensions = array_map('trim', array_filter(explode(',', $this->getOption('build-shared'))));
+        if (!empty($shared_extensions)) {
+            logger()->info('Building shared extensions ...');
+            $this->buildSharedExts();
+        }
         if ($enableFrankenphp) {
             logger()->info('building frankenphp');
             $this->buildFrankenphp();

--- a/src/SPC/builder/macos/MacOSBuilder.php
+++ b/src/SPC/builder/macos/MacOSBuilder.php
@@ -252,6 +252,8 @@ class MacOSBuilder extends UnixBuilderBase
         if (getenv('SPC_CMD_VAR_PHP_EMBED_TYPE') === 'static') {
             $AR = getenv('AR') ?: 'ar';
             f_passthru("{$AR} -t " . BUILD_LIB_PATH . "/libphp.a | grep '\\.a$' | xargs -n1 {$AR} d " . BUILD_LIB_PATH . '/libphp.a');
+            // export dynamic symbols
+            SystemUtil::exportDynamicSymbols(BUILD_LIB_PATH . '/libphp.a');
         }
         $this->patchPhpScripts();
     }

--- a/src/SPC/builder/traits/UnixSystemUtilTrait.php
+++ b/src/SPC/builder/traits/UnixSystemUtilTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SPC\builder\traits;
 
 use SPC\exception\ExecutionException;
+use SPC\exception\SPCInternalException;
 use SPC\exception\WrongUsageException;
 use SPC\toolchain\ToolchainManager;
 use SPC\toolchain\ZigToolchain;
@@ -66,7 +67,10 @@ trait UnixSystemUtilTrait
     {
         $symbol_file = "{$lib_file}.dynsym";
         if (!is_file($symbol_file)) {
-            return null;
+            self::exportDynamicSymbols($lib_file);
+        }
+        if (!is_file($symbol_file)) {
+            throw new SPCInternalException("The symbol file {$symbol_file} does not exist, please check if nm command is available.");
         }
         // https://github.com/ziglang/zig/issues/24662
         if (ToolchainManager::getToolchainClass() === ZigToolchain::class) {

--- a/src/SPC/builder/traits/UnixSystemUtilTrait.php
+++ b/src/SPC/builder/traits/UnixSystemUtilTrait.php
@@ -4,15 +4,88 @@ declare(strict_types=1);
 
 namespace SPC\builder\traits;
 
-/**
- * Unix 系统的工具函数 Trait，适用于 Linux、macOS
- */
+use SPC\exception\ExecutionException;
+use SPC\exception\WrongUsageException;
+use SPC\toolchain\ToolchainManager;
+use SPC\toolchain\ZigToolchain;
+use SPC\util\SPCTarget;
+
 trait UnixSystemUtilTrait
 {
     /**
-     * @param  string      $name  命令名称
-     * @param  array       $paths 寻找的目标路径（如果不传入，则使用环境变量 PATH）
-     * @return null|string 找到了返回命令路径，找不到返回 null
+     * Export static library dynamic symbols to a .dynsym file.
+     * It will export to "/path/to/libxxx.a.dynsym".
+     *
+     * @param string $lib_file Static library file path (e.g. /path/to/libxxx.a)
+     */
+    public static function exportDynamicSymbols(string $lib_file): void
+    {
+        // check
+        if (!is_file($lib_file)) {
+            throw new WrongUsageException("The lib archive file {$lib_file} does not exist, please build it first.");
+        }
+        // shell out
+        $cmd = 'nm -g --defined-only -P ' . escapeshellarg($lib_file);
+        $result = shell()->execWithResult($cmd);
+        if ($result[0] !== 0) {
+            throw new ExecutionException($cmd, 'Failed to get defined symbols from ' . $lib_file);
+        }
+        // parse shell output and filter
+        $defined = [];
+        foreach ($result[1] as $line) {
+            $line = trim($line);
+            if ($line === '' || str_ends_with($line, '.o:') || str_ends_with($line, '.o]:')) {
+                continue;
+            }
+            $name = strtok($line, " \t");
+            if (!$name) {
+                continue;
+            }
+            $name = preg_replace('/@.*$/', '', $name);
+            if ($name !== '' && $name !== false) {
+                $defined[] = $name;
+            }
+        }
+        $defined = array_unique($defined);
+        sort($defined);
+        // export
+        if (SPCTarget::getTargetOS() === 'Linux') {
+            file_put_contents("{$lib_file}.dynsym", "{\n" . implode("\n", array_map(fn ($x) => "  {$x};", $defined)) . "};\n");
+        } else {
+            file_put_contents("{$lib_file}.dynsym", implode("\n", $defined) . "\n");
+        }
+    }
+
+    /**
+     * Get linker flag to export dynamic symbols from a static library.
+     *
+     * @param  string      $lib_file Static library file path (e.g. /path/to/libxxx.a)
+     * @return null|string Linker flag to export dynamic symbols, null if no .dynsym file found
+     */
+    public static function getDynamicExportedSymbols(string $lib_file): ?string
+    {
+        $symbol_file = "{$lib_file}.dynsym";
+        if (!is_file($symbol_file)) {
+            return null;
+        }
+        // https://github.com/ziglang/zig/issues/24662
+        if (ToolchainManager::getToolchainClass() === ZigToolchain::class) {
+            return '-Wl,--export-dynamic';
+        }
+        // macOS
+        if (SPCTarget::getTargetOS() !== 'Linux') {
+            return "-Wl,-exported_symbols_list,{$symbol_file}";
+        }
+        return "-Wl,--dynamic-list={$symbol_file}";
+    }
+
+    /**
+     * Find a command in given paths or system PATH.
+     * If $name is an absolute path, check if it exists.
+     *
+     * @param  string      $name  Command name or absolute path
+     * @param  array       $paths Paths to search, if empty, use system PATH
+     * @return null|string Absolute path of the command if found, null otherwise
      */
     public static function findCommand(string $name, array $paths = []): ?string
     {
@@ -31,6 +104,8 @@ trait UnixSystemUtilTrait
     }
 
     /**
+     * Make environment variable string for shell command.
+     *
      * @param  array  $vars Variables, like: ["CFLAGS" => "-Ixxx"]
      * @return string like: CFLAGS="-Ixxx"
      */

--- a/src/SPC/builder/unix/UnixBuilderBase.php
+++ b/src/SPC/builder/unix/UnixBuilderBase.php
@@ -51,7 +51,7 @@ abstract class UnixBuilderBase extends BuilderBase
 
         if ($out = shell_exec('nm -g --defined-only -P ' . escapeshellarg($libphp) . ' 2>/dev/null')) {
             foreach (preg_split('/\R/', trim($out)) as $line) {
-                if ($line === '' || str_ends_with($line, '.o:')) {
+                if ($line === '' || str_ends_with($line, '.o:') || str_ends_with($line, '.o]:')) {
                     continue;
                 }
                 $name = strtok($line, " \t");
@@ -59,7 +59,7 @@ abstract class UnixBuilderBase extends BuilderBase
                     continue;
                 }
                 $name = preg_replace('/@.*$/', '', $name);
-                if ($name !== '' && $name !== false && !str_starts_with($name, $libphp)) {
+                if ($name !== '' && $name !== false) {
                     $defined[] = $name;
                 }
             }

--- a/src/SPC/builder/unix/UnixBuilderBase.php
+++ b/src/SPC/builder/unix/UnixBuilderBase.php
@@ -86,7 +86,7 @@ abstract class UnixBuilderBase extends BuilderBase
 
         $argument = "-Wl,--dynamic-list={$exportList}";
         if (ToolchainManager::getToolchainClass() === ZigToolchain::class) {
-            $argument = "-Wl,--export-dynamic";
+            $argument = '-Wl,--export-dynamic'; // https://github.com/ziglang/zig/issues/24662
         }
         if (SPCTarget::getTargetOS() !== 'Linux') {
             $argument = "-Wl,-exported_symbols_list {$exportList}";

--- a/src/SPC/builder/unix/UnixBuilderBase.php
+++ b/src/SPC/builder/unix/UnixBuilderBase.php
@@ -203,7 +203,7 @@ abstract class UnixBuilderBase extends BuilderBase
                     unlink($file);
                 }
                 $symbolList = $this->getDynamicExportSymbolsFile();
-                $dynamic_exports = $symbolList ? (' -Wl,--dynamic-list=' . $symbolList) : '';
+                $dynamic_exports = $symbolList ? (' -Wl,--dynamic-list' . (SPCTarget::getTargetOS() === 'Darwin' ? '-file' : '') . '=' . $symbolList) : '';
             }
             [$ret, $out] = shell()->cd($sample_file_path)->execWithResult(getenv('CC') . ' -o embed embed.c ' . $lens . ' ' . $dynamic_exports);
             if ($ret !== 0) {
@@ -327,7 +327,7 @@ abstract class UnixBuilderBase extends BuilderBase
         $dynamic_exports = '';
         if (getenv('SPC_CMD_VAR_PHP_EMBED_TYPE') === 'static') {
             $symbolList = $this->getDynamicExportSymbolsFile();
-            $dynamic_exports = $symbolList ? (' -Wl,--dynamic-list=' . $symbolList) : '';
+            $dynamic_exports = $symbolList ? (' -Wl,--dynamic-list' . (SPCTarget::getTargetOS() === 'Darwin' ? '-file' : '') . '=' . $symbolList) : '';
         }
         $extLdFlags = "-extldflags '-pie{$dynamic_exports}'";
         $muslTags = '';

--- a/src/SPC/builder/unix/UnixBuilderBase.php
+++ b/src/SPC/builder/unix/UnixBuilderBase.php
@@ -49,7 +49,9 @@ abstract class UnixBuilderBase extends BuilderBase
             throw new WrongUsageException('You must build libphp.a before calling this function.');
         }
 
-        $cmd = 'nm -g --defined-only -P ' . escapeshellarg($libphp) . ' 2>/dev/null';
+        $cmd = (SPCTarget::getTargetOS() === 'Linux')
+            ? 'nm -g --defined-only -P ' . escapeshellarg($libphp) . ' 2>/dev/null'
+            : 'nm -gUj ' . escapeshellarg($libphp) . ' 2>/dev/null';
         $out = shell_exec($cmd) ?: '';
         if ($out !== '') {
             foreach (preg_split('/\R/', trim($out)) as $line) {
@@ -89,7 +91,7 @@ abstract class UnixBuilderBase extends BuilderBase
             $argument = '-Wl,--export-dynamic'; // https://github.com/ziglang/zig/issues/24662
         }
         if (SPCTarget::getTargetOS() !== 'Linux') {
-            $argument = "-Wl,-exported_symbols_list {$exportList}";
+            $argument = "-Wl,-exported_symbols_list,{$exportList}";
         }
 
         $this->dynamic_export_list = $argument;

--- a/src/SPC/builder/unix/UnixBuilderBase.php
+++ b/src/SPC/builder/unix/UnixBuilderBase.php
@@ -203,7 +203,7 @@ abstract class UnixBuilderBase extends BuilderBase
                     unlink($file);
                 }
                 $symbolList = $this->getDynamicExportSymbolsFile();
-                $dynamic_exports = ' -Wl,--dynamic-list=' . $symbolList;
+                $dynamic_exports = $symbolList ? (' -Wl,--dynamic-list=' . $symbolList) : '';
             }
             [$ret, $out] = shell()->cd($sample_file_path)->execWithResult(getenv('CC') . ' -o embed embed.c ' . $lens . ' ' . $dynamic_exports);
             if ($ret !== 0) {
@@ -327,7 +327,7 @@ abstract class UnixBuilderBase extends BuilderBase
         $dynamic_exports = '';
         if (getenv('SPC_CMD_VAR_PHP_EMBED_TYPE') === 'static') {
             $symbolList = $this->getDynamicExportSymbolsFile();
-            $dynamic_exports = ' -Wl,--dynamic-list=' . $symbolList;
+            $dynamic_exports = $symbolList ? (' -Wl,--dynamic-list=' . $symbolList) : '';
         }
         $extLdFlags = "-extldflags '-pie{$dynamic_exports}'";
         $muslTags = '';

--- a/src/SPC/builder/unix/UnixBuilderBase.php
+++ b/src/SPC/builder/unix/UnixBuilderBase.php
@@ -49,13 +49,9 @@ abstract class UnixBuilderBase extends BuilderBase
             throw new WrongUsageException('You must build libphp.a before calling this function.');
         }
 
-        $cmd = (SPCTarget::getTargetOS() === 'Linux')
-            ? 'nm -g --defined-only -P ' . escapeshellarg($libphp) . ' 2>/dev/null'
-            : 'nm -gUj ' . escapeshellarg($libphp) . ' 2>/dev/null';
-        $out = shell_exec($cmd) ?: '';
-        if ($out !== '') {
+        if ($out = shell_exec('nm -g --defined-only -P ' . escapeshellarg($libphp) . ' 2>/dev/null')) {
             foreach (preg_split('/\R/', trim($out)) as $line) {
-                if ($line === '') {
+                if ($line === '' || str_ends_with($line, '.o:')) {
                     continue;
                 }
                 $name = strtok($line, " \t");

--- a/src/SPC/builder/unix/UnixBuilderBase.php
+++ b/src/SPC/builder/unix/UnixBuilderBase.php
@@ -338,16 +338,15 @@ abstract class UnixBuilderBase extends BuilderBase
         ), true);
         $frankenPhpVersion = $releaseInfo['tag_name'];
         $libphpVersion = $this->getPHPVersion();
-        if (getenv('SPC_CMD_VAR_PHP_EMBED_TYPE') === 'shared') {
-            $libphpVersion = preg_replace('/\.\d$/', '', $libphpVersion);
-        }
-        $debugFlags = $this->getOption('no-strip') ? '-w -s ' : '';
         $dynamic_exports = '';
-        if (getenv('SPC_CMD_VAR_PHP_EMBED_TYPE') === 'static') {
+        if (getenv('SPC_CMD_VAR_PHP_EMBED_TYPE') === 'shared') {
+            $libphpVersion = preg_replace('/\.\d+$/', '', $libphpVersion);
+        } else {
             if ($dynamicSymbolsArgument = $this->getDynamicExportSymbolsArgument()) {
                 $dynamic_exports = ' ' . $dynamicSymbolsArgument;
             }
         }
+        $debugFlags = $this->getOption('no-strip') ? '-w -s ' : '';
         $extLdFlags = "-extldflags '-pie{$dynamic_exports}'";
         $muslTags = '';
         $staticFlags = '';

--- a/src/SPC/command/BuildPHPCommand.php
+++ b/src/SPC/command/BuildPHPCommand.php
@@ -211,12 +211,6 @@ class BuildPHPCommand extends BuildCommand
         // start to build
         $builder->buildPHP($rule);
 
-        // build dynamic extensions if needed
-        if (!empty($shared_extensions)) {
-            logger()->info('Building shared extensions ...');
-            $builder->buildSharedExts();
-        }
-
         $builder->testPHP($rule);
 
         // compile stopwatch :P

--- a/src/globals/test-extensions.php
+++ b/src/globals/test-extensions.php
@@ -50,13 +50,13 @@ $prefer_pre_built = false;
 
 // If you want to test your added extensions and libs, add below (comma separated, example `bcmath,openssl`).
 $extensions = match (PHP_OS_FAMILY) {
-    'Linux', 'Darwin' => 'swoole,swoole-hook-mysql,swoole-hook-pgsql,swoole-hook-sqlite,swoole-hook-odbc,apcu,bcmath,bz2,calendar,ctype,curl,dba,dom,event,exif,fileinfo,filter,ftp,gd,gmp,iconv,imagick,intl,mbregex,mbstring,mysqli,mysqlnd,opcache,openssl,pcntl,pdo,pdo_mysql,pgsql,phar,posix,protobuf,readline,redis,session,shmop,simplexml,soap,sockets,sodium,sqlite3,swoole,sysvmsg,sysvsem,sysvshm,tokenizer,xml,xmlreader,xmlwriter,xsl,zip,zlib',
+    'Linux', 'Darwin' => 'bcmath',
     'Windows' => 'bcmath,bz2,calendar,ctype,curl,dom,exif,fileinfo,filter,ftp,iconv,xml,mbstring,mbregex,mysqlnd,openssl,pdo,pdo_mysql,pdo_sqlite,phar,session,simplexml,soap,sockets,sqlite3,tokenizer,xmlwriter,xmlreader,zlib,zip',
 };
 
 // If you want to test shared extensions, add them below (comma separated, example `bcmath,openssl`).
 $shared_extensions = match (PHP_OS_FAMILY) {
-    'Linux' => '',
+    'Linux' => 'zip',
     'Darwin' => '',
     'Windows' => '',
 };

--- a/src/globals/test-extensions.php
+++ b/src/globals/test-extensions.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 // test php version (8.1 ~ 8.4 available, multiple for matrix)
 $test_php_version = [
-    '8.1',
-    '8.2',
-    '8.3',
+    // '8.1',
+    // '8.2',
+    // '8.3',
     '8.4',
     // '8.5',
     // 'git',
@@ -28,9 +28,9 @@ $test_os = [
     'macos-15', // bin/spc for arm64
     'ubuntu-latest', // bin/spc-alpine-docker for x86_64
     'ubuntu-22.04', // bin/spc-gnu-docker for x86_64
-    'ubuntu-24.04', // bin/spc for x86_64
+    // 'ubuntu-24.04', // bin/spc for x86_64
     'ubuntu-22.04-arm', // bin/spc-gnu-docker for arm64
-    'ubuntu-24.04-arm', // bin/spc for arm64
+    // 'ubuntu-24.04-arm', // bin/spc for arm64
     // 'windows-latest', // .\bin\spc.ps1
 ];
 


### PR DESCRIPTION
make sure the linker doesn't drop libphp.a symbols that extensions need

## What does this PR do?

previously, if we built libphp.a, the linker cleans up dead symbols when creating the executable. This is undesirable, because when you try to load shared extensions with frankenphp, it will fail to load them with undefined references to `zend_ini_display_cb...` and other functions.

Now, instead of marking all symbols as dynamic, which *massively* bloats the executable size, we loop through all shared extensions, figure out what symbols they need, match that against what libphp.a provides and then mark those as export-dynamic.

Keep in mind that this *does* still increase the executable size a little! But it only takes effect when people build shared extensions.