### PR TITLE
Remove icu backend from libxml2

### DIFF
--- a/config/ext.json
+++ b/config/ext.json
@@ -414,9 +414,17 @@
             "libmemcached",
             "fastlz"
         ],
+        "lib-suggests": [
+            "zstd"
+        ],
         "ext-depends": [
             "session",
             "zlib"
+        ],
+        "ext-suggests": [
+            "igbinary",
+            "msgpack",
+            "session"
         ]
     },
     "mongodb": {

--- a/config/lib.json
+++ b/config/lib.json
@@ -450,6 +450,7 @@
     },
     "libmemcached": {
         "source": "libmemcached",
+        "cpp-library": true,
         "static-libs-unix": [
             "libmemcached.a",
             "libmemcachedprotocol.a",
@@ -594,7 +595,6 @@
         ],
         "lib-suggests-unix": [
             "xz",
-            "icu",
             "zlib"
         ],
         "lib-depends-windows": [

--- a/src/SPC/builder/extension/memcached.php
+++ b/src/SPC/builder/extension/memcached.php
@@ -17,6 +17,10 @@ class memcached extends Extension
             '--with-libmemcached-dir=' . BUILD_ROOT_PATH . ' ' .
             '--disable-memcached-sasl ' .
             '--enable-memcached-json ' .
+            ($this->builder->getLib('zstd') ? '--with-zstd ' : '') .
+            ($this->builder->getExt('igbinary') ? '--enable-memcached-igbinary ' : '') .
+            ($this->builder->getExt('session') ? '--enable-memcached-session ' : '') .
+            ($this->builder->getExt('msgpack') ? '--enable-memcached-msgpack ' : '') .
             '--with-system-fastlz';
     }
 }

--- a/src/SPC/builder/unix/library/libxml2.php
+++ b/src/SPC/builder/unix/library/libxml2.php
@@ -20,10 +20,10 @@ trait libxml2
                 "-DZLIB_INCLUDE_DIR={$this->getIncludeDir()}",
                 '-DLIBXML2_WITH_ZLIB=OFF',
             )
