### PR TITLE
[v2] Fix bunch of build bugs for Windows

### DIFF
--- a/config/ext.json
+++ b/config/ext.json
@@ -63,7 +63,8 @@
         ],
         "ext-depends-windows": [
             "zlib",
-            "openssl"
+            "openssl",
+            "brotli"
         ]
     },
     "dba": {

--- a/config/lib.json
+++ b/config/lib.json
@@ -109,8 +109,7 @@
             "krb5"
         ],
         "lib-suggests-windows": [
-            "brotli",
-            "zstd"
+            "brotli"
         ],
         "frameworks": [
             "CoreFoundation",

--- a/config/lib.json
+++ b/config/lib.json
@@ -762,7 +762,6 @@
             "xz"
         ],
         "lib-suggests-windows": [
-            "zstd",
             "openssl"
         ]
     },

--- a/src/SPC/builder/extension/sqlsrv.php
+++ b/src/SPC/builder/extension/sqlsrv.php
@@ -33,4 +33,14 @@ class sqlsrv extends Extension
         }
         return false;
     }
+
+    public function patchBeforeMake(): bool
+    {
+        $makefile = SOURCE_PATH . '\php-src\Makefile';
+        $makeContent = file_get_contents($makefile);
+        $makeContent = preg_replace('/^(CFLAGS_(?:PDO_)?SQLSRV=.*?)\s+\/W4\b/m', '$1', $makeContent);
+        $makeContent = preg_replace('/^(CFLAGS_(?:PDO_)?SQLSRV=.*?)\s+\/WX\b/m', '$1', $makeContent);
+        file_put_contents($makefile, $makeContent);
+        return true;
+    }
 }

--- a/src/SPC/builder/windows/library/libjpeg.php
+++ b/src/SPC/builder/windows/library/libjpeg.php
@@ -28,6 +28,7 @@ class libjpeg extends WindowsLibraryBase
                 '-DENABLE_STATIC=ON ' .
                 '-DBUILD_TESTING=OFF ' .
                 '-DWITH_JAVA=OFF ' .
+                '-DWITH_SIMD=OFF ' .
                 '-DWITH_CRT_DLL=OFF ' .
                 "-DENABLE_ZLIB_COMPRESSION={$zlib} " .
                 '-DCMAKE_INSTALL_PREFIX=' . BUILD_ROOT_PATH . ' '

--- a/src/SPC/builder/windows/library/ngtcp2.php
+++ b/src/SPC/builder/windows/library/ngtcp2.php
@@ -29,6 +29,7 @@ class ngtcp2 extends WindowsLibraryBase
                 '-DBUILD_SHARED_LIBS=OFF ' .
                 '-DENABLE_STATIC_CRT=ON ' .
                 '-DENABLE_LIB_ONLY=ON ' .
