### PR TITLE
fix(xlswriter): fix macOS build with modern Clang (C23)

### DIFF
--- a/src/SPC/builder/extension/xlswriter.php
+++ b/src/SPC/builder/extension/xlswriter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SPC\builder\extension;
 
 use SPC\builder\Extension;
+use SPC\store\FileSystem;
 use SPC\store\SourcePatcher;
 use SPC\util\CustomExt;
 
@@ -28,6 +29,18 @@ class xlswriter extends Extension
     public function patchBeforeMake(): bool
     {
         $patched = parent::patchBeforeMake();
+
+        // Fix K&R C function declaration in bundled minizip rejected by modern Clang (C23 default)
+        $mztools = $this->source_dir . '/library/libxlsxwriter/third_party/minizip/mztools.c';
+        if (file_exists($mztools)) {
+            FileSystem::replaceFileStr(
+                $mztools,
+                "extern int ZEXPORT unzRepair(file, fileOut, fileOutTmp, nRecovered, bytesRecovered)\nconst char* file;\nconst char* fileOut;\nconst char* fileOutTmp;\nuLong* nRecovered;\nuLong* bytesRecovered;\n{",
+                "extern int ZEXPORT unzRepair(const char* file, const char* fileOut, const char* fileOutTmp, uLong* nRecovered, uLong* bytesRecovered)\n{"
+            );
+            $patched = true;
+        }
+
         if (PHP_OS_FAMILY === 'Windows') {
             // fix windows build with openssl extension duplicate symbol bug
             SourcePatcher::patchFile('spc_fix_xlswriter_win32.patch', $this->source_dir);

--- a/src/SPC/builder/extension/xlswriter.php
+++ b/src/SPC/builder/extension/xlswriter.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace SPC\builder\extension;
 
 use SPC\builder\Extension;
-use SPC\store\FileSystem;
 use SPC\store\SourcePatcher;
 use SPC\util\CustomExt;
+use SPC\util\GlobalEnvManager;
 
 #[CustomExt('xlswriter')]
 class xlswriter extends Extension
@@ -30,14 +30,9 @@ class xlswriter extends Extension
     {
         $patched = parent::patchBeforeMake();
 
-        // Fix K&R C function declaration in bundled minizip rejected by modern Clang (C23 default)
-        $mztools = $this->source_dir . '/library/libxlsxwriter/third_party/minizip/mztools.c';
-        if (file_exists($mztools)) {
-            FileSystem::replaceFileStr(
-                $mztools,
-                "extern int ZEXPORT unzRepair(file, fileOut, fileOutTmp, nRecovered, bytesRecovered)\nconst char* file;\nconst char* fileOut;\nconst char* fileOutTmp;\nuLong* nRecovered;\nuLong* bytesRecovered;\n{",
-                "extern int ZEXPORT unzRepair(const char* file, const char* fileOut, const char* fileOutTmp, uLong* nRecovered, uLong* bytesRecovered)\n{"
-            );
+        // Bundled minizip uses K&R C function declarations rejected by C23 (default on macOS with Xcode 16+)
+        if (PHP_OS_FAMILY !== 'Windows') {
+            GlobalEnvManager::putenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_CFLAGS=' . getenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_CFLAGS') . ' -std=gnu17');
             $patched = true;
         }
 
@@ -52,5 +47,10 @@ class xlswriter extends Extension
             return true;
         }
         return $patched;
+    }
+
+    protected function getExtraEnv(): array
+    {
+        return ['CFLAGS' => '-std=gnu17'];
     }
 }

--- a/src/SPC/builder/extension/xlswriter.php
+++ b/src/SPC/builder/extension/xlswriter.php
@@ -30,7 +30,7 @@ class xlswriter extends Extension
     {
         $patched = parent::patchBeforeMake();
 
-        // Bundled minizip uses K&R C function declarations rejected by C23 (default on macOS with Xcode 16+)
+        // Remove when https://github.com/viest/php-ext-xlswriter/pull/560 is merged
         if (PHP_OS_FAMILY !== 'Windows') {
             GlobalEnvManager::putenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_CFLAGS=' . getenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_CFLAGS') . ' -std=gnu17');
             $patched = true;
@@ -49,6 +49,7 @@ class xlswriter extends Extension
         return $patched;
     }
 
+    // Remove when https://github.com/viest/php-ext-xlswriter/pull/560 is merged
     protected function getExtraEnv(): array
     {
         return ['CFLAGS' => '-std=gnu17'];


### PR DESCRIPTION
## Summary
- The bundled minizip in xlswriter (pinned at libxlsxwriter `RELEASE_1.0.0`) uses a K&R-style function declaration in `mztools.c`
- Modern Clang on macOS defaults to C23, which **removed** K&R function definitions from the standard — this causes a hard syntax error, not a suppressible warning
- The upstream [libxlsxwriter `main` branch](https://github.com/jmcnamara/libxlsxwriter/blob/main/third_party/minizip/mztools.c) already has the ANSI C fix; the PECL extension just pins an old release
- This patch converts the K&R declaration to ANSI C in `patchBeforeMake()`, matching the upstream fix

## Error
```
ext/xlswriter/library/libxlsxwriter/third_party/minizip/mztools.c:30:30: error: unknown type name 'file'
   30 | extern int ZEXPORT unzRepair(file, fileOut, fileOutTmp, nRecovered, bytesRecovered)
```

## Test plan
- [x] Verify the fix applies cleanly by checking the string replacement targets match the actual source from PECL xlswriter
- [ ] macOS build should succeed with this patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)