### PR TITLE
add input with-suggested-libs for build command

### DIFF
--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -218,7 +218,7 @@ jobs:
         name: "Upload build logs on failure"
         uses: actions/upload-artifact@v4
         with:
-          name: php-cli-logs-${{ inputs.php-version }}-${{ inputs.os }}
+          name: spc-logs-${{ inputs.php-version }}-${{ inputs.os }}
           path: log/*.log
 
       # Upload cli executable


### PR DESCRIPTION
## What does this PR do?
Added the `--with-suggested-libs` flag input option to the CI build workflow. This will resolve some problems with the `sqlsrv` & `pdo_sqlsrv` extension on Debian environment (#1030).

> It's not consistent with the `download` command because suggested libs are automatically downloaded(`download --without-suggested`). But v3 is coming, it makes more sense to fix it in v3 due API changes.

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- If you modified `*.php` or `*.json`, run them locally to ensure your changes are valid:
  - [ ] `composer cs-fix`
  - [ ] `composer analyse`
  - [ ] `composer test`
  - [ ] `bin/spc dev:sort-config`
- If it's an extension or dependency update, please ensure the following:
  - [ ] Add your test combination to `src/globals/test-extensions.php`.
  - [ ] If adding new or fixing bugs, add commit message containing `extension test` or `test extensions` to trigger full test suite.
