### PR TITLE
fix: FrankenPHP build args

### DIFF
--- a/src/SPC/builder/unix/UnixBuilderBase.php
+++ b/src/SPC/builder/unix/UnixBuilderBase.php
@@ -457,8 +457,8 @@ abstract class UnixBuilderBase extends BuilderBase
             'XCADDY_GO_BUILD_FLAGS' => '-buildmode=pie ' .
                 '-ldflags \"-linkmode=external ' . $extLdFlags . ' ' .
                 '-X \'github.com/caddyserver/caddy/v2/modules/caddyhttp.ServerHeader=FrankenPHP Caddy\' ' .
+                '-X \'github.com/caddyserver/caddy/v2.CustomBinaryName=frankenphp\' ' .
                 '-X \'github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP ' .
-                '-X \'github.com/caddyserver/caddy/v2.CustomBinaryName=frankenphp ' .
                 "v{$frankenPhpVersion} PHP {$libphpVersion} Caddy'\\\" " .
                 "-tags={$muslTags}nobadger,nomysql,nopgx{$nobrotli}{$nowatcher}",
             'LD_LIBRARY_PATH' => BUILD_LIB_PATH,


### PR DESCRIPTION
## What does this PR do?

Fix a bug in Caddy build arguments introduced in https://github.com/crazywhalecc/static-php-cli/pull/1056.
This breaks FrankenPHP's CI: https://github.com/php/frankenphp/actions/runs/22896611170/job/66432268615

cc @henderkes 

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- If you modified `*.php` or `*.json`, run them locally to ensure your changes are valid:
  - [x] `composer cs-fix`
  - [x] `composer analyse`
  - [x] `composer test`
  - [x] `bin/spc dev:sort-config`
- If it's an extension or dependency update, please ensure the following:
  - [x] Add your test combination to `src/globals/test-extensions.php`.
  - [x] If adding new or fixing bugs, add commit message containing `extension test` or `test extensions` to trigger full test suite.
