### PR TITLE
fix libkrb5 and decimal shard build

### DIFF
--- a/src/SPC/builder/extension/decimal.php
+++ b/src/SPC/builder/extension/decimal.php
@@ -22,7 +22,7 @@ class decimal extends Extension
             ],
             [
                 'zend_module_entry php_decimal_module_entry',
-                'ZEND_GET_MODULE(php_decimal)'
+                'ZEND_GET_MODULE(php_decimal)',
             ]
         );
         FileSystem::replaceFileStr(

--- a/src/SPC/builder/extension/decimal.php
+++ b/src/SPC/builder/extension/decimal.php
@@ -16,8 +16,14 @@ class decimal extends Extension
     {
         FileSystem::replaceFileStr(
             $this->source_dir . '/php_decimal.c',
-            'zend_module_entry decimal_module_entry',
-            'zend_module_entry php_decimal_module_entry'
+            [
+                'zend_module_entry decimal_module_entry',
+                'ZEND_GET_MODULE(decimal)',
+            ],
+            [
+                'zend_module_entry php_decimal_module_entry',
+                'ZEND_GET_MODULE(php_decimal)'
+            ]
         );
         FileSystem::replaceFileStr(
             $this->source_dir . '/config.w32',

--- a/src/SPC/builder/unix/library/krb5.php
+++ b/src/SPC/builder/unix/library/krb5.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace SPC\builder\unix\library;
 
+use SPC\toolchain\ToolchainManager;
+use SPC\toolchain\ZigToolchain;
 use SPC\util\executor\UnixAutoconfExecutor;
 use SPC\util\SPCConfigUtil;
 
@@ -39,13 +41,16 @@ trait krb5
             $extraEnv['LDFLAGS'] = '-framework Kerberos';
             $args[] = 'ac_cv_func_secure_getenv=no';
         }
-        UnixAutoconfExecutor::create($this)
+        $make = UnixAutoconfExecutor::create($this)
             ->appendEnv($extraEnv)
             ->optionalLib('ldap', '--with-ldap', '--without-ldap')
             ->optionalLib('libedit', '--with-libedit', '--without-libedit')
-            ->configure(...$args)
-            ->exec('find . -name Makefile -exec sed -i "s/-Werror=incompatible-pointer-types//g" {} +')
-            ->make();
+            ->configure(...$args);
+
+        if (ToolchainManager::getToolchainClass() === ZigToolchain::class) {
+            $make->exec('find . -name Makefile -exec sed -i "s/-Werror=incompatible-pointer-types//g" {} +');
+        }
+        $make->make();
         $this->patchPkgconfPrefix([
             'krb5-gssapi.pc',
             'krb5.pc',

--- a/src/SPC/builder/unix/library/krb5.php
+++ b/src/SPC/builder/unix/library/krb5.php
@@ -44,6 +44,7 @@ trait krb5
             ->optionalLib('ldap', '--with-ldap', '--without-ldap')
             ->optionalLib('libedit', '--with-libedit', '--without-libedit')
             ->configure(...$args)
+            ->exec('find . -name Makefile -exec sed -i "s/-Werror=incompatible-pointer-types//g" {} +')
             ->make();
         $this->patchPkgconfPrefix([
             'krb5-gssapi.pc',


### PR DESCRIPTION
## What does this PR do?
fixes zig-cc 0.16 being stricter. Silly of krb5 to define -Werror on it when they assign a const pointer to a non-const pointer type.


## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- If you modified `*.php` or `*.json`, run them locally to ensure your changes are valid:
  - [ ] `composer cs-fix`
  - [ ] `composer analyse`
  - [ ] `composer test`
  - [ ] `bin/spc dev:sort-config`
- If it's an extension or dependency update, please ensure the following:
  - [ ] Add your test combination to `src/globals/test-extensions.php`.
  - [ ] If adding new or fixing bugs, add commit message containing `extension test` or `test extensions` to trigger full test suite.
