### PR TITLE
Fix old PHP extension with newer C standard bug

### DIFF
--- a/src/SPC/store/SourcePatcher.php
+++ b/src/SPC/store/SourcePatcher.php
@@ -125,6 +125,15 @@ class SourcePatcher
             FileSystem::replaceFileRegex(SOURCE_PATH . '/php-src/configure', '/have_capstone="yes"/', 'have_capstone="no"');
         }
 
+        // PHP 8.2 and below: bcmath libbcmath uses K&R style C function
+        if (is_unix() && $builder->getPHPVersionID() < 80300) {
+            FileSystem::replaceFileStr(
+                SOURCE_PATH . '/php-src/configure',
+                "for ac_arg in '' -std=gnu23",
+                "for ac_arg in ''"
+            );
+        }
+
         if (file_exists(SOURCE_PATH . '/php-src/configure.ac.bak')) {
             // restore configure.ac
             FileSystem::restoreBackupFile(SOURCE_PATH . '/php-src/configure.ac');

--- a/src/SPC/store/SourcePatcher.php
+++ b/src/SPC/store/SourcePatcher.php
@@ -130,7 +130,7 @@ class SourcePatcher
             FileSystem::replaceFileStr(
                 SOURCE_PATH . '/php-src/configure',
                 "for ac_arg in '' -std=gnu23",
-                "for ac_arg in ''"
+                "for ac_arg in '' -std=gnu17",
             );
         }
 

--- a/src/SPC/util/executor/UnixCMakeExecutor.php
+++ b/src/SPC/util/executor/UnixCMakeExecutor.php
@@ -182,7 +182,7 @@ class UnixCMakeExecutor extends Executor
         $target_arch = arch2gnu(php_uname('m'));
         $cflags = getenv('SPC_DEFAULT_C_FLAGS');
         $cc = getenv('CC');
-        $cxx = getenv('CCX');
+        $cxx = getenv('CXX');
         $include = BUILD_INCLUDE_PATH;
         logger()->debug("making cmake tool chain file for {$os} {$target_arch} with CFLAGS='{$cflags}'");
         $root = BUILD_ROOT_PATH;


### PR DESCRIPTION
## What does this PR do?

- Fix https://github.com/static-php/static-php-cli-hosted/actions/runs/24241425139/job/70776700964
- Typo fix

Tested on local machine.

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- If you modified `*.php` or `*.json`, run them locally to ensure your changes are valid:
  - [ ] `composer cs-fix`
  - [ ] `composer analyse`
  - [ ] `composer test`
  - [ ] `bin/spc dev:sort-config`
- If it's an extension or dependency update, please ensure the following:
  - [X] Add your test combination to `src/globals/test-extensions.php`.
  - [ ] If adding new or fixing bugs, add commit message containing `extension test` or `test extensions` to trigger full test suite.
