### PR TITLE
patch 8.3 src to use avx512 cache vars

### DIFF
--- a/src/SPC/store/SourcePatcher.php
+++ b/src/SPC/store/SourcePatcher.php
@@ -95,6 +95,10 @@ class SourcePatcher
         // patch php-src/build/php.m4 PKG_CHECK_MODULES -> PKG_CHECK_MODULES_STATIC
         FileSystem::replaceFileStr(SOURCE_PATH . '/php-src/build/php.m4', 'PKG_CHECK_MODULES(', 'PKG_CHECK_MODULES_STATIC(');
 
+        if ($builder->getPHPVersionID() >= 80300 && $builder->getPHPVersionID() < 80400) {
+            self::patchFile('spc_fix_avx512_cache_before_80400.patch', SOURCE_PATH . '/php-src');
+        }
+
         if ($builder->getOption('enable-micro-win32')) {
             self::patchMicroWin32();
         } else {

--- a/src/globals/patch/spc_fix_avx512_cache_before_80400.patch
+++ b/src/globals/patch/spc_fix_avx512_cache_before_80400.patch
@@ -1,0 +1,91 @@
+--- a/build/php.m4
++++ b/build/php.m4
+@@ -2812,27 +2812,26 @@
+ dnl PHP_CHECK_AVX512_SUPPORTS
+ dnl
+ AC_DEFUN([PHP_CHECK_AVX512_SUPPORTS], [
+-  AC_MSG_CHECKING([for avx512 supports in compiler])
+-  save_CFLAGS="$CFLAGS"
+-  CFLAGS="-mavx512f -mavx512cd -mavx512vl -mavx512dq -mavx512bw $CFLAGS"
+-
+-  AC_LINK_IFELSE([AC_LANG_SOURCE([[
+-    #include <immintrin.h>
+-      int main(void) {
+-        __m512i mask = _mm512_set1_epi32(0x1);
+-        char out[32];
+-        _mm512_storeu_si512(out, _mm512_shuffle_epi8(mask, mask));
+-        return 0;
+-    }]])], [
++  AC_CACHE_CHECK([whether compiler supports AVX-512], [php_cv_have_avx512], [
++    save_CFLAGS="$CFLAGS"
++    CFLAGS="-mavx512f -mavx512cd -mavx512vl -mavx512dq -mavx512bw $CFLAGS"
++    AC_LINK_IFELSE([AC_LANG_SOURCE([[
++      #include <immintrin.h>
++        int main(void) {
++          __m512i mask = _mm512_set1_epi32(0x1);
++          char out[32];
++          _mm512_storeu_si512(out, _mm512_shuffle_epi8(mask, mask));
++          return 0;
++      }]])],
++      [php_cv_have_avx512=yes],
++      [php_cv_have_avx512=no])
++    CFLAGS="$save_CFLAGS"
++  ])
++  if test "$php_cv_have_avx512" = "yes"; then
+     have_avx512_supports=1
+-    AC_MSG_RESULT([yes])
+-  ], [
++  else
+     have_avx512_supports=0
+-    AC_MSG_RESULT([no])
+-  ])
+-
+-  CFLAGS="$save_CFLAGS"
+-
++  fi
+   AC_DEFINE_UNQUOTED([PHP_HAVE_AVX512_SUPPORTS],
+    [$have_avx512_supports], [Whether the compiler supports AVX512])
+ ])
+@@ -2841,24 +2840,26 @@
+ dnl PHP_CHECK_AVX512_VBMI_SUPPORTS
+ dnl
+ AC_DEFUN([PHP_CHECK_AVX512_VBMI_SUPPORTS], [
+-  AC_MSG_CHECKING([for avx512 vbmi supports in compiler])
+-  save_CFLAGS="$CFLAGS"
+-  CFLAGS="-mavx512f -mavx512cd -mavx512vl -mavx512dq -mavx512bw -mavx512vbmi $CFLAGS"
+-  AC_LINK_IFELSE([AC_LANG_SOURCE([[
+-    #include <immintrin.h>
+-      int main(void) {
+-        __m512i mask = _mm512_set1_epi32(0x1);
+-        char out[32];
+-        _mm512_storeu_si512(out, _mm512_permutexvar_epi8(mask, mask));
+-        return 0;
+-    }]])], [
++  AC_CACHE_CHECK([whether compiler supports AVX-512 VBMI], [php_cv_have_avx512vbmi], [
++    save_CFLAGS="$CFLAGS"
++    CFLAGS="-mavx512f -mavx512cd -mavx512vl -mavx512dq -mavx512bw -mavx512vbmi $CFLAGS"
++    AC_LINK_IFELSE([AC_LANG_SOURCE([[
++      #include <immintrin.h>
++        int main(void) {
++          __m512i mask = _mm512_set1_epi32(0x1);
++          char out[32];
++          _mm512_storeu_si512(out, _mm512_permutexvar_epi8(mask, mask));
++          return 0;
++      }]])],
++      [php_cv_have_avx512vbmi=yes],
++      [php_cv_have_avx512vbmi=no])
++    CFLAGS="$save_CFLAGS"
++  ])
++  if test "$php_cv_have_avx512vbmi" = "yes"; then
+     have_avx512_vbmi_supports=1
+-    AC_MSG_RESULT([yes])
+-  ], [
++  else
+     have_avx512_vbmi_supports=0
+-    AC_MSG_RESULT([no])
+-  ])
+-  CFLAGS="$save_CFLAGS"
++  fi
+   AC_DEFINE_UNQUOTED([PHP_HAVE_AVX512_VBMI_SUPPORTS],
+    [$have_avx512_vbmi_supports], [Whether the compiler supports AVX512 VBMI])
+ ])


### PR DESCRIPTION
## What does this PR do?

closes https://github.com/crazywhalecc/static-php-cli/issues/1111
also closes https://github.com/crazywhalecc/static-php-cli/pull/1114 , whatever that attempt was
turns out 8.2 had no avx512, 8.3 ran the checks unconditionally.
backported the 8.4 checks into 8.3 here.

## Checklist before merging

> If your PR involves the changes mentioned below and completed the action, please tick the corresponding option.
> If a modification is not involved, please skip it directly.

- If you modified `*.php` or `*.json`, run them locally to ensure your changes are valid:
  - [ ] `composer cs-fix`
  - [ ] `composer analyse`
  - [ ] `composer test`
  - [ ] `bin/spc dev:sort-config`
- If it's an extension or dependency update, please ensure the following:
  - [ ] Add your test combination to `src/globals/test-extensions.php`.
  - [ ] If adding new or fixing bugs, add commit message containing `extension test` or `test extensions` to trigger full test suite.
