### PR TITLE
Add linux mint to ubuntu/debian variants

### DIFF
--- a/src/SPC/doctor/item/LinuxToolCheckList.php
+++ b/src/SPC/doctor/item/LinuxToolCheckList.php
@@ -109,7 +109,7 @@ class LinuxToolCheckList
     public function fixBuildTools(array $distro, array $missing): bool
     {
         $install_cmd = match ($distro['dist']) {
-            'ubuntu', 'debian', 'Deepin' => 'apt-get install -y',
+            'ubuntu', 'debian', 'linuxmint', 'Deepin' => 'apt-get install -y',
             'alpine' => 'apk add',
             'redhat' => 'dnf install -y',
             'centos' => 'yum install -y',


### PR DESCRIPTION
Since Linux Mint is by default based on Ubuntu, but LMDE is based on Debian, this change should work in both OSes (at least it works on my LMDE 7 machine)
