### PR TITLE
libxml2 build arg typo

### DIFF
--- a/src/SPC/builder/unix/library/libxml2.php
+++ b/src/SPC/builder/unix/library/libxml2.php
@@ -30,7 +30,7 @@ trait libxml2
             );
 
         if ($this instanceof LinuxLibraryBase) {
-            $cmake->addConfigureArgs('-DIconv_IS_BUILD_IN=OFF');
+            $cmake->addConfigureArgs('-DIconv_IS_BUILT_IN=OFF');
         }
 
         $cmake->build();


### PR DESCRIPTION
## What does this PR do?
`Iconv_IS_BUILD_IN` should be `Iconv_IS_BUILT_IN` in `libxml2` build arg


## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- If you modified `*.php` or `*.json`, run them locally to ensure your changes are valid:
  - [x] `composer cs-fix`
  - [x] `composer analyse`
  - [ ] `composer test`
  - [ ] `bin/spc dev:sort-config`
- If it's an extension or dependency update, please ensure the following:
  - [ ] Add your test combination to `src/globals/test-extensions.php`.
  - [ ] If adding new or fixing bugs, add commit message containing `extension test` or `test extensions` to trigger full test suite.
