### PR TITLE
Add condition for ffi patch

### DIFF
--- a/src/SPC/builder/extension/ffi.php
+++ b/src/SPC/builder/extension/ffi.php
@@ -5,11 +5,21 @@ declare(strict_types=1);
 namespace SPC\builder\extension;
 
 use SPC\builder\Extension;
+use SPC\builder\linux\SystemUtil;
+use SPC\store\SourcePatcher;
 use SPC\util\CustomExt;
 
 #[CustomExt('ffi')]
 class ffi extends Extension
 {
+    public function patchBeforeBuildconf(): bool
+    {
+        if (PHP_OS_FAMILY === 'Linux' && SystemUtil::getOSRelease()['dist'] === 'centos') {
+            return SourcePatcher::patchFfiCentos7FixO3strncmp();
+        }
+        return false;
+    }
+
     public function getUnixConfigureArg(bool $shared = false): string
     {
         return '--with-ffi' . ($shared ? '=shared' : '') . ' --enable-zend-signals';

--- a/src/SPC/store/SourcePatcher.php
+++ b/src/SPC/store/SourcePatcher.php
@@ -22,7 +22,7 @@ class SourcePatcher
         FileSystem::addSourceExtractHook('swoole', [__CLASS__, 'patchSwoole']);
         FileSystem::addSourceExtractHook('php-src', [__CLASS__, 'patchPhpLibxml212']);
         FileSystem::addSourceExtractHook('php-src', [__CLASS__, 'patchGDWin32']);
-        FileSystem::addSourceExtractHook('php-src', [__CLASS__, 'patchFfiCentos7FixO3strncmp']);
+        // FileSystem::addSourceExtractHook('php-src', [__CLASS__, 'patchFfiCentos7FixO3strncmp']);
         FileSystem::addSourceExtractHook('sqlsrv', [__CLASS__, 'patchSQLSRVWin32']);
         FileSystem::addSourceExtractHook('pdo_sqlsrv', [__CLASS__, 'patchSQLSRVWin32']);
         FileSystem::addSourceExtractHook('pdo_sqlsrv', [__CLASS__, 'patchSQLSRVPhp85']);


### PR DESCRIPTION
## What does this PR do?

Fix #1049 .

This is not a fix for supporting old patch version, just to let this patch be applied only when needed. 

This issue (and similar issues) does not exist in v3 because we will be deprecating CentOS 7 support, and other patch the triggering conditions were already set during the v3 refactoring.