-            ->optionalLib('icu', ...cmake_boolean_args('LIBXML2_WITH_ICU'))
             ->optionalLib('xz', ...cmake_boolean_args('LIBXML2_WITH_LZMA'))
             ->addConfigureArgs(
                 '-DLIBXML2_WITH_ICONV=ON',
+                '-DLIBXML2_WITH_ICU=OFF', // optional, but discouraged: https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/README.md
                 '-DLIBXML2_WITH_PYTHON=OFF',
                 '-DLIBXML2_WITH_PROGRAMS=OFF',
                 '-DLIBXML2_WITH_TESTS=OFF',

--- a/src/globals/ext-tests/gettext.php
+++ b/src/globals/ext-tests/gettext.php
@@ -4,20 +4,40 @@ declare(strict_types=1);
 
 assert(function_exists('gettext'));
 assert(function_exists('bindtextdomain'));
+assert(function_exists('bind_textdomain_codeset'));
 assert(function_exists('textdomain'));
 
-if (!is_dir('locale/en_US/LC_MESSAGES/')) {
-    mkdir('locale/en_US/LC_MESSAGES/', 0755, true);
+foreach (['en_US', 'en_GB'] as $lc) {
+    $dir = "locale/{$lc}/LC_MESSAGES";
+    if (!is_dir($dir)) {
+        mkdir($dir, 0755, true);
+    }
+    $mo = '3hIElQAAAAACAAAAHAAAACwAAAAFAAAAPAAAAAAAAABQAAAABgAAAFEAAAAXAQAAWAAAAAcAAABwAQAAAQAAAAAAAAAAAAAAAgAAAAAAAAAA56S65L6LAFByb2plY3QtSWQtVmVyc2lvbjogUEFDS0FHRSBWRVJTSU9OClJlcG9ydC1Nc2dpZC1CdWdzLVRvOiAKUE8tUmV2aXNpb24tRGF0ZTogWUVBUi1NTy1EQSBITzpNSytaT05FCkxhc3QtVHJhbnNsYXRvcjogRlVMTCBOQU1FIDxFTUFJTEBBRERSRVNTPgpMYW5ndWFnZS1UZWFtOiBMQU5HVUFHRSA8TExAbGkub3JnPgpMYW5ndWFnZTogCk1JTUUtVmVyc2lvbjogMS4wCkNvbnRlbnQtVHlwZTogdGV4dC9wbGFpbjsgY2hhcnNldD1VVEYtOApDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiA4Yml0CgBFeGFtcGxlAA==';
+    $path = "{$dir}/test.mo";
+    if (!file_exists($path)) {
+        file_put_contents($path, base64_decode($mo));
+    }
 }
-if (!file_exists('locale/en_US/LC_MESSAGES/test.mo')) {
-    $mo = '3hIElQAAAAACAAAAHAAAACwAAAAFAAAAPAAAAAAAAABQAAAABgAAAFEAAAAXAQAAWAAAAAcAAABwAQAAAQAAAAAAAAAAAAAAAgAAAAAAAAAA56S65L6LAFByb2plY3QtSWQtVmVyc2lvbjogUEFDS0FHRSBWRVJTSU9OClJlcG9ydC1Nc2dpZC1CdWdzLVRvOiAKUE8tUmV2aXNpb24tRGF0ZTogWUVBUi1NTy1EQSBITzpNSStaT05FCkxhc3QtVHJhbnNsYXRvcjogRlVMTCBOQU1FIDxFTUFJTEBBRERSRVNTPgpMYW5ndWFnZS1UZWFtOiBMQU5HVUFHRSA8TExAbGkub3JnPgpMYW5ndWFnZTogCk1JTUUtVmVyc2lvbjogMS4wCkNvbnRlbnQtVHlwZTogdGV4dC9wbGFpbjsgY2hhcnNldD1VVEYtOApDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiA4Yml0CgBFeGFtcGxlAA==';
-    file_put_contents('locale/en_US/LC_MESSAGES/test.mo', base64_decode($mo));
-}
-putenv('LANG=en_US');
-assert(setlocale(LC_ALL, 'en_US.utf-8') === 'en_US.utf-8');
+
+// Probe for an available English locale
+$candidates = [
+    'en_US.UTF-8', 'en_US.utf8', 'en_US.utf-8', 'en_US',
+    'en_GB.UTF-8', 'en_GB.utf8', 'en_GB.utf-8', 'en_GB',
+    'English_United States.65001', 'English_United States.1252',
+    'English_United Kingdom.65001', 'English_United Kingdom.1252',
+];
+
+$locale = setlocale(LC_ALL, $candidates);
+assert($locale !== false);
+
+putenv('LC_ALL=' . $locale);
+putenv('LANG=' . $locale);
+putenv('LANGUAGE=' . (stripos($locale, 'US') !== false ? 'en_US:en_GB' : 'en_GB:en_US'));
 
 $domain = 'test';
 bindtextdomain($domain, 'locale/');
+bind_textdomain_codeset($domain, 'UTF-8');
 textdomain($domain);
 
-assert(gettext(json_decode('"\u793a\u4f8b"', true)) === 'Example');
+$src = json_decode('"\u793a\u4f8b"', true);
+assert(gettext($src) === 'Example');


### PR DESCRIPTION
## What does this PR do?
removes the icu backend from libxml2, because it is not recommended and will not be used if iconv is present, which we have as a depencency

this lead to roughly 32mb (before upx) of useless icu data floating around in the php binary when libxml2 was built, but intl wasn't


## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- If you modified `*.php` or `*.json`, run them locally to ensure your changes are valid:
  - [ ] `composer cs-fix`
  - [ ] `composer analyse`
  - [ ] `composer test`
  - [ ] `bin/spc dev:sort-config`
- If it's an extension or dependency update, please ensure the following:
  - [ ] Add your test combination to `src/globals/test-extensions.php`.
  - [ ] If adding new or fixing bugs, add commit message containing `extension test` or `test extensions` to trigger full test suite.