+                '-DENABLE_OPENSSL=OFF ' .
                 '-DCMAKE_INSTALL_PREFIX=' . BUILD_ROOT_PATH . ' '
             )
             ->execWithWrapper(

--- a/src/SPC/store/FileSystem.php
+++ b/src/SPC/store/FileSystem.php
@@ -152,7 +152,7 @@ class FileSystem
         $src_path = FileSystem::convertPath($from);
         switch (PHP_OS_FAMILY) {
             case 'Windows':
-                f_passthru('xcopy "' . $src_path . '" "' . $dst_path . '" /s/e/v/y/i');
+                f_passthru('xcopy "' . $src_path . '" "' . $dst_path . '" /s/e/y/i');
                 break;
             case 'Linux':
             case 'Darwin':

--- a/src/globals/ext-tests/openssl.php
+++ b/src/globals/ext-tests/openssl.php
@@ -31,6 +31,6 @@ if (file_exists('/etc/ssl/openssl.cnf')) {
     }
     assert($valid);
 }
-if (PHP_VERSION_ID >= 80500 && !PHP_ZTS && defined('OPENSSL_VERSION_NUMBER') && OPENSSL_VERSION_NUMBER >= 0x30200000) {
+if (PHP_VERSION_ID >= 80500 && (!PHP_ZTS || PHP_OS_FAMILY !== 'Windows') && defined('OPENSSL_VERSION_NUMBER') && OPENSSL_VERSION_NUMBER >= 0x30200000) {
     assert(function_exists('openssl_password_hash'));
 }

--- a/src/globals/ext-tests/openssl.php
+++ b/src/globals/ext-tests/openssl.php
@@ -31,6 +31,6 @@ if (file_exists('/etc/ssl/openssl.cnf')) {
     }
     assert($valid);
 }
-if (PHP_VERSION_ID >= 80500 && defined('OPENSSL_VERSION_NUMBER') && OPENSSL_VERSION_NUMBER >= 0x30200000) {
+if (PHP_VERSION_ID >= 80500 && !PHP_ZTS && defined('OPENSSL_VERSION_NUMBER') && OPENSSL_VERSION_NUMBER >= 0x30200000) {
     assert(function_exists('openssl_password_hash'));
 }

--- a/src/globals/test-extensions.php
+++ b/src/globals/test-extensions.php
@@ -24,11 +24,11 @@ $test_php_version = [
 // test os (macos-15-intel, macos-15, ubuntu-latest, windows-latest are available)
 $test_os = [
     // 'macos-15-intel', // bin/spc for x86_64
-    'macos-15', // bin/spc for arm64
-    'ubuntu-latest', // bin/spc-alpine-docker for x86_64
-    'ubuntu-22.04', // bin/spc-gnu-docker for x86_64
+    // 'macos-15', // bin/spc for arm64
+    // 'ubuntu-latest', // bin/spc-alpine-docker for x86_64
+    // 'ubuntu-22.04', // bin/spc-gnu-docker for x86_64
     // 'ubuntu-24.04', // bin/spc for x86_64
-    'ubuntu-22.04-arm', // bin/spc-gnu-docker for arm64
+    // 'ubuntu-22.04-arm', // bin/spc-gnu-docker for arm64
     // 'ubuntu-24.04-arm', // bin/spc for arm64
     // 'windows-2022', // .\bin\spc.ps1
     'windows-2025',
@@ -51,7 +51,7 @@ $prefer_pre_built = false;
 // If you want to test your added extensions and libs, add below (comma separated, example `bcmath,openssl`).
 $extensions = match (PHP_OS_FAMILY) {
     'Linux', 'Darwin' => 'zlib',
-    'Windows' => 'gd,zlib,mbstring,filter',
+    'Windows' => 'amqp,apcu,bcmath,bz2,calendar,ctype,curl,dba,dom,ds,exif,ffi,fileinfo,filter,ftp,gd,iconv,igbinary,libxml,mbregex,mbstring,mysqli,mysqlnd,opcache,openssl,pdo,pdo_mysql,pdo_sqlite,pdo_sqlsrv,phar,rar,redis,session,shmop,simdjson,simplexml,soap,sockets,sqlite3,sqlsrv,ssh2,sysvshm,tokenizer,xml,xmlreader,xmlwriter,yac,yaml,zip,zlib',
 };
 
 // If you want to test shared extensions, add them below (comma separated, example `bcmath,openssl`).


### PR DESCRIPTION
## What does this PR do?

Fix sqlsrv redundant cflags when building PHP. Resolve https://github.com/static-php/static-php-cli-hosted/actions/runs/23831532972/job/69465987785#step:13:17283 .

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- If you modified `*.php` or `*.json`, run them locally to ensure your changes are valid:
  - [X] `composer cs-fix`
  - [X] `composer analyse`
  - [X] `composer test`
  - [ ] `bin/spc dev:sort-config`
- If it's an extension or dependency update, please ensure the following:
  - [X] Add your test combination to `src/globals/test-extensions.php`.
  - [ ] If adding new or fixing bugs, add commit message containing `extension test` or `test extensions` to trigger full test suite.
