### PR TITLE
Fix cli generator: prefer-pre-built belongs to download-options

### DIFF
--- a/docs/.vitepress/components/CliGenerator.vue
+++ b/docs/.vitepress/components/CliGenerator.vue
@@ -379,6 +379,11 @@ const craftCommandString = computed(() => {
     str += 'debug: true\n';
   }
 
+  if (preBuilt.value) {
+    str += 'download-options:\n';
+    str += '  prefer-pre-built: true\n';
+  }
+
   str += '{{position_hold}}';
 
   if (enableUPX.value) {
@@ -386,9 +391,6 @@ const craftCommandString = computed(() => {
   }
   if (zts.value) {
     str += '  enable-zts: true\n';
-  }
-  if (preBuilt.value) {
-    str += '  prefer-pre-built: true\n';
   }
 
   if (!str.endsWith('{{position_hold}}')) {


### PR DESCRIPTION
fix the craft.yml example generated by CliGenerator.vue:
the "prefer-pre-built" param belongs to "download-options" rather than "build-options"