### PR TITLE
fix silly mistake in trader config.m4

### DIFF
--- a/src/SPC/builder/extension/trader.php
+++ b/src/SPC/builder/extension/trader.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\extension;
+
+use SPC\builder\Extension;
+use SPC\store\FileSystem;
+use SPC\util\CustomExt;
+
+#[CustomExt('trader')]
+class trader extends Extension
+{
+    public function patchBeforeBuildconf(): bool
+    {
+        FileSystem::replaceFileStr(SOURCE_PATH . '/php-src/ext/trader/config.m4', 'PHP_TA', 'PHP_TRADER');
+        return true;
+    }
+}


### PR DESCRIPTION
## What does this PR do?
makes sure that trader isn't compiled in statically if it's not meant to be