### PR TITLE
don't download musl if zig isn't building for musl

### DIFF
--- a/src/SPC/doctor/item/LinuxMuslCheck.php
+++ b/src/SPC/doctor/item/LinuxMuslCheck.php
@@ -22,7 +22,7 @@ class LinuxMuslCheck
     public static function optionalCheck(): bool
     {
         return getenv('SPC_TOOLCHAIN') === MuslToolchain::class ||
-            (getenv('SPC_TOOLCHAIN') === ZigToolchain::class && !SystemUtil::isMuslDist());
+            (getenv('SPC_TOOLCHAIN') === ZigToolchain::class && !SystemUtil::isMuslDist() && !str_contains((string) getenv('SPC_TARGET'), 'gnu'));
     }
 
     /** @noinspection PhpUnused */


### PR DESCRIPTION
## What does this PR do?

just don't download musl libc when we use zig to build glibc