### PR TITLE
Fix argument naming in InstallPackageCommand for clarity

### DIFF
--- a/src/StaticPHP/Command/InstallPackageCommand.php
+++ b/src/StaticPHP/Command/InstallPackageCommand.php
@@ -8,19 +8,19 @@ use StaticPHP\DI\ApplicationContext;
 use StaticPHP\Package\PackageInstaller;
 use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand('install-pkg', 'Install additional packages', ['i', 'install-package'])]
+#[AsCommand('install-pkg', 'Install additional package', ['i', 'install-package'])]
 class InstallPackageCommand extends BaseCommand
 {
     public function configure()
     {
-        $this->addArgument('packages', null, 'The package to install (name or path)');
+        $this->addArgument('package', null, 'The package to install (name or path)');
     }
 
     public function handle(): int
     {
         ApplicationContext::set('elephant', true);
         $installer = new PackageInstaller([...$this->input->getOptions(), 'dl-prefer-binary' => true]);
-        $installer->addInstallPackage($this->input->getArgument('packages'));
+        $installer->addInstallPackage($this->input->getArgument('package'));
         $installer->run(true, true);
         return static::SUCCESS;
     }


### PR DESCRIPTION
## What does this PR do?

Fix https://github.com/crazywhalecc/static-php-cli/pull/980/files/20892ab1940df01243242017321dee8e29bbe714..dc5bf6dc98d55b7d07e18c8f3a03c7f69652ed21#r2594661944

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- If you modified `*.php` or `*.json`, run them locally to ensure your changes are valid:
  - [ ] `composer cs-fix`
  - [ ] `composer analyse`
  - [ ] `composer test`
  - [ ] `bin/spc dev:sort-config`
- If it's an extension or dependency update, please ensure the following:
  - [ ] Add your test combination to `src/globals/test-extensions.php`.
  - [ ] If adding new or fixing bugs, add commit message containing `extension test` or `test extensions` to trigger full test suite.
