### PR TITLE
retry fetching frankenphp release info

### DIFF
--- a/src/SPC/builder/unix/UnixBuilderBase.php
+++ b/src/SPC/builder/unix/UnixBuilderBase.php
@@ -271,6 +271,7 @@ abstract class UnixBuilderBase extends BuilderBase
         $releaseInfo = json_decode(Downloader::curlExec(
             'https://api.github.com/repos/php/frankenphp/releases/latest',
             hooks: [[CurlHook::class, 'setupGithubToken']],
+            retries: 3,
         ), true);
         $frankenPhpVersion = $releaseInfo['tag_name'];
         $libphpVersion = $this->getPHPVersion();


### PR DESCRIPTION
## What does this PR do?

Alternatively, instead of hardcoding the value, we could also get it from the environment variable the Downloader class uess. What do you think?