### PR TITLE
perf: profile guided optimizations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,10 +32,13 @@ jobs:
           php-version: '8.4'
           extensions: curl, openssl, mbstring
           ini-values: memory_limit=-1
-          tools: pecl, composer, php-cs-fixer
+          tools: pecl, composer
+
+      - name: "Install dependencies"
+        run: composer install --no-progress --prefer-dist --optimize-autoloader
 
       - name: Run PHP-CS-Fixer fix
-        run: php-cs-fixer fix --dry-run --diff --ansi
+        run: vendor/bin/php-cs-fixer fix --dry-run --diff --ansi
 
   phpstan:
     runs-on: ubuntu-latest

--- a/composer.lock
+++ b/composer.lock
@@ -2603,6 +2603,75 @@
             "time": "2025-04-07T20:06:18+00:00"
         },
         {
+            "name": "ergebnis/agent-detector",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/agent-detector.git",
+                "reference": "5b654a9f1ff8a5d2ce6a57568df5ae8801c87f64"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/agent-detector/zipball/5b654a9f1ff8a5d2ce6a57568df5ae8801c87f64",
+                "reference": "5b654a9f1ff8a5d2ce6a57568df5ae8801c87f64",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0 || ~8.6.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.50.0",
+                "ergebnis/license": "^2.7.0",
+                "ergebnis/php-cs-fixer-config": "^6.60.2",
+                "ergebnis/phpstan-rules": "^2.13.1",
+                "ergebnis/phpunit-slow-test-detector": "^2.24.0",
+                "ergebnis/rector-rules": "^1.16.0",
+                "fakerphp/faker": "^1.24.1",
+                "infection/infection": "^0.26.6",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^2.1.46",
+                "phpstan/phpstan-deprecation-rules": "^2.0.4",
+                "phpstan/phpstan-phpunit": "^2.0.16",
+                "phpstan/phpstan-strict-rules": "^2.0.10",
+                "phpunit/phpunit": "^9.6.34",
+                "rector/rector": "^2.4.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.0-dev"
+                },
+                "composer-normalize": {
+                    "indent-size": 2,
+                    "indent-style": "space"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\AgentDetector\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com",
+                    "homepage": "https://localheinz.com"
+                }
+            ],
+            "description": "Provides a detector for detecting the presence of an agent.",
+            "homepage": "https://github.com/ergebnis/agent-detector",
+            "support": {
+                "issues": "https://github.com/ergebnis/agent-detector/issues",
+                "security": "https://github.com/ergebnis/agent-detector/blob/main/.github/SECURITY.md",
+                "source": "https://github.com/ergebnis/agent-detector"
+            },
+            "time": "2026-04-10T13:45:13+00:00"
+        },
+        {
             "name": "evenement/evenement",
             "version": "v3.0.2",
             "source": {
@@ -2864,22 +2933,23 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.92.3",
+            "version": "v3.95.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "2ba8f5a60f6f42fb65758cfb3768434fa2d1c7e8"
+                "reference": "a9727678fbd12997f1d9de8f4a37824ed9df1065"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/2ba8f5a60f6f42fb65758cfb3768434fa2d1c7e8",
-                "reference": "2ba8f5a60f6f42fb65758cfb3768434fa2d1c7e8",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/a9727678fbd12997f1d9de8f4a37824ed9df1065",
+                "reference": "a9727678fbd12997f1d9de8f4a37824ed9df1065",
                 "shasum": ""
             },
             "require": {
                 "clue/ndjson-react": "^1.3",
                 "composer/semver": "^3.4",
                 "composer/xdebug-handler": "^3.0.5",
+                "ergebnis/agent-detector": "^1.1.1",
                 "ext-filter": "*",
                 "ext-hash": "*",
                 "ext-json": "*",
@@ -2890,7 +2960,7 @@
                 "react/event-loop": "^1.5",
                 "react/socket": "^1.16",
                 "react/stream": "^1.4",
-                "sebastian/diff": "^4.0.6 || ^5.1.1 || ^6.0.2 || ^7.0",
+                "sebastian/diff": "^4.0.6 || ^5.1.1 || ^6.0.2 || ^7.0 || ^8.0",
                 "symfony/console": "^5.4.47 || ^6.4.24 || ^7.0 || ^8.0",
                 "symfony/event-dispatcher": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
                 "symfony/filesystem": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
@@ -2904,18 +2974,18 @@
                 "symfony/stopwatch": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "facile-it/paraunit": "^1.3.1 || ^2.7",
-                "infection/infection": "^0.31.0",
-                "justinrainbow/json-schema": "^6.5",
-                "keradus/cli-executor": "^2.2",
+                "facile-it/paraunit": "^1.3.1 || ^2.8.0",
+                "infection/infection": "^0.32.6",
+                "justinrainbow/json-schema": "^6.8.0",
+                "keradus/cli-executor": "^2.3",
                 "mikey179/vfsstream": "^1.6.12",
-                "php-coveralls/php-coveralls": "^2.9",
-                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.6",
-                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.6",
-                "phpunit/phpunit": "^9.6.25 || ^10.5.53 || ^11.5.34",
+                "php-coveralls/php-coveralls": "^2.9.1",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.8",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.8",
+                "phpunit/phpunit": "^9.6.34 || ^10.5.63 || ^11.5.55",
                 "symfony/polyfill-php85": "^1.33",
-                "symfony/var-dumper": "^5.4.48 || ^6.4.24 || ^7.3.2 || ^8.0",
-                "symfony/yaml": "^5.4.45 || ^6.4.24 || ^7.3.2 || ^8.0"
+                "symfony/var-dumper": "^5.4.48 || ^6.4.32 || ^7.4.4 || ^8.0.8",
+                "symfony/yaml": "^5.4.45 || ^6.4.30 || ^7.4.1 || ^8.0.8"
             },
             "suggest": {
                 "ext-dom": "For handling output formats in XML",
@@ -2956,7 +3026,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.92.3"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.1"
             },
             "funding": [
                 {
@@ -2964,7 +3034,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-18T10:45:02+00:00"
+            "time": "2026-04-12T17:00:09+00:00"
         },
         {
             "name": "humbug/box",
@@ -7573,5 +7643,5 @@
         "ext-zlib": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/config/env.ini
+++ b/config/env.ini
@@ -93,6 +93,7 @@ SPC_LIBC=musl
 CC=${SPC_LINUX_DEFAULT_CC}
 CXX=${SPC_LINUX_DEFAULT_CXX}
 AR=${SPC_LINUX_DEFAULT_AR}
+RANLIB=${SPC_LINUX_DEFAULT_RANLIB}
 LD=${SPC_LINUX_DEFAULT_LD}
 ; default compiler flags, used in CMake toolchain file, openssl and pkg-config build
 SPC_DEFAULT_C_FLAGS="-fPIC -Os"

--- a/config/ext.json
+++ b/config/ext.json
@@ -43,6 +43,19 @@
     "calendar": {
         "type": "builtin"
     },
+    "clickhouse": {
+        "support": {
+            "Windows": "wip",
+            "BSD": "wip"
+        },
+        "type": "external",
+        "source": "ext-clickhouse",
+        "arg-type": "custom",
+        "cpp-extension": true,
+        "lib-suggests": [
+            "openssl"
+        ]
+    },
     "com_dotnet": {
         "support": {
             "BSD": "no",
@@ -159,6 +172,30 @@
     },
     "exif": {
         "type": "builtin"
+    },
+    "fastchart": {
+        "support": {
+            "Windows": "wip",
+            "BSD": "wip"
+        },
+        "type": "external",
+        "source": "ext-fastchart",
+        "lib-depends": [
+            "freetype"
+        ],
+        "lib-suggests": [
+            "libpng",
+            "libjpeg",
+            "libwebp"
+        ]
+    },
+    "fastjson": {
+        "support": {
+            "Windows": "wip",
+            "BSD": "wip"
+        },
+        "type": "external",
+        "source": "ext-fastjson"
     },
     "ffi": {
         "support": {

--- a/config/ext.json
+++ b/config/ext.json
@@ -287,6 +287,7 @@
         "support": {
             "BSD": "wip"
         },
+        "arg-type": "with-path",
         "type": "external",
         "source": "ext-gmssl",
         "lib-depends": [

--- a/config/lib.json
+++ b/config/lib.json
@@ -454,6 +454,7 @@
     },
     "libheif": {
         "source": "libheif",
+        "cpp-library": true,
         "static-libs-unix": [
             "libheif.a"
         ],

--- a/config/lib.json
+++ b/config/lib.json
@@ -123,7 +123,7 @@
             "libfastlz.a"
         ],
         "headers": [
-            "fastlz/fastlz.h"
+            "fastlz.h"
         ]
     },
     "freetype": {

--- a/config/source.json
+++ b/config/source.json
@@ -421,9 +421,9 @@
         }
     },
     "gmssl": {
-        "type": "ghtar",
-        "repo": "guanzhi/GmSSL",
-        "provide-pre-built": true,
+        "type": "git",
+        "url": "https://github.com/guanzhi/GmSSL.git",
+        "rev": "master",
         "license": {
             "type": "file",
             "path": "LICENSE"

--- a/config/source.json
+++ b/config/source.json
@@ -133,6 +133,16 @@
             "path": "LICENSE"
         }
     },
+    "ext-clickhouse": {
+        "type": "ghtagtar",
+        "repo": "iliaal/php_clickhouse",
+        "match": "tarball/refs/tags/\\d",
+        "path": "php-src/ext/clickhouse",
+        "license": {
+            "type": "file",
+            "path": "LICENSE"
+        }
+    },
     "ext-ds": {
         "type": "url",
         "url": "https://pecl.php.net/get/ds",
@@ -157,6 +167,24 @@
         "url": "https://pecl.php.net/get/excimer",
         "path": "php-src/ext/excimer",
         "filename": "excimer.tgz",
+        "license": {
+            "type": "file",
+            "path": "LICENSE"
+        }
+    },
+    "ext-fastchart": {
+        "type": "ghtagtar",
+        "repo": "iliaal/fastchart",
+        "path": "php-src/ext/fastchart",
+        "license": {
+            "type": "file",
+            "path": "LICENSE"
+        }
+    },
+    "ext-fastjson": {
+        "type": "ghtagtar",
+        "repo": "iliaal/fastjson",
+        "path": "php-src/ext/fastjson",
         "license": {
             "type": "file",
             "path": "LICENSE"

--- a/config/source.json
+++ b/config/source.json
@@ -1108,7 +1108,7 @@
     },
     "protobuf": {
         "type": "url",
-        "url": "https://pecl.php.net/get/protobuf-5.34.1.tgz",
+        "url": "https://pecl.php.net/get/protobuf",
         "path": "php-src/ext/protobuf",
         "filename": "protobuf.tgz",
         "license": {

--- a/src/SPC/builder/BuilderBase.php
+++ b/src/SPC/builder/BuilderBase.php
@@ -29,7 +29,7 @@ abstract class BuilderBase
     /** @var array<int, string> extension names */
     protected array $ext_list = [];
 
-    /** @var array<int, string> library names */
+    /** @var array<int, string> all libraries being built (resolved dep list) */
     protected array $lib_list = [];
 
     /** @var bool compile libs only (just mark it) */

--- a/src/SPC/builder/BuilderBase.php
+++ b/src/SPC/builder/BuilderBase.php
@@ -143,7 +143,7 @@ abstract class BuilderBase
      *
      * @internal
      */
-    public function proveExts(array $static_extensions, array $shared_extensions = [], bool $skip_check_deps = false, bool $skip_extract = false): void
+    public function proveExts(array $static_extensions, array $shared_extensions = [], bool $skip_check_deps = false, bool $skip_extract = false, int $build_target = BUILD_TARGET_NONE): void
     {
         // judge ext
         foreach ($static_extensions as $ext) {
@@ -171,7 +171,9 @@ abstract class BuilderBase
             SourceManager::initSource(exts: [...$static_extensions, ...$shared_extensions]);
             $this->emitPatchPoint('after-exts-extract');
             // patch micro
-            SourcePatcher::patchMicro();
+            if (($build_target & BUILD_TARGET_MICRO) === BUILD_TARGET_MICRO) {
+                SourcePatcher::patchMicro();
+            }
         }
 
         foreach ([...$static_extensions, ...$shared_extensions] as $extension) {

--- a/src/SPC/builder/Extension.php
+++ b/src/SPC/builder/Extension.php
@@ -592,7 +592,7 @@ class Extension
      *                of static library flags, and the second is a space-separated string
      *                of shared library flags
      */
-    protected function splitLibsIntoStaticAndShared(string $allLibs, array $excludeFromStatic = []): array
+    protected function splitLibsIntoStaticAndShared(string $allLibs): array
     {
         $staticLibString = '';
         $sharedLibString = '';
@@ -601,16 +601,6 @@ class Extension
             $staticLib = BUILD_LIB_PATH . '/lib' . str_replace('-l', '', $lib) . '.a';
             if (str_starts_with($lib, BUILD_LIB_PATH . '/lib') && str_ends_with($lib, '.a')) {
                 $staticLib = $lib;
-            }
-            // Libs in $excludeFromStatic are statically linked into php-cli already and re-export their
-            // symbols; including them as static archives in a shared extension creates a second in-process
-            // copy of the same library (e.g. libssl/libcrypto), causing duplicated atexit handlers and
-            // shared-state corruption (NULL engine_lock at exit). Drop them here so the shared extension's
-            // undefined refs resolve at runtime against php-cli's exported symbols instead.
-            $libName = str_starts_with($lib, '-l') ? substr($lib, 2) : basename($lib, '.a');
-            $libName = str_starts_with($libName, 'lib') ? substr($libName, 3) : $libName;
-            if (in_array($libName, $excludeFromStatic, true)) {
-                continue;
             }
             if ($lib === '-lphp' || !file_exists($staticLib)) {
                 $sharedLibString .= " {$lib}";

--- a/src/SPC/builder/Extension.php
+++ b/src/SPC/builder/Extension.php
@@ -187,14 +187,6 @@ class Extension
      */
     public function patchBeforeMake(): bool
     {
-        if (SPCTarget::getTargetOS() === 'Linux' && $this->isBuildShared() && ($objs = getenv('SPC_EXTRA_RUNTIME_OBJECTS'))) {
-            FileSystem::replaceFileRegex(
-                SOURCE_PATH . '/php-src/Makefile',
-                "/^(shared_objects_{$this->getName()}\\s*=.*)$/m",
-                "$1 {$objs}",
-            );
-            return true;
-        }
         return false;
     }
 
@@ -244,13 +236,6 @@ class Extension
             );
         }
 
-        if ($objs = getenv('SPC_EXTRA_RUNTIME_OBJECTS')) {
-            FileSystem::replaceFileRegex(
-                $this->source_dir . '/Makefile',
-                "/^(shared_objects_{$this->getName()}\\s*=.*)$/m",
-                "$1 {$objs}",
-            );
-        }
         return true;
     }
 

--- a/src/SPC/builder/Extension.php
+++ b/src/SPC/builder/Extension.php
@@ -15,7 +15,6 @@ use SPC\toolchain\ToolchainManager;
 use SPC\toolchain\ZigToolchain;
 use SPC\util\GlobalEnvManager;
 use SPC\util\SPCConfigUtil;
-use SPC\util\SPCTarget;
 
 class Extension
 {

--- a/src/SPC/builder/Extension.php
+++ b/src/SPC/builder/Extension.php
@@ -539,11 +539,15 @@ class Extension
         [$staticLibs, $sharedLibs] = $this->splitLibsIntoStaticAndShared($config['libs']);
         $preStatic = PHP_OS_FAMILY === 'Darwin' ? '' : '-Wl,--start-group ';
         $postStatic = PHP_OS_FAMILY === 'Darwin' ? '' : ' -Wl,--end-group ';
+        $extraLd = trim((string) getenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_LDFLAGS'));
+        if (PHP_OS_FAMILY !== 'Darwin') {
+            $extraLd = trim($extraLd . ' -Wl,-Bsymbolic');
+        }
         return [
             'CFLAGS' => $config['cflags'],
             'CXXFLAGS' => $config['cflags'],
             'LDFLAGS' => $config['ldflags'],
-            'EXTRA_LDFLAGS' => getenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_LDFLAGS'),
+            'EXTRA_LDFLAGS' => $extraLd,
             'LIBS' => clean_spaces("{$preStatic} {$staticLibs} {$postStatic} {$sharedLibs}"),
             'LD_LIBRARY_PATH' => BUILD_LIB_PATH,
         ];
@@ -588,7 +592,7 @@ class Extension
      *                of static library flags, and the second is a space-separated string
      *                of shared library flags
      */
-    protected function splitLibsIntoStaticAndShared(string $allLibs): array
+    protected function splitLibsIntoStaticAndShared(string $allLibs, array $excludeFromStatic = []): array
     {
         $staticLibString = '';
         $sharedLibString = '';
@@ -597,6 +601,16 @@ class Extension
             $staticLib = BUILD_LIB_PATH . '/lib' . str_replace('-l', '', $lib) . '.a';
             if (str_starts_with($lib, BUILD_LIB_PATH . '/lib') && str_ends_with($lib, '.a')) {
                 $staticLib = $lib;
+            }
+            // Libs in $excludeFromStatic are statically linked into php-cli already and re-export their
+            // symbols; including them as static archives in a shared extension creates a second in-process
+            // copy of the same library (e.g. libssl/libcrypto), causing duplicated atexit handlers and
+            // shared-state corruption (NULL engine_lock at exit). Drop them here so the shared extension's
+            // undefined refs resolve at runtime against php-cli's exported symbols instead.
+            $libName = str_starts_with($lib, '-l') ? substr($lib, 2) : basename($lib, '.a');
+            $libName = str_starts_with($libName, 'lib') ? substr($libName, 3) : $libName;
+            if (in_array($libName, $excludeFromStatic, true)) {
+                continue;
             }
             if ($lib === '-lphp' || !file_exists($staticLib)) {
                 $sharedLibString .= " {$lib}";

--- a/src/SPC/builder/extension/clickhouse.php
+++ b/src/SPC/builder/extension/clickhouse.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\extension;
+
+use SPC\builder\Extension;
+use SPC\util\CustomExt;
+
+#[CustomExt('clickhouse')]
+class clickhouse extends Extension
+{
+    public function getUnixConfigureArg(bool $shared = false): string
+    {
+        $arg = '--enable-clickhouse' . ($shared ? '=shared' : '');
+        if ($this->builder->getLib('openssl')) {
+            $arg .= ' --enable-clickhouse-openssl';
+        }
+        return $arg;
+    }
+}

--- a/src/SPC/builder/extension/imagick.php
+++ b/src/SPC/builder/extension/imagick.php
@@ -18,9 +18,9 @@ class imagick extends Extension
         return '--with-imagick=' . ($shared ? 'shared,' : '') . BUILD_ROOT_PATH . $disable_omp;
     }
 
-    protected function splitLibsIntoStaticAndShared(string $allLibs, array $excludeFromStatic = []): array
+    protected function splitLibsIntoStaticAndShared(string $allLibs): array
     {
-        [$static, $shared] = parent::splitLibsIntoStaticAndShared($allLibs, $excludeFromStatic);
+        [$static, $shared] = parent::splitLibsIntoStaticAndShared($allLibs);
         if (ToolchainManager::getToolchainClass() !== ZigToolchain::class &&
             (str_contains(getenv('PATH'), 'rh/devtoolset') || str_contains(getenv('PATH'), 'rh/gcc-toolset'))
         ) {

--- a/src/SPC/builder/extension/imagick.php
+++ b/src/SPC/builder/extension/imagick.php
@@ -18,9 +18,9 @@ class imagick extends Extension
         return '--with-imagick=' . ($shared ? 'shared,' : '') . BUILD_ROOT_PATH . $disable_omp;
     }
 
-    protected function splitLibsIntoStaticAndShared(string $allLibs): array
+    protected function splitLibsIntoStaticAndShared(string $allLibs, array $excludeFromStatic = []): array
     {
-        [$static, $shared] = parent::splitLibsIntoStaticAndShared($allLibs);
+        [$static, $shared] = parent::splitLibsIntoStaticAndShared($allLibs, $excludeFromStatic);
         if (ToolchainManager::getToolchainClass() !== ZigToolchain::class &&
             (str_contains(getenv('PATH'), 'rh/devtoolset') || str_contains(getenv('PATH'), 'rh/gcc-toolset'))
         ) {

--- a/src/SPC/builder/extension/opcache.php
+++ b/src/SPC/builder/extension/opcache.php
@@ -58,7 +58,10 @@ class opcache extends Extension
         ) {
             $opcache_jit = ' --disable-opcache-jit';
         }
-        return '--enable-opcache' . ($shared ? '=shared' : '') . $opcache_jit;
+        if ($phpVersionID < 80500) {
+            return '--enable-opcache' . ($shared ? '=shared' : '') . $opcache_jit;
+        }
+        return trim($opcache_jit);
     }
 
     public function getDistName(): string

--- a/src/SPC/builder/linux/LinuxBuilder.php
+++ b/src/SPC/builder/linux/LinuxBuilder.php
@@ -136,11 +136,11 @@ class LinuxBuilder extends UnixBuilderBase
         $pgo = PgoManager::active();
         $needsClean = false;
         $sapiBuilds = [
-            ['cli',        $enableCli,        true,  fn () => $this->buildCli()],
-            ['fpm',        $enableFpm,        true,  fn () => $this->buildFpm()],
-            ['cgi',        $enableCgi,        true,  fn () => $this->buildCgi()],
-            ['micro',      $enableMicro,      true,  fn () => $this->buildMicro()],
-            ['embed',      $enableEmbed,      true,  function () use ($enableMicro): void {
+            ['cli', $enableCli, true, fn () => $this->buildCli()],
+            ['fpm', $enableFpm, true, fn () => $this->buildFpm()],
+            ['cgi', $enableCgi, true, fn () => $this->buildCgi()],
+            ['micro', $enableMicro, true, fn () => $this->buildMicro()],
+            ['embed', $enableEmbed, true, function () use ($enableMicro): void {
                 if ($enableMicro) {
                     FileSystem::replaceFileStr(SOURCE_PATH . '/php-src/Makefile', 'OVERALL_TARGET =', 'OVERALL_TARGET = libphp.la');
                 }

--- a/src/SPC/builder/linux/LinuxBuilder.php
+++ b/src/SPC/builder/linux/LinuxBuilder.php
@@ -14,6 +14,7 @@ use SPC\store\SourcePatcher;
 use SPC\toolchain\ToolchainManager;
 use SPC\toolchain\ZigToolchain;
 use SPC\util\GlobalEnvManager;
+use SPC\util\PgoManager;
 use SPC\util\SPCConfigUtil;
 use SPC\util\SPCTarget;
 
@@ -132,32 +133,36 @@ class LinuxBuilder extends UnixBuilderBase
 
         $this->cleanMake();
 
-        if ($enableCli) {
-            logger()->info('building cli');
-            $this->buildCli();
-        }
-        if ($enableFpm) {
-            logger()->info('building fpm');
-            $this->buildFpm();
-        }
-        if ($enableCgi) {
-            logger()->info('building cgi');
-            $this->buildCgi();
-        }
-        if ($enableMicro) {
-            logger()->info('building micro');
-            $this->buildMicro();
-        }
-        if ($enableEmbed) {
-            logger()->info('building embed');
-            if ($enableMicro) {
-                FileSystem::replaceFileStr(SOURCE_PATH . '/php-src/Makefile', 'OVERALL_TARGET =', 'OVERALL_TARGET = libphp.la');
+        $pgo = PgoManager::active();
+        $needsClean = false;
+        $sapiBuilds = [
+            ['cli',        $enableCli,        true,  fn () => $this->buildCli()],
+            ['fpm',        $enableFpm,        true,  fn () => $this->buildFpm()],
+            ['cgi',        $enableCgi,        true,  fn () => $this->buildCgi()],
+            ['micro',      $enableMicro,      true,  fn () => $this->buildMicro()],
+            ['embed',      $enableEmbed,      true,  function () use ($enableMicro): void {
+                if ($enableMicro) {
+                    FileSystem::replaceFileStr(SOURCE_PATH . '/php-src/Makefile', 'OVERALL_TARGET =', 'OVERALL_TARGET = libphp.la');
+                }
+                $this->buildEmbed();
+            }],
+            // frankenphp doesn't rebuild php-src; xcaddy links against the deployed libphp.so
+            ['frankenphp', $enableFrankenphp, false, fn () => $this->buildFrankenphp()],
+        ];
+
+        foreach ($sapiBuilds as [$sapi, $enabled, $rebuildsPhpSrc, $build]) {
+            if (!$enabled) {
+                continue;
             }
-            $this->buildEmbed();
-        }
-        if ($enableFrankenphp) {
-            logger()->info('building frankenphp');
-            $this->buildFrankenphp();
+            if ($pgo) {
+                if ($needsClean && $rebuildsPhpSrc) {
+                    $this->cleanMake();
+                }
+                $pgo->applyForSapi($sapi);
+                $needsClean = $needsClean || $rebuildsPhpSrc;
+            }
+            logger()->info('building ' . $sapi);
+            $build();
         }
         $shared_extensions = array_map('trim', array_filter(explode(',', $this->getOption('build-shared'))));
         if (!empty($shared_extensions)) {
@@ -327,11 +332,18 @@ class LinuxBuilder extends UnixBuilderBase
         $config = (new SPCConfigUtil($this, ['libs_only_deps' => true, 'absolute_libs' => true]))->config($this->ext_list, $this->lib_list, $this->getOption('with-suggested-exts'), $this->getOption('with-suggested-libs'));
         $static = SPCTarget::isStatic() ? '-all-static' : '';
         $lib = BUILD_LIB_PATH;
+        $extra_ldflags = (string) getenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_LDFLAGS');
+        if (getenv('SPC_CMD_VAR_PHP_EMBED_TYPE') === 'shared'
+            && !str_contains($extra_ldflags, '-avoid-version')
+            && !preg_match('/-release\s+\S+/', $extra_ldflags)) {
+            $extra_ldflags = trim($extra_ldflags . ' -avoid-version -module');
+        }
+        $extra_ldflags_program = trim("-L{$lib} {$static} -pie " . getenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_LDFLAGS_PROGRAM'));
         return array_filter([
             'EXTRA_CFLAGS' => getenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_CFLAGS'),
             'EXTRA_LIBS' => $config['libs'],
-            'EXTRA_LDFLAGS' => getenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_LDFLAGS'),
-            'EXTRA_LDFLAGS_PROGRAM' => "-L{$lib} {$static} -pie",
+            'EXTRA_LDFLAGS' => $extra_ldflags,
+            'EXTRA_LDFLAGS_PROGRAM' => $extra_ldflags_program,
         ]);
     }
 

--- a/src/SPC/builder/linux/LinuxBuilder.php
+++ b/src/SPC/builder/linux/LinuxBuilder.php
@@ -130,6 +130,7 @@ class LinuxBuilder extends UnixBuilderBase
 
         $this->emitPatchPoint('before-php-make');
         SourcePatcher::patchBeforeMake($this);
+        PgoManager::patchBeforeMake($this);
 
         $this->cleanMake();
 

--- a/src/SPC/builder/linux/LinuxBuilder.php
+++ b/src/SPC/builder/linux/LinuxBuilder.php
@@ -334,7 +334,7 @@ class LinuxBuilder extends UnixBuilderBase
      */
     private function getMakeExtraVars(): array
     {
-        $config = (new SPCConfigUtil($this, ['libs_only_deps' => true, 'absolute_libs' => true]))->config($this->ext_list, $this->lib_list, $this->getOption('with-suggested-exts'), $this->getOption('with-suggested-libs'));
+        $config = (new SPCConfigUtil($this, ['libs_only_deps' => true, 'absolute_libs' => true]))->config(array_keys($this->getExts(false)), [], $this->getOption('with-suggested-exts'), $this->lib_list);
         $static = SPCTarget::isStatic() ? '-all-static' : '';
         $lib = BUILD_LIB_PATH;
         $extra_ldflags = (string) getenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_LDFLAGS');

--- a/src/SPC/builder/linux/LinuxBuilder.php
+++ b/src/SPC/builder/linux/LinuxBuilder.php
@@ -23,6 +23,8 @@ class LinuxBuilder extends UnixBuilderBase
     /** @var bool Micro patch phar flag */
     private bool $phar_patched = false;
 
+    private ?PgoManager $pgo = null;
+
     public function __construct(array $options = [])
     {
         $this->options = $options;
@@ -49,6 +51,8 @@ class LinuxBuilder extends UnixBuilderBase
      */
     public function buildPHP(int $build_target = BUILD_TARGET_NONE): void
     {
+        $this->pgo = PgoManager::fromBuilder($this, $build_target);
+
         $cflags = $this->arch_c_flags;
         f_putenv('CFLAGS=' . $cflags);
 
@@ -134,7 +138,7 @@ class LinuxBuilder extends UnixBuilderBase
 
         $this->cleanMake();
 
-        $pgo = PgoManager::active();
+        $pgo = $this->pgo;
         $needsClean = false;
         $sapiBuilds = [
             ['cli', $enableCli, true, fn () => $this->buildCli()],

--- a/src/SPC/builder/linux/library/icu.php
+++ b/src/SPC/builder/linux/library/icu.php
@@ -15,9 +15,11 @@ class icu extends LinuxLibraryBase
 
     protected function build(): void
     {
+        $userCxxFlags = trim((string) getenv('SPC_DEFAULT_CXX_FLAGS'));
+        $userLdFlags = trim((string) getenv('SPC_DEFAULT_LD_FLAGS'));
         $cppflags = 'CPPFLAGS="-DU_CHARSET_IS_UTF8=1  -DU_USING_ICU_NAMESPACE=1 -DU_STATIC_IMPLEMENTATION=1 -DPIC -fPIC"';
-        $cxxflags = 'CXXFLAGS="-std=c++17 -DPIC -fPIC -fno-ident"';
-        $ldflags = SPCTarget::isStatic() ? 'LDFLAGS="-static"' : '';
+        $cxxflags = "CXXFLAGS=\"-std=c++17 -DPIC -fPIC -fno-ident {$userCxxFlags}\"";
+        $ldflags = SPCTarget::isStatic() ? "LDFLAGS=\"-static {$userLdFlags}\"" : "LDFLAGS=\"{$userLdFlags}\"";
         shell()->cd($this->source_dir . '/source')->initializeEnv($this)
             ->exec(
                 "{$cppflags} {$cxxflags} {$ldflags} " .

--- a/src/SPC/builder/linux/library/openssl.php
+++ b/src/SPC/builder/linux/library/openssl.php
@@ -57,6 +57,11 @@ class openssl extends LinuxLibraryBase
         $openssl_dir ??= '/etc/ssl';
         $ex_lib = trim($ex_lib);
 
+        // OpenSSL's Configure ignores env CFLAGS for its target template; pass our flags as extra args after the target.
+        $userCFlags = trim((string) getenv('SPC_DEFAULT_C_FLAGS'));
+        $userLdFlags = trim((string) getenv('SPC_DEFAULT_LD_FLAGS'));
+        $userExtraFlags = trim($userCFlags . ' ' . $userLdFlags);
+
         shell()->cd($this->source_dir)->initializeEnv($this)
             ->exec(
                 "{$env} ./Configure no-shared {$extra} " .
@@ -67,7 +72,8 @@ class openssl extends LinuxLibraryBase
                 'enable-pie ' .
                 'no-legacy ' .
                 'no-tests ' .
-                "linux-{$arch}"
+                "linux-{$arch} " .
+                $userExtraFlags
             )
             ->exec('make clean')
             ->exec("make -j{$this->builder->concurrency} CNF_EX_LIBS=\"{$ex_lib}\"")

--- a/src/SPC/builder/macos/MacOSBuilder.php
+++ b/src/SPC/builder/macos/MacOSBuilder.php
@@ -293,7 +293,7 @@ class MacOSBuilder extends UnixBuilderBase
 
     private function getMakeExtraVars(): array
     {
-        $config = (new SPCConfigUtil($this, ['libs_only_deps' => true]))->config($this->ext_list, $this->lib_list, $this->getOption('with-suggested-exts'), $this->getOption('with-suggested-libs'));
+        $config = (new SPCConfigUtil($this, ['libs_only_deps' => true]))->config(array_keys($this->getExts(false)), [], $this->getOption('with-suggested-exts'), $this->lib_list);
         return array_filter([
             'EXTRA_CFLAGS' => getenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_CFLAGS'),
             'EXTRA_LDFLAGS_PROGRAM' => '-L' . BUILD_LIB_PATH,

--- a/src/SPC/builder/unix/UnixBuilderBase.php
+++ b/src/SPC/builder/unix/UnixBuilderBase.php
@@ -145,7 +145,7 @@ abstract class UnixBuilderBase extends BuilderBase
             throw new SPCInternalException("Deploy failed. Cannot find file after copy: {$dst}");
         }
 
-        if (!$this->getOption('no-strip')) {
+        if (!$this->getOption('no-strip') && !$this->getOption('pgi')) {
             // extract debug info
             $this->extractDebugInfo($dst);
             // extra strip

--- a/src/SPC/builder/unix/UnixBuilderBase.php
+++ b/src/SPC/builder/unix/UnixBuilderBase.php
@@ -229,7 +229,7 @@ abstract class UnixBuilderBase extends BuilderBase
             copy(ROOT_DIR . '/src/globals/common-tests/embed.c', $sample_file_path . '/embed.c');
             copy(ROOT_DIR . '/src/globals/common-tests/embed.php', $sample_file_path . '/embed.php');
             $util = new SPCConfigUtil($this);
-            $config = $util->config($this->ext_list, $this->lib_list, $this->getOption('with-suggested-exts'), $this->getOption('with-suggested-libs'));
+            $config = $util->config(array_keys($this->getExts(false)), [], $this->getOption('with-suggested-exts'), $this->lib_list);
             $lens = "{$config['cflags']} {$config['ldflags']} {$config['libs']}";
             if (SPCTarget::isStatic()) {
                 $lens .= ' -static';
@@ -440,7 +440,7 @@ abstract class UnixBuilderBase extends BuilderBase
             $staticFlags = '-static-pie';
         }
 
-        $config = (new SPCConfigUtil($this))->config($this->ext_list, $this->lib_list);
+        $config = (new SPCConfigUtil($this))->config(array_keys($this->getExts(false)), [], false, $this->lib_list);
         $cflags = "{$this->arch_c_flags} {$config['cflags']} " . getenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_CFLAGS') . ' -DFRANKENPHP_VERSION=' . $frankenPhpVersion;
         $libs = $config['libs'];
         // Go's gcc driver doesn't automatically link against -lgcov or -lrt. Ugly, but necessary fix.

--- a/src/SPC/builder/unix/UnixBuilderBase.php
+++ b/src/SPC/builder/unix/UnixBuilderBase.php
@@ -463,9 +463,10 @@ abstract class UnixBuilderBase extends BuilderBase
                 "-tags={$muslTags}nobadger,nomysql,nopgx{$nobrotli}{$nowatcher}",
             'LD_LIBRARY_PATH' => BUILD_LIB_PATH,
         ], ...GoXcaddy::getEnvironment()];
+        $pgo = file_exists("{$frankenphpSourceDir}/caddy/frankenphp/default.pgo") ? "--pgo {$frankenphpSourceDir}/caddy/frankenphp/default.pgo " : '';
         shell()->cd(BUILD_BIN_PATH)
             ->setEnv($env)
-            ->exec("xcaddy build --output frankenphp {$xcaddyModules}");
+            ->exec("xcaddy build --output frankenphp {$pgo}{$xcaddyModules}");
 
         $this->deploySAPIBinary(BUILD_TARGET_FRANKENPHP);
     }

--- a/src/SPC/builder/unix/UnixBuilderBase.php
+++ b/src/SPC/builder/unix/UnixBuilderBase.php
@@ -450,10 +450,11 @@ abstract class UnixBuilderBase extends BuilderBase
             $cflags .= ' -Wno-error=missing-profile';
             $libs .= ' -lgcov';
         }
+        $extraLdProgram = (string) getenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_LDFLAGS_PROGRAM');
         $env = [...[
             'CGO_ENABLED' => '1',
             'CGO_CFLAGS' => clean_spaces($cflags),
-            'CGO_LDFLAGS' => "{$this->arch_ld_flags} {$staticFlags} {$config['ldflags']} {$libs}",
+            'CGO_LDFLAGS' => trim("{$this->arch_ld_flags} {$staticFlags} {$config['ldflags']} {$libs} {$extraLdProgram}"),
             'XCADDY_GO_BUILD_FLAGS' => '-buildmode=pie ' .
                 '-ldflags \"-linkmode=external ' . $extLdFlags . ' ' .
                 '-X \'github.com/caddyserver/caddy/v2/modules/caddyhttp.ServerHeader=FrankenPHP Caddy\' ' .

--- a/src/SPC/builder/unix/UnixBuilderBase.php
+++ b/src/SPC/builder/unix/UnixBuilderBase.php
@@ -145,7 +145,7 @@ abstract class UnixBuilderBase extends BuilderBase
             throw new SPCInternalException("Deploy failed. Cannot find file after copy: {$dst}");
         }
 
-        if (!$this->getOption('no-strip') && !$this->getOption('pgi')) {
+        if (!$this->getOption('no-strip') && !$this->getOption('pgi') && !$this->getOption('cs-pgi')) {
             // extract debug info
             $this->extractDebugInfo($dst);
             // extra strip

--- a/src/SPC/builder/unix/library/bzip2.php
+++ b/src/SPC/builder/unix/library/bzip2.php
@@ -11,7 +11,7 @@ trait bzip2
     public function patchBeforeBuild(): bool
     {
         $extra = trim((string) getenv('SPC_DEFAULT_C_FLAGS'));
-        FileSystem::replaceFileStr($this->source_dir . '/Makefile', 'CFLAGS=-Wall', "CFLAGS=-Wall {$extra}");
+        FileSystem::replaceFileStr($this->source_dir . '/Makefile', 'CFLAGS=-Wall', "CFLAGS={$extra} -Wall");
         return true;
     }
 

--- a/src/SPC/builder/unix/library/bzip2.php
+++ b/src/SPC/builder/unix/library/bzip2.php
@@ -10,7 +10,8 @@ trait bzip2
 {
     public function patchBeforeBuild(): bool
     {
-        FileSystem::replaceFileStr($this->source_dir . '/Makefile', 'CFLAGS=-Wall', 'CFLAGS=-fPIC -Wall');
+        $extra = trim((string) getenv('SPC_DEFAULT_C_FLAGS'));
+        FileSystem::replaceFileStr($this->source_dir . '/Makefile', 'CFLAGS=-Wall', "CFLAGS=-Wall {$extra}");
         return true;
     }
 

--- a/src/SPC/builder/unix/library/curl.php
+++ b/src/SPC/builder/unix/library/curl.php
@@ -29,6 +29,7 @@ trait curl
             ->addConfigureArgs(
                 '-DBUILD_CURL_EXE=OFF',
                 '-DBUILD_LIBCURL_DOCS=OFF',
+                '-DOPENSSL_ROOT_DIR=' . BUILD_ROOT_PATH,
             )
             ->build();
 

--- a/src/SPC/builder/unix/library/fastlz.php
+++ b/src/SPC/builder/unix/library/fastlz.php
@@ -10,8 +10,9 @@ trait fastlz
 {
     protected function build(): void
     {
+        $extra = trim((string) getenv('SPC_DEFAULT_C_FLAGS'));
         shell()->cd($this->source_dir)->initializeEnv($this)
-            ->exec((getenv('CC') ?: 'cc') . ' -c -O3 -fPIC fastlz.c -o fastlz.o')
+            ->exec((getenv('CC') ?: 'cc') . " -c {$extra} fastlz.c -o fastlz.o")
             ->exec((getenv('AR') ?: 'ar') . ' rcs libfastlz.a fastlz.o');
 
         if (!copy($this->source_dir . '/fastlz.h', BUILD_INCLUDE_PATH . '/fastlz.h')) {

--- a/src/SPC/builder/unix/library/imagemagick.php
+++ b/src/SPC/builder/unix/library/imagemagick.php
@@ -34,6 +34,9 @@ trait imagemagick
             ->addConfigureArgs(
                 '--disable-openmp',
                 '--without-x',
+                // implicit --with-gcc-arch
+                // bleeds host cpu features into built binaries
+                '--without-gcc-arch',
             );
 
         // special: linux-static target needs `-static`

--- a/src/SPC/builder/unix/library/jbig.php
+++ b/src/SPC/builder/unix/library/jbig.php
@@ -11,7 +11,7 @@ trait jbig
     public function patchBeforeBuild(): bool
     {
         $extra = trim((string) getenv('SPC_DEFAULT_C_FLAGS'));
-        FileSystem::replaceFileStr($this->source_dir . '/Makefile', 'CFLAGS = -O2 -W -Wno-unused-result', "CFLAGS = -W -Wno-unused-result {$extra}");
+        FileSystem::replaceFileStr($this->source_dir . '/Makefile', 'CFLAGS = -O2 -W -Wno-unused-result', "CFLAGS = {$extra} -W -Wno-unused-result");
         return true;
     }
 

--- a/src/SPC/builder/unix/library/jbig.php
+++ b/src/SPC/builder/unix/library/jbig.php
@@ -10,7 +10,8 @@ trait jbig
 {
     public function patchBeforeBuild(): bool
     {
-        FileSystem::replaceFileStr($this->source_dir . '/Makefile', 'CFLAGS = -O2 -W -Wno-unused-result', 'CFLAGS = -O2 -W -Wno-unused-result -fPIC');
+        $extra = trim((string) getenv('SPC_DEFAULT_C_FLAGS'));
+        FileSystem::replaceFileStr($this->source_dir . '/Makefile', 'CFLAGS = -O2 -W -Wno-unused-result', "CFLAGS = -W -Wno-unused-result {$extra}");
         return true;
     }
 

--- a/src/SPC/builder/unix/library/libaom.php
+++ b/src/SPC/builder/unix/library/libaom.php
@@ -30,7 +30,11 @@ trait libaom
             ->setBuildDir("{$this->source_dir}/builddir")
             ->addConfigureArgs(
                 "-DAOM_TARGET_CPU={$targetCpu}",
-                '-DCONFIG_RUNTIME_CPU_DETECT=1'
+                '-DCONFIG_RUNTIME_CPU_DETECT=1',
+                '-DENABLE_EXAMPLES=0',
+                '-DENABLE_TOOLS=0',
+                '-DENABLE_TESTS=0',
+                '-DENABLE_DOCS=0'
             )
             ->build();
         f_putenv("SPC_COMPILER_EXTRA={$extra}");

--- a/src/SPC/builder/unix/library/libaom.php
+++ b/src/SPC/builder/unix/library/libaom.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SPC\builder\unix\library;
 
+use SPC\builder\linux\SystemUtil;
 use SPC\toolchain\ToolchainManager;
 use SPC\toolchain\ZigToolchain;
 use SPC\util\executor\UnixCMakeExecutor;
@@ -21,6 +22,9 @@ trait libaom
         $targetCpu = SPCTarget::getTargetArch();
         if (str_starts_with($targetCpu, 'aarch')) {
             $targetCpu = str_replace($targetCpu, 'aarch', 'arm');
+        }
+        if (!SystemUtil::findCommand('nasm') && !SystemUtil::findCommand('yasm')) {
+            $targetCpu = 'generic';
         }
         UnixCMakeExecutor::create($this)
             ->setBuildDir("{$this->source_dir}/builddir")

--- a/src/SPC/builder/unix/library/libaom.php
+++ b/src/SPC/builder/unix/library/libaom.php
@@ -7,6 +7,7 @@ namespace SPC\builder\unix\library;
 use SPC\toolchain\ToolchainManager;
 use SPC\toolchain\ZigToolchain;
 use SPC\util\executor\UnixCMakeExecutor;
+use SPC\util\SPCTarget;
 
 trait libaom
 {
@@ -17,9 +18,16 @@ trait libaom
             $new = trim($extra . ' -D_GNU_SOURCE');
             f_putenv("SPC_COMPILER_EXTRA={$new}");
         }
+        $targetCpu = SPCTarget::getTargetArch();
+        if (str_starts_with($targetCpu, 'aarch')) {
+            $targetCpu = str_replace($targetCpu, 'aarch', 'arm');
+        }
         UnixCMakeExecutor::create($this)
             ->setBuildDir("{$this->source_dir}/builddir")
-            ->addConfigureArgs('-DAOM_TARGET_CPU=generic')
+            ->addConfigureArgs(
+                "-DAOM_TARGET_CPU={$targetCpu}",
+                '-DCONFIG_RUNTIME_CPU_DETECT=1'
+            )
             ->build();
         f_putenv("SPC_COMPILER_EXTRA={$extra}");
         $this->patchPkgconfPrefix(['aom.pc']);

--- a/src/SPC/builder/unix/library/libaom.php
+++ b/src/SPC/builder/unix/library/libaom.php
@@ -21,7 +21,7 @@ trait libaom
         }
         $targetCpu = SPCTarget::getTargetArch();
         if (str_starts_with($targetCpu, 'aarch')) {
-            $targetCpu = str_replace($targetCpu, 'aarch', 'arm');
+            $targetCpu = str_replace('aarch', 'arm', $targetCpu);
         }
         if (!SystemUtil::findCommand('nasm') && !SystemUtil::findCommand('yasm')) {
             $targetCpu = 'generic';

--- a/src/SPC/builder/unix/library/libheif.php
+++ b/src/SPC/builder/unix/library/libheif.php
@@ -11,15 +11,28 @@ trait libheif
 {
     public function patchBeforeBuild(): bool
     {
+        $patched = false;
         if (!str_contains(file_get_contents($this->source_dir . '/CMakeLists.txt'), 'libbrotlienc')) {
             FileSystem::replaceFileStr(
                 $this->source_dir . '/CMakeLists.txt',
                 'list(APPEND REQUIRES_PRIVATE "libbrotlidec")',
                 'list(APPEND REQUIRES_PRIVATE "libbrotlidec")' . "\n" . '        list(APPEND REQUIRES_PRIVATE "libbrotlienc")'
             );
-            return true;
+            $patched = true;
         }
-        return false;
+        // libheif 1.22+ ships a C-incompatible header: `struct heif_bad_pixel`
+        $heif_properties = $this->source_dir . '/libheif/api/libheif/heif_properties.h';
+        if (file_exists($heif_properties)
+            && str_contains(file_get_contents($heif_properties), 'struct heif_bad_pixel { uint32_t row; uint32_t column; };')
+        ) {
+            FileSystem::replaceFileStr(
+                $heif_properties,
+                'struct heif_bad_pixel { uint32_t row; uint32_t column; };',
+                'typedef struct heif_bad_pixel { uint32_t row; uint32_t column; } heif_bad_pixel;'
+            );
+            $patched = true;
+        }
+        return $patched;
     }
 
     protected function build(): void

--- a/src/SPC/builder/unix/library/liblz4.php
+++ b/src/SPC/builder/unix/library/liblz4.php
@@ -12,6 +12,13 @@ trait liblz4
     {
         // disable executables
         FileSystem::replaceFileStr($this->source_dir . '/programs/Makefile', 'install: lz4', "install: lz4\n\ninstallewfwef: lz4");
+        // zig-cc / clang -flto -c with multiple input files only produces an .o for the first source,
+        // leaving liblz4.a with just lz4.o. Compile sources individually so all .o files exist.
+        FileSystem::replaceFileStr(
+            $this->source_dir . '/lib/Makefile',
+            "liblz4.a: \$(SRCFILES)\nifeq (\$(BUILD_STATIC),yes)  # can be disabled on command line\n\t@echo compiling static library\n\t\$(COMPILE.c) \$^\n\t\$(AR) rcs \$@ *.o\nendif",
+            "liblz4.a: \$(SRCFILES:.c=.o)\nifeq (\$(BUILD_STATIC),yes)  # can be disabled on command line\n\t@echo compiling static library\n\t\$(AR) rcs \$@ \$^\nendif"
+        );
         return true;
     }
 
@@ -28,7 +35,7 @@ trait liblz4
 
         $this->patchPkgconfPrefix(['liblz4.pc']);
 
-        foreach (FileSystem::scanDirFiles(BUILD_ROOT_PATH . '/lib/', false, true) as $filename) {
+        foreach (FileSystem::scanDirFiles(BUILD_LIB_PATH . '/', false, true) as $filename) {
             if (str_starts_with($filename, 'liblz4') && (str_contains($filename, '.so') || str_ends_with($filename, '.dylib'))) {
                 unlink(BUILD_ROOT_PATH . '/lib/' . $filename);
             }

--- a/src/SPC/builder/unix/library/ncurses.php
+++ b/src/SPC/builder/unix/library/ncurses.php
@@ -15,11 +15,14 @@ trait ncurses
         // MKlib_gen.sh feeds preprocessor stdout through a sed/awk pipeline into lib_gen.c.
         // zig-cc/clang leaks the "N warning(s) generated." summary onto stdout (not stderr),
         // and that line ends up as invalid C in the generated source. Filter it out of the pipe.
-        FileSystem::replaceFileStr(
-            $this->source_dir . '/ncurses/base/MKlib_gen.sh',
-            '$preprocessor $TMP 2>/dev/null \\',
-            "\$preprocessor \$TMP 2>/dev/null \\\n| grep -v ' generated\\.\$' \\",
-        );
+        $mklibGen = $this->source_dir . '/ncurses/base/MKlib_gen.sh';
+        if (!str_contains((string) file_get_contents($mklibGen), "| grep -v ' generated")) {
+            FileSystem::replaceFileStr(
+                $mklibGen,
+                '$preprocessor $TMP 2>/dev/null \\',
+                "\$preprocessor \$TMP 2>/dev/null \\\n| grep -v ' generated\\.\$' \\",
+            );
+        }
         return true;
     }
 

--- a/src/SPC/builder/unix/library/ncurses.php
+++ b/src/SPC/builder/unix/library/ncurses.php
@@ -10,13 +10,26 @@ use SPC\util\SPCTarget;
 
 trait ncurses
 {
+    public function patchBeforeBuild(): bool
+    {
+        // MKlib_gen.sh feeds preprocessor stdout through a sed/awk pipeline into lib_gen.c.
+        // zig-cc/clang leaks the "N warning(s) generated." summary onto stdout (not stderr),
+        // and that line ends up as invalid C in the generated source. Filter it out of the pipe.
+        FileSystem::replaceFileStr(
+            $this->source_dir . '/ncurses/base/MKlib_gen.sh',
+            '$preprocessor $TMP 2>/dev/null \\',
+            "\$preprocessor \$TMP 2>/dev/null \\\n| grep -v ' generated\\.\$' \\",
+        );
+        return true;
+    }
+
     protected function build(): void
     {
         $filelist = FileSystem::scanDirFiles(BUILD_BIN_PATH, relative: true);
 
         UnixAutoconfExecutor::create($this)
             ->appendEnv([
-                'CFLAGS' => '-std=c17',
+                'CFLAGS' => '-std=c17 -w',
                 'LDFLAGS' => SPCTarget::isStatic() ? '-static' : '',
             ])
             ->configure(

--- a/src/SPC/builder/unix/library/qdbm.php
+++ b/src/SPC/builder/unix/library/qdbm.php
@@ -14,6 +14,8 @@ trait qdbm
     {
         $ac = UnixAutoconfExecutor::create($this)->configure();
         FileSystem::replaceFileRegex($this->source_dir . '/Makefile', '/MYLIBS = libqdbm.a.*/m', 'MYLIBS = libqdbm.a');
+        $extra = trim((string) getenv('SPC_DEFAULT_C_FLAGS'));
+        FileSystem::replaceFileRegex($this->source_dir . '/Makefile', '/^CFLAGS = .*$/m', "CFLAGS = -Wall {$extra}");
         $ac->make($this instanceof MacOSLibraryBase ? 'mac' : '');
         $this->patchPkgconfPrefix(['qdbm.pc']);
     }

--- a/src/SPC/builder/unix/library/unixodbc.php
+++ b/src/SPC/builder/unix/library/unixodbc.php
@@ -31,10 +31,9 @@ trait unixodbc
                 '--enable-gui=no',
             );
 
-        FileSystem::replaceFileStr(
-            "{$this->source_dir}/Makefile",
-            "\texe \\\n",
-            '',
+        file_put_contents(
+            "{$this->source_dir}/exe/Makefile",
+            ".PHONY: all install clean check distclean install-strip\nall install clean check distclean install-strip:\n\t@true\n",
         );
 
         $make->make();

--- a/src/SPC/builder/unix/library/unixodbc.php
+++ b/src/SPC/builder/unix/library/unixodbc.php
@@ -21,7 +21,7 @@ trait unixodbc
             'Linux' => '/etc',
             default => throw new WrongUsageException('Unsupported OS: ' . PHP_OS_FAMILY),
         };
-        UnixAutoconfExecutor::create($this)
+        $make = UnixAutoconfExecutor::create($this)
             ->configure(
                 '--disable-debug',
                 '--disable-dependency-tracking',
@@ -29,8 +29,15 @@ trait unixodbc
                 '--with-included-ltdl',
                 "--sysconfdir={$sysconf_selector}",
                 '--enable-gui=no',
-            )
-            ->make();
+            );
+
+        FileSystem::replaceFileRegex(
+            "{$this->source_dir}/Makefile",
+            '/^(SUBDIRS\s*=\s*[^\n]*)\bexe\b\s*/m',
+            '$1'
+        );
+
+        $make->make();
         $pkgConfigs = ['odbc.pc', 'odbccr.pc', 'odbcinst.pc'];
         $this->patchPkgconfPrefix($pkgConfigs);
         foreach ($pkgConfigs as $file) {

--- a/src/SPC/builder/unix/library/unixodbc.php
+++ b/src/SPC/builder/unix/library/unixodbc.php
@@ -31,10 +31,10 @@ trait unixodbc
                 '--enable-gui=no',
             );
 
-        FileSystem::replaceFileRegex(
+        FileSystem::replaceFileStr(
             "{$this->source_dir}/Makefile",
-            '/^(SUBDIRS\s*=\s*[^\n]*)\bexe\b\s*/m',
-            '$1'
+            "\texe \\\n",
+            '',
         );
 
         $make->make();

--- a/src/SPC/builder/unix/library/unixodbc.php
+++ b/src/SPC/builder/unix/library/unixodbc.php
@@ -21,6 +21,14 @@ trait unixodbc
             'Linux' => '/etc',
             default => throw new WrongUsageException('Unsupported OS: ' . PHP_OS_FAMILY),
         };
+        // libltdl is incompatible with -flto (https://bugs.gentoo.org/532672)
+        $stripLto = static fn ($s) => preg_replace('/(^|\s)-flto(=\S+)?(?=\s|$)/', ' ', (string) $s);
+        $origC = $this->builder->arch_c_flags;
+        $origCxx = $this->builder->arch_cxx_flags;
+        $origLd = $this->builder->arch_ld_flags;
+        $this->builder->arch_c_flags = clean_spaces($stripLto($origC));
+        $this->builder->arch_cxx_flags = clean_spaces($stripLto($origCxx));
+        $this->builder->arch_ld_flags = clean_spaces($stripLto($origLd));
         $make = UnixAutoconfExecutor::create($this)
             ->configure(
                 '--disable-debug',
@@ -37,6 +45,10 @@ trait unixodbc
         );
 
         $make->make();
+        $this->builder->arch_c_flags = $origC;
+        $this->builder->arch_cxx_flags = $origCxx;
+        $this->builder->arch_ld_flags = $origLd;
+
         $pkgConfigs = ['odbc.pc', 'odbccr.pc', 'odbcinst.pc'];
         $this->patchPkgconfPrefix($pkgConfigs);
         foreach ($pkgConfigs as $file) {

--- a/src/SPC/command/BuildLibsCommand.php
+++ b/src/SPC/command/BuildLibsCommand.php
@@ -19,7 +19,7 @@ class BuildLibsCommand extends BuildCommand
     {
         $this->addArgument('libraries', InputArgument::REQUIRED, 'The libraries will be compiled, comma separated');
         $this->addOption('clean', null, null, 'Clean old download cache and source before fetch');
-        $this->addOption('all', 'A', null, 'Build all libs that static-php-cli needed');
+        $this->addOption('all', 'A', null, 'Build all libs that static-php-cli has');
     }
 
     public function initialize(InputInterface $input, OutputInterface $output): void

--- a/src/SPC/command/BuildPHPCommand.php
+++ b/src/SPC/command/BuildPHPCommand.php
@@ -12,7 +12,6 @@ use SPC\store\SourcePatcher;
 use SPC\util\DependencyUtil;
 use SPC\util\GlobalEnvManager;
 use SPC\util\LicenseDumper;
-use SPC\util\PgoManager;
 use SPC\util\SPCTarget;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -215,20 +214,6 @@ class BuildPHPCommand extends BuildCommand
         // clean old modules that may conflict with the new php build
         FileSystem::removeDir(BUILD_MODULES_PATH);
 
-        $pgi = (bool) $this->getOption('pgi');
-        $csPgi = (bool) $this->getOption('cs-pgi');
-        $pgo = (bool) $this->getOption('pgo');
-        if (((int) $pgi + (int) $csPgi + (int) $pgo) > 1) {
-            $this->output->writeln('<error>--pgi, --cs-pgi, and --pgo are mutually exclusive</error>');
-            return static::FAILURE;
-        }
-        if ($pgi) {
-            (new PgoManager())->setupInstrument($rule);
-        } elseif ($csPgi) {
-            (new PgoManager())->setupCsInstrument($rule);
-        } elseif ($pgo) {
-            (new PgoManager())->setupUse($rule);
-        }
         $builder->buildPHP($rule);
         $builder->testPHP($rule);
 

--- a/src/SPC/command/BuildPHPCommand.php
+++ b/src/SPC/command/BuildPHPCommand.php
@@ -12,6 +12,7 @@ use SPC\store\SourcePatcher;
 use SPC\util\DependencyUtil;
 use SPC\util\GlobalEnvManager;
 use SPC\util\LicenseDumper;
+use SPC\util\PgoManager;
 use SPC\util\SPCTarget;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -49,6 +50,8 @@ class BuildPHPCommand extends BuildCommand
         $this->addOption('with-micro-logo', null, InputOption::VALUE_REQUIRED, 'Use custom .ico for micro.sfx (windows only)');
         $this->addOption('enable-micro-win32', null, null, 'Enable win32 mode for phpmicro (Windows only)');
         $this->addOption('with-frankenphp-app', null, InputOption::VALUE_REQUIRED, 'Path to a folder to be embedded in FrankenPHP');
+        $this->addOption('pgi', null, null, 'Build instrumented binaries (-fprofile-generate). Run them to collect .profraw files, then re-run with --pgo.');
+        $this->addOption('pgo', null, null, 'Build optimised binaries (-fprofile-use) from .profraw collected by a previous --pgi run.');
     }
 
     public function handle(): int
@@ -210,9 +213,19 @@ class BuildPHPCommand extends BuildCommand
 
         // clean old modules that may conflict with the new php build
         FileSystem::removeDir(BUILD_MODULES_PATH);
-        // start to build
-        $builder->buildPHP($rule);
 
+        $pgi = (bool) $this->getOption('pgi');
+        $pgo = (bool) $this->getOption('pgo');
+        if ($pgi && $pgo) {
+            $this->output->writeln('<error>--pgi and --pgo are mutually exclusive</error>');
+            return static::FAILURE;
+        }
+        if ($pgi) {
+            (new PgoManager())->setupInstrument($rule);
+        } elseif ($pgo) {
+            (new PgoManager())->setupUse($rule);
+        }
+        $builder->buildPHP($rule);
         $builder->testPHP($rule);
 
         // compile stopwatch :P

--- a/src/SPC/command/BuildPHPCommand.php
+++ b/src/SPC/command/BuildPHPCommand.php
@@ -51,6 +51,7 @@ class BuildPHPCommand extends BuildCommand
         $this->addOption('enable-micro-win32', null, null, 'Enable win32 mode for phpmicro (Windows only)');
         $this->addOption('with-frankenphp-app', null, InputOption::VALUE_REQUIRED, 'Path to a folder to be embedded in FrankenPHP');
         $this->addOption('pgi', null, null, 'Build instrumented binaries (-fprofile-generate). Run them to collect .profraw files, then re-run with --pgo.');
+        $this->addOption('cs-pgi', null, null, 'Build cs-instrumented binaries (-fprofile-use=<existing.profdata> -fcs-profile-generate). Requires a prior --pgi+--pgo cycle.');
         $this->addOption('pgo', null, null, 'Build optimised binaries (-fprofile-use) from .profraw collected by a previous --pgi run.');
     }
 
@@ -215,13 +216,16 @@ class BuildPHPCommand extends BuildCommand
         FileSystem::removeDir(BUILD_MODULES_PATH);
 
         $pgi = (bool) $this->getOption('pgi');
+        $csPgi = (bool) $this->getOption('cs-pgi');
         $pgo = (bool) $this->getOption('pgo');
-        if ($pgi && $pgo) {
-            $this->output->writeln('<error>--pgi and --pgo are mutually exclusive</error>');
+        if (((int) $pgi + (int) $csPgi + (int) $pgo) > 1) {
+            $this->output->writeln('<error>--pgi, --cs-pgi, and --pgo are mutually exclusive</error>');
             return static::FAILURE;
         }
         if ($pgi) {
             (new PgoManager())->setupInstrument($rule);
+        } elseif ($csPgi) {
+            (new PgoManager())->setupCsInstrument($rule);
         } elseif ($pgo) {
             (new PgoManager())->setupUse($rule);
         }

--- a/src/SPC/command/BuildPHPCommand.php
+++ b/src/SPC/command/BuildPHPCommand.php
@@ -180,7 +180,7 @@ class BuildPHPCommand extends BuildCommand
         // compile libraries
         $builder->proveLibs($libraries);
         // check extensions
-        $builder->proveExts($static_extensions, $shared_extensions);
+        $builder->proveExts($static_extensions, $shared_extensions, build_target: $rule);
         // validate libs and extensions
         $builder->validateLibsAndExts();
 

--- a/src/SPC/command/CraftCommand.php
+++ b/src/SPC/command/CraftCommand.php
@@ -10,6 +10,7 @@ use SPC\store\pkg\Zig;
 use SPC\toolchain\ToolchainManager;
 use SPC\toolchain\ZigToolchain;
 use SPC\util\ConfigValidator;
+use SPC\util\DependencyUtil;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Process\Process;
 
@@ -22,6 +23,7 @@ class CraftCommand extends BuildCommand
         $this->addOption('pgi', null, null, 'Forward --pgi to the inner build (instrumented binaries).');
         $this->addOption('cs-pgi', null, null, 'Forward --cs-pgi to the inner build (cs-instrumented binaries).');
         $this->addOption('pgo', null, null, 'Forward --pgo to the inner build (use collected profile data).');
+        $this->addOption('libs-only', null, null, 'Build only the libraries needed by the configured exts (skip PHP and extension build).');
     }
 
     public function handle(): int
@@ -106,17 +108,38 @@ class CraftCommand extends BuildCommand
 
         // craft build
         if ($craft['craft-options']['build']) {
-            $args = [$static_extensions, "--with-libs={$libs}", "--build-shared={$shared_extensions}", ...array_map(fn ($x) => "--build-{$x}", $craft['sapi'])];
-            $this->optionsToArguments($craft['build-options'], $args);
-            foreach (['pgi', 'cs-pgi', 'pgo'] as $pgoFlag) {
-                if ($this->getOption($pgoFlag)) {
-                    $args[] = "--{$pgoFlag}";
+            if ($this->getOption('libs-only')) {
+                $exts = array_merge($craft['extensions'], $craft['shared-extensions'] ?? []);
+                $include_suggested_exts = (bool) ($craft['build-options']['with-suggested-exts'] ?? false);
+                $include_suggested_libs = (bool) ($craft['build-options']['with-suggested-libs'] ?? false);
+                [, $needed_libs] = DependencyUtil::getExtsAndLibs(
+                    $exts,
+                    $craft['libs'],
+                    $include_suggested_exts,
+                    $include_suggested_libs,
+                );
+                if ($needed_libs === []) {
+                    $this->output->writeln('<comment>No libs needed for the configured extensions; skipping build:libs.</comment>');
+                } else {
+                    $retcode = $this->runCommand('build:libs', implode(',', $needed_libs));
+                    if ($retcode !== 0) {
+                        $this->output->writeln('<error>craft build:libs failed</error>');
+                        return static::FAILURE;
+                    }
                 }
-            }
-            $retcode = $this->runCommand('build', ...$args);
-            if ($retcode !== 0) {
-                $this->output->writeln('<error>craft build failed</error>');
-                return static::FAILURE;
+            } else {
+                $args = [$static_extensions, "--with-libs={$libs}", "--build-shared={$shared_extensions}", ...array_map(fn ($x) => "--build-{$x}", $craft['sapi'])];
+                $this->optionsToArguments($craft['build-options'], $args);
+                foreach (['pgi', 'cs-pgi', 'pgo'] as $pgoFlag) {
+                    if ($this->getOption($pgoFlag)) {
+                        $args[] = "--{$pgoFlag}";
+                    }
+                }
+                $retcode = $this->runCommand('build', ...$args);
+                if ($retcode !== 0) {
+                    $this->output->writeln('<error>craft build failed</error>');
+                    return static::FAILURE;
+                }
             }
         }
 

--- a/src/SPC/command/CraftCommand.php
+++ b/src/SPC/command/CraftCommand.php
@@ -19,6 +19,9 @@ class CraftCommand extends BuildCommand
     public function configure(): void
     {
         $this->addArgument('craft', null, 'Path to craft.yml file', WORKING_DIR . '/craft.yml');
+        $this->addOption('pgi', null, null, 'Forward --pgi to the inner build (instrumented binaries).');
+        $this->addOption('cs-pgi', null, null, 'Forward --cs-pgi to the inner build (cs-instrumented binaries).');
+        $this->addOption('pgo', null, null, 'Forward --pgo to the inner build (use collected profile data).');
     }
 
     public function handle(): int
@@ -105,6 +108,11 @@ class CraftCommand extends BuildCommand
         if ($craft['craft-options']['build']) {
             $args = [$static_extensions, "--with-libs={$libs}", "--build-shared={$shared_extensions}", ...array_map(fn ($x) => "--build-{$x}", $craft['sapi'])];
             $this->optionsToArguments($craft['build-options'], $args);
+            foreach (['pgi', 'cs-pgi', 'pgo'] as $pgoFlag) {
+                if ($this->getOption($pgoFlag)) {
+                    $args[] = "--{$pgoFlag}";
+                }
+            }
             $retcode = $this->runCommand('build', ...$args);
             if ($retcode !== 0) {
                 $this->output->writeln('<error>craft build failed</error>');

--- a/src/SPC/doctor/item/LinuxMuslCheck.php
+++ b/src/SPC/doctor/item/LinuxMuslCheck.php
@@ -74,9 +74,10 @@ class LinuxMuslCheck
         SourcePatcher::patchFile('musl-1.2.5_CVE-2025-26519_0002.patch', SOURCE_PATH . "/{$musl_version_name}");
         logger()->info('Installing musl wrapper');
         shell()->cd(SOURCE_PATH . "/{$musl_version_name}")
-            ->exec('CC=gcc CXX=g++ AR=ar LD=ld ./configure --disable-gcc-wrapper')
-            ->exec('CC=gcc CXX=g++ AR=ar LD=ld make -j')
-            ->exec("CC=gcc CXX=g++ AR=ar LD=ld {$prefix}make install");
+            ->setEnv(['CC' => 'gcc', 'CXX' => 'g++', 'AR' => 'ar', 'LD' => 'ld', 'RANLIB' => 'ranlib'])
+            ->exec('./configure --disable-gcc-wrapper')
+            ->exec('make -j')
+            ->exec("{$prefix}make install");
         // TODO: add path using putenv instead of editing /etc/profile
         return true;
     }

--- a/src/SPC/exception/ValidationException.php
+++ b/src/SPC/exception/ValidationException.php
@@ -14,9 +14,9 @@ use SPC\builder\Extension;
  */
 class ValidationException extends SPCException
 {
-    private null|array|string $validation_module = null;
+    private array|string|null $validation_module = null;
 
-    public function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null, null|array|string $validation_module = null)
+    public function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null, array|string|null $validation_module = null)
     {
         parent::__construct($message, $code, $previous);
 

--- a/src/SPC/exception/ValidationException.php
+++ b/src/SPC/exception/ValidationException.php
@@ -14,9 +14,9 @@ use SPC\builder\Extension;
  */
 class ValidationException extends SPCException
 {
-    private array|string|null $validation_module = null;
+    private null|array|string $validation_module = null;
 
-    public function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null, array|string|null $validation_module = null)
+    public function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null, null|array|string $validation_module = null)
     {
         parent::__construct($message, $code, $previous);
 

--- a/src/SPC/store/SourcePatcher.php
+++ b/src/SPC/store/SourcePatcher.php
@@ -321,20 +321,6 @@ class SourcePatcher
                 logger()->info("Library [{$lib->getName()}] patched before make");
             }
         }
-
-        if (str_contains((string) getenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_LDFLAGS'), '-release')) {
-            FileSystem::replaceFileLineContainsString(
-                SOURCE_PATH . '/php-src/ext/standard/info.c',
-                '#ifdef CONFIGURE_COMMAND',
-                '#ifdef NO_CONFIGURE_COMMAND',
-            );
-        } else {
-            FileSystem::replaceFileLineContainsString(
-                SOURCE_PATH . '/php-src/ext/standard/info.c',
-                '#ifdef NO_CONFIGURE_COMMAND',
-                '#ifdef CONFIGURE_COMMAND',
-            );
-        }
     }
 
     public static function patchHardcodedINI(array $ini = []): bool

--- a/src/SPC/store/pkg/GoXcaddy.php
+++ b/src/SPC/store/pkg/GoXcaddy.php
@@ -85,7 +85,7 @@ class GoXcaddy extends CustomPackage
                 'GOBIN' => "{$pkgroot}/go-xcaddy/bin",
                 'GOPATH' => "{$pkgroot}/go",
             ])
-            ->exec('CC=cc go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest');
+            ->exec('CGO_ENABLED=0 go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest');
     }
 
     public static function getEnvironment(): array

--- a/src/SPC/store/pkg/GoXcaddy.php
+++ b/src/SPC/store/pkg/GoXcaddy.php
@@ -85,7 +85,7 @@ class GoXcaddy extends CustomPackage
                 'GOBIN' => "{$pkgroot}/go-xcaddy/bin",
                 'GOPATH' => "{$pkgroot}/go",
             ])
-            ->exec('CC=cc go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest');
+            ->exec('CGO_ENABLED=0 go install github.com/caddyserver/xcaddy/cmd/xcaddy@master');
     }
 
     public static function getEnvironment(): array

--- a/src/SPC/store/pkg/Zig.php
+++ b/src/SPC/store/pkg/Zig.php
@@ -157,7 +157,8 @@ class Zig extends CustomPackage
         $profileLib = "{$libDir}/libclang_rt.profile.a";
         $crtBegin = "{$libDir}/clang_rt.crtbegin.o";
         $crtEnd = "{$libDir}/clang_rt.crtend.o";
-        if (file_exists($profileLib) && file_exists($crtBegin) && file_exists($crtEnd)) {
+        $cpuModelLib = "{$libDir}/libclang_rt.cpu_model.a";
+        if (file_exists($profileLib) && file_exists($crtBegin) && file_exists($crtEnd) && file_exists($cpuModelLib)) {
             return;
         }
 
@@ -182,7 +183,47 @@ class Zig extends CustomPackage
         if (!file_exists($crtBegin) || !file_exists($crtEnd)) {
             $this->buildCrtObjects($zig, $srcRoot, $crtBegin, $crtEnd);
         }
+        if (!file_exists($cpuModelLib)) {
+            $this->buildCpuModelBuiltins($zig, $srcRoot, $cpuModelLib);
+        }
         FileSystem::removeDir($srcRoot);
+    }
+
+    private function buildCpuModelBuiltins(string $zig, string $srcRoot, string $libPath): void
+    {
+        $builtins = "{$srcRoot}/lib/builtins";
+        $arch = php_uname('m');
+        $cpuModelDir = "{$builtins}/cpu_model";
+        if (is_dir($cpuModelDir)) {
+            $src = match (true) {
+                in_array($arch, ['x86_64', 'amd64', 'i386', 'i686', 'x86'], true) => "{$cpuModelDir}/x86.c",
+                in_array($arch, ['aarch64', 'arm64'], true) => "{$cpuModelDir}/aarch64.c",
+                str_starts_with($arch, 'riscv') => "{$cpuModelDir}/riscv.c",
+                default => null,
+            };
+            $includes = '-I' . escapeshellarg($builtins) . ' -I' . escapeshellarg($cpuModelDir);
+        } else {
+            $src = "{$builtins}/cpu_model.c";
+            $includes = '-I' . escapeshellarg($builtins);
+        }
+        if ($src === null || !is_file($src)) {
+            logger()->warning("[zig] cpu_model source not found for arch {$arch} under {$builtins} — __builtin_cpu_supports/__cpu_model will be unresolved");
+            return;
+        }
+
+        $objDir = "{$srcRoot}/obj-cpu-model";
+        f_mkdir($objDir, recursive: true);
+        $obj = "{$objDir}/cpu_model.o";
+        $cflags = '-c -O2 -fPIC ' . $includes;
+        $cmd = escapeshellarg($zig) . ' cc ' . $cflags . ' -o ' . escapeshellarg($obj) . ' ' . escapeshellarg($src) . ' 2>&1';
+        if (!$this->runZigCmd($cmd, $obj, "failed to compile {$src}")) {
+            return;
+        }
+        $arCmd = escapeshellarg($zig) . ' ar rcs ' . escapeshellarg($libPath) . ' ' . escapeshellarg($obj) . ' 2>&1';
+        if (!$this->runZigCmd($arCmd, $libPath, 'zig ar failed for cpu_model')) {
+            return;
+        }
+        logger()->info('[zig] libclang_rt.cpu_model.a installed (' . filesize($libPath) . ' bytes)');
     }
 
     private function fetchCompilerRtSource(string $llvmVersion): ?string

--- a/src/SPC/store/pkg/Zig.php
+++ b/src/SPC/store/pkg/Zig.php
@@ -162,7 +162,7 @@ class Zig extends CustomPackage
         }
 
         $zig = "{$zig_bin_dir}/zig";
-        $verLine = trim((string)shell_exec(escapeshellarg($zig) . ' cc --version 2>/dev/null'));
+        $verLine = trim((string) shell_exec(escapeshellarg($zig) . ' cc --version 2>/dev/null'));
         if (!preg_match('/clang version (\d+\.\d+\.\d+)/', $verLine, $m)) {
             logger()->warning('[zig] could not detect bundled clang version; skipping runtime bit build (--pgo + shared libs without __dso_handle)');
             return;
@@ -196,8 +196,7 @@ class Zig extends CustomPackage
                 'url' => $url,
                 'filename' => $tarball,
             ]);
-        }
-        catch (\Throwable $e) {
+        } catch (\Throwable $e) {
             logger()->warning("[zig] failed to download {$tarball}: {$e->getMessage()}");
             return null;
         }

--- a/src/SPC/store/pkg/Zig.php
+++ b/src/SPC/store/pkg/Zig.php
@@ -116,18 +116,17 @@ class Zig extends CustomPackage
                 break;
             }
         }
-        if ($all_exist) {
-            return;
+        if (!$all_exist) {
+            $lock = json_decode(FileSystem::readFile(LockFile::LOCK_FILE), true);
+            $source_type = $lock[$name]['source_type'];
+            $filename = DOWNLOAD_PATH . '/' . ($lock[$name]['filename'] ?? $lock[$name]['dirname']);
+            $extract = "{$pkgroot}/zig";
+
+            FileSystem::extractPackage($name, $source_type, $filename, $extract);
+
+            $this->createZigCcScript($zig_bin_dir);
         }
-
-        $lock = json_decode(FileSystem::readFile(LockFile::LOCK_FILE), true);
-        $source_type = $lock[$name]['source_type'];
-        $filename = DOWNLOAD_PATH . '/' . ($lock[$name]['filename'] ?? $lock[$name]['dirname']);
-        $extract = "{$pkgroot}/zig";
-
-        FileSystem::extractPackage($name, $source_type, $filename, $extract);
-
-        $this->createZigCcScript($zig_bin_dir);
+        $this->buildClangRuntimeBits($zig_bin_dir);
     }
 
     public static function getEnvironment(): array
@@ -138,6 +137,145 @@ class Zig extends CustomPackage
     public static function getPath(): ?string
     {
         return PKG_ROOT_PATH . '/zig';
+    }
+
+    /**
+     * Build the bits of clang's runtime that zig 0.16 doesn't ship: the
+     * profile runtime (so -fprofile-generate actually emits .profraw) and
+     * crtbegin.o/crtend.o (so shared libraries get __dso_handle and the
+     * __cxa_finalize atexit hook).
+     *
+     * Build from 2mb compiler-rt-<llvm>.src tar
+     * to avoid downloading 2gb full prebuilt tarball.
+     */
+    private function buildClangRuntimeBits(string $zig_bin_dir): void
+    {
+        if (PHP_OS_FAMILY !== 'Linux') {
+            return;
+        }
+        $libDir = "{$zig_bin_dir}/lib";
+        $profileLib = "{$libDir}/libclang_rt.profile.a";
+        $crtBegin = "{$libDir}/clang_rt.crtbegin.o";
+        $crtEnd = "{$libDir}/clang_rt.crtend.o";
+        if (file_exists($profileLib) && file_exists($crtBegin) && file_exists($crtEnd)) {
+            return;
+        }
+
+        $zig = "{$zig_bin_dir}/zig";
+        $verLine = trim((string)shell_exec(escapeshellarg($zig) . ' cc --version 2>/dev/null'));
+        if (!preg_match('/clang version (\d+\.\d+\.\d+)/', $verLine, $m)) {
+            logger()->warning('[zig] could not detect bundled clang version; skipping runtime bit build (--pgo + shared libs without __dso_handle)');
+            return;
+        }
+        $llvmVersion = $m[1];
+        logger()->info("Building clang runtime bits for LLVM {$llvmVersion} (zig's bundled clang)");
+
+        $srcRoot = $this->fetchCompilerRtSource($llvmVersion);
+        if ($srcRoot === null) {
+            return;
+        }
+
+        f_mkdir($libDir, recursive: true);
+        if (!file_exists($profileLib)) {
+            $this->buildProfileRuntime($zig, $srcRoot, $profileLib);
+        }
+        if (!file_exists($crtBegin) || !file_exists($crtEnd)) {
+            $this->buildCrtObjects($zig, $srcRoot, $crtBegin, $crtEnd);
+        }
+        FileSystem::removeDir($srcRoot);
+    }
+
+    private function fetchCompilerRtSource(string $llvmVersion): ?string
+    {
+        $pkgName = "compiler-rt-{$llvmVersion}";
+        $tarball = "compiler-rt-{$llvmVersion}.src.tar.xz";
+        $url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-{$llvmVersion}/{$tarball}";
+        try {
+            Downloader::downloadPackage($pkgName, [
+                'type' => 'url',
+                'url' => $url,
+                'filename' => $tarball,
+            ]);
+        }
+        catch (\Throwable $e) {
+            logger()->warning("[zig] failed to download {$tarball}: {$e->getMessage()}");
+            return null;
+        }
+        $srcRoot = PKG_ROOT_PATH . "/compiler-rt-src-{$llvmVersion}";
+        FileSystem::removeDir($srcRoot);
+        FileSystem::extractPackage($pkgName, SPC_SOURCE_ARCHIVE, DOWNLOAD_PATH . '/' . $tarball, $srcRoot);
+        return $srcRoot;
+    }
+
+    private function buildProfileRuntime(string $zig, string $srcRoot, string $libPath): void
+    {
+        $profileSrc = "{$srcRoot}/lib/profile";
+        $profileInc = "{$srcRoot}/include";
+        if (!is_dir($profileSrc)) {
+            logger()->warning("[zig] profile src dir missing at {$profileSrc} — --pgo will not work");
+            return;
+        }
+        $sources = array_merge(
+            glob("{$profileSrc}/*.c") ?: [],
+            glob("{$profileSrc}/*.cpp") ?: []
+        );
+        $skip = ['/PlatformAIX', '/PlatformDarwin', '/PlatformFuchsia', '/PlatformOther', '/PlatformWindows', '/WindowsMMap'];
+        $sources = array_filter($sources, function ($f) use ($skip) {
+            foreach ($skip as $s) {
+                if (str_contains($f, $s)) {
+                    return false;
+                }
+            }
+            return true;
+        });
+
+        $objDir = "{$srcRoot}/obj-profile";
+        f_mkdir($objDir, recursive: true);
+        $cflags = '-c -O2 -fPIC -fvisibility=hidden ' .
+            '-I' . escapeshellarg($profileInc) . ' ' .
+            '-DCOMPILER_RT_HAS_ATOMICS=1 -DCOMPILER_RT_HAS_FCNTL_LCK=1 -DCOMPILER_RT_HAS_UNAME=1';
+        $objs = [];
+        foreach ($sources as $src) {
+            $obj = $objDir . '/' . pathinfo($src, PATHINFO_FILENAME) . '.o';
+            $cmd = escapeshellarg($zig) . ' cc ' . $cflags . ' -o ' . escapeshellarg($obj) . ' ' . escapeshellarg($src) . ' 2>&1';
+            if (!$this->runZigCmd($cmd, $obj, "failed to compile {$src}")) {
+                return;
+            }
+            $objs[] = $obj;
+        }
+        $arCmd = escapeshellarg($zig) . ' ar rcs ' . escapeshellarg($libPath) . ' ' . implode(' ', array_map('escapeshellarg', $objs)) . ' 2>&1';
+        if (!$this->runZigCmd($arCmd, $libPath, 'zig ar failed')) {
+            return;
+        }
+        logger()->info('[zig] libclang_rt.profile.a installed (' . filesize($libPath) . ' bytes)');
+    }
+
+    private function buildCrtObjects(string $zig, string $srcRoot, string $crtBegin, string $crtEnd): void
+    {
+        $beginSrc = "{$srcRoot}/lib/builtins/crtbegin.c";
+        $endSrc = "{$srcRoot}/lib/builtins/crtend.c";
+        if (!is_file($beginSrc) || !is_file($endSrc)) {
+            logger()->error("[zig] crtbegin/crtend source missing under {$srcRoot}/lib/builtins — shared libs will lack __dso_handle");
+            return;
+        }
+        $cflags = '-c -O2 -fPIC -fvisibility=hidden -DCRT_HAS_INITFINI_ARRAY';
+        foreach ([[$beginSrc, $crtBegin], [$endSrc, $crtEnd]] as [$src, $dst]) {
+            $cmd = escapeshellarg($zig) . ' cc ' . $cflags . ' -o ' . escapeshellarg($dst) . ' ' . escapeshellarg($src) . ' 2>&1';
+            if (!$this->runZigCmd($cmd, $dst, "failed to compile {$src}")) {
+                return;
+            }
+        }
+        logger()->info('[zig] clang_rt.crtbegin.o + clang_rt.crtend.o installed (' . filesize($crtBegin) . ' + ' . filesize($crtEnd) . ' bytes)');
+    }
+
+    private function runZigCmd(string $cmd, string $dst, string $errPrefix): bool
+    {
+        exec($cmd, $out, $rc);
+        if ($rc !== 0 || !is_file($dst)) {
+            logger()->warning("[zig] {$errPrefix}: " . implode("\n", $out));
+            return false;
+        }
+        return true;
     }
 
     private function createZigCcScript(string $bin_dir): void

--- a/src/SPC/store/scripts/zig-cc.sh
+++ b/src/SPC/store/scripts/zig-cc.sh
@@ -67,6 +67,9 @@ fi
 if [[ $IS_LINK -eq 1 && $NEED_CRT -eq 1 && -f "$SCRIPT_DIR/lib/clang_rt.crtbegin.o" && -f "$SCRIPT_DIR/lib/clang_rt.crtend.o" ]]; then
     PARSED_ARGS+=("$SCRIPT_DIR/lib/clang_rt.crtbegin.o" "$SCRIPT_DIR/lib/clang_rt.crtend.o")
 fi
+if [[ $IS_LINK -eq 1 && -f "$SCRIPT_DIR/lib/libclang_rt.cpu_model.a" ]]; then
+    PARSED_ARGS+=("$SCRIPT_DIR/lib/libclang_rt.cpu_model.a")
+fi
 
 [[ -n "$SPC_TARGET" ]] && TARGET="-target $SPC_TARGET" || TARGET=""
 

--- a/src/SPC/store/scripts/zig-cc.sh
+++ b/src/SPC/store/scripts/zig-cc.sh
@@ -27,12 +27,14 @@ while [[ $# -gt 0 ]]; do
         -march=*|-mcpu=*)
             OPT_NAME="${1%%=*}"
             OPT_VALUE="${1#*=}"
-            # Skip armv8- flags entirely as Zig doesn't support them
-            if [[ "$OPT_VALUE" == armv8-* ]]; then
-                shift
-                continue
+            # zig rejects -march=armv8-a but accepts -mcpu=generic+v8a; rewrite
+            # armv<X>[.<Y>]-a[+feat] -> generic+v<X>[_<Y>]a[+feat] so it goes through.
+            if [[ "$OPT_VALUE" =~ ^armv([89])(\.([0-9]+))?-a(\+.*)?$ ]]; then
+                arch_feat="v${BASH_REMATCH[1]}"
+                [[ -n "${BASH_REMATCH[3]}" ]] && arch_feat="${arch_feat}_${BASH_REMATCH[3]}"
+                OPT_VALUE="generic+${arch_feat}a${BASH_REMATCH[4]}"
             fi
-            # replace -march=x86-64 with -march=x86_64
+            # zig uses snake_case in CPU/feature names (x86-64 -> x86_64).
             OPT_VALUE="${OPT_VALUE//-/_}"
             PARSED_ARGS+=("${OPT_NAME}=${OPT_VALUE}")
             shift

--- a/src/SPC/store/scripts/zig-cc.sh
+++ b/src/SPC/store/scripts/zig-cc.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
-BUILDROOT_ABS="$(realpath "$SCRIPT_DIR/../../../buildroot/include" 2>/dev/null || true)"
+BUILDROOT_INC="${BUILD_INCLUDE_PATH:-$SCRIPT_DIR/../../../buildroot/include}"
+BUILDROOT_ABS="$(realpath "$BUILDROOT_INC" 2>/dev/null || true)"
 PARSED_ARGS=()
+
+is_buildroot_inc() {
+    [[ -n "$BUILDROOT_ABS" && "$1" == "$BUILDROOT_ABS" ]]
+}
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -11,13 +16,13 @@ while [[ $# -gt 0 ]]; do
             ARG="$1"
             shift
             ARG_ABS="$(realpath "$ARG" 2>/dev/null || true)"
-            [[ "$ARG_ABS" == "$BUILDROOT_ABS" ]] && PARSED_ARGS+=("-I$ARG") || PARSED_ARGS+=("-isystem" "$ARG")
+            is_buildroot_inc "$ARG_ABS" && PARSED_ARGS+=("-I$ARG") || PARSED_ARGS+=("-isystem" "$ARG")
             ;;
         -isystem*)
             ARG="${1#-isystem}"
             shift
             ARG_ABS="$(realpath "$ARG" 2>/dev/null || true)"
-            [[ "$ARG_ABS" == "$BUILDROOT_ABS" ]] && PARSED_ARGS+=("-I$ARG") || PARSED_ARGS+=("-isystem$ARG")
+            is_buildroot_inc "$ARG_ABS" && PARSED_ARGS+=("-I$ARG") || PARSED_ARGS+=("-isystem$ARG")
             ;;
         -march=*|-mcpu=*)
             OPT_NAME="${1%%=*}"
@@ -30,6 +35,10 @@ while [[ $# -gt 0 ]]; do
             # replace -march=x86-64 with -march=x86_64
             OPT_VALUE="${OPT_VALUE//-/_}"
             PARSED_ARGS+=("${OPT_NAME}=${OPT_VALUE}")
+            shift
+            ;;
+        -Wlogical-op|-Wduplicated-cond|-Wduplicated-branches|-Wno-clobbered|-Wjump-misses-init|-Wformat-truncation|-Warray-bounds=*|-Wimplicit-fallthrough=*)
+            # GCC-only warning flags that clang/zig doesn't recognize; drop to silence -Wunknown-warning-option noise
             shift
             ;;
         *)

--- a/src/SPC/store/scripts/zig-cc.sh
+++ b/src/SPC/store/scripts/zig-cc.sh
@@ -45,11 +45,11 @@ NEED_CRT=0 # https://codeberg.org/ziglang/zig/issues/32064
 for _a in "${PARSED_ARGS[@]}"; do
     case "$_a" in
         -c|-S|-E|-M|-MM) IS_LINK=0 ;;
-        -fprofile-generate*|-fprofile-instr-generate*) NEED_PROFILE_RT=1 ;;
+        -fprofile-generate*|-fprofile-instr-generate*|-fcs-profile-generate*) NEED_PROFILE_RT=1 ;;
         -shared) NEED_CRT=1 ;;
     esac
 done
-[[ "$SPC_COMPILER_EXTRA" == *-fprofile-generate* ]] && NEED_PROFILE_RT=1
+[[ "$SPC_COMPILER_EXTRA" == *-fprofile-generate* || "$SPC_COMPILER_EXTRA" == *-fcs-profile-generate* ]] && NEED_PROFILE_RT=1
 if [[ $IS_LINK -eq 1 && $NEED_PROFILE_RT -eq 1 && -f "$SCRIPT_DIR/lib/libclang_rt.profile.a" ]]; then
     PARSED_ARGS+=("$SCRIPT_DIR/lib/libclang_rt.profile.a" "-Wl,-u,__llvm_profile_runtime")
 fi

--- a/src/SPC/store/scripts/zig-cc.sh
+++ b/src/SPC/store/scripts/zig-cc.sh
@@ -39,6 +39,24 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+IS_LINK=1
+NEED_PROFILE_RT=0 # https://codeberg.org/ziglang/zig/issues/32066
+NEED_CRT=0 # https://codeberg.org/ziglang/zig/issues/32064
+for _a in "${PARSED_ARGS[@]}"; do
+    case "$_a" in
+        -c|-S|-E|-M|-MM) IS_LINK=0 ;;
+        -fprofile-generate*|-fprofile-instr-generate*) NEED_PROFILE_RT=1 ;;
+        -shared) NEED_CRT=1 ;;
+    esac
+done
+[[ "$SPC_COMPILER_EXTRA" == *-fprofile-generate* ]] && NEED_PROFILE_RT=1
+if [[ $IS_LINK -eq 1 && $NEED_PROFILE_RT -eq 1 && -f "$SCRIPT_DIR/lib/libclang_rt.profile.a" ]]; then
+    PARSED_ARGS+=("$SCRIPT_DIR/lib/libclang_rt.profile.a" "-Wl,-u,__llvm_profile_runtime")
+fi
+if [[ $IS_LINK -eq 1 && $NEED_CRT -eq 1 && -f "$SCRIPT_DIR/lib/clang_rt.crtbegin.o" && -f "$SCRIPT_DIR/lib/clang_rt.crtend.o" ]]; then
+    PARSED_ARGS+=("$SCRIPT_DIR/lib/clang_rt.crtbegin.o" "$SCRIPT_DIR/lib/clang_rt.crtend.o")
+fi
+
 [[ -n "$SPC_TARGET" ]] && TARGET="-target $SPC_TARGET" || TARGET=""
 
 if [[ "$SPC_TARGET" =~ \.[0-9]+\.[0-9]+ ]]; then

--- a/src/SPC/store/scripts/zig-cc.sh
+++ b/src/SPC/store/scripts/zig-cc.sh
@@ -62,13 +62,13 @@ for _a in "${PARSED_ARGS[@]}"; do
 done
 [[ "$SPC_COMPILER_EXTRA" == *-fprofile-generate* || "$SPC_COMPILER_EXTRA" == *-fcs-profile-generate* ]] && NEED_PROFILE_RT=1
 if [[ $IS_LINK -eq 1 && $NEED_PROFILE_RT -eq 1 && -f "$SCRIPT_DIR/lib/libclang_rt.profile.a" ]]; then
-    PARSED_ARGS+=("$SCRIPT_DIR/lib/libclang_rt.profile.a" "-Wl,-u,__llvm_profile_runtime")
+    PARSED_ARGS+=("-x" "none" "$SCRIPT_DIR/lib/libclang_rt.profile.a" "-Wl,-u,__llvm_profile_runtime")
 fi
 if [[ $IS_LINK -eq 1 && $NEED_CRT -eq 1 && -f "$SCRIPT_DIR/lib/clang_rt.crtbegin.o" && -f "$SCRIPT_DIR/lib/clang_rt.crtend.o" ]]; then
-    PARSED_ARGS+=("$SCRIPT_DIR/lib/clang_rt.crtbegin.o" "$SCRIPT_DIR/lib/clang_rt.crtend.o")
+    PARSED_ARGS+=("-x" "none" "$SCRIPT_DIR/lib/clang_rt.crtbegin.o" "$SCRIPT_DIR/lib/clang_rt.crtend.o")
 fi
 if [[ $IS_LINK -eq 1 && -f "$SCRIPT_DIR/lib/libclang_rt.cpu_model.a" ]]; then
-    PARSED_ARGS+=("$SCRIPT_DIR/lib/libclang_rt.cpu_model.a")
+    PARSED_ARGS+=("-x" "none" "$SCRIPT_DIR/lib/libclang_rt.cpu_model.a")
 fi
 
 [[ -n "$SPC_TARGET" ]] && TARGET="-target $SPC_TARGET" || TARGET=""

--- a/src/SPC/toolchain/ClangNativeToolchain.php
+++ b/src/SPC/toolchain/ClangNativeToolchain.php
@@ -21,6 +21,7 @@ class ClangNativeToolchain implements ToolchainInterface
         GlobalEnvManager::putenv('SPC_LINUX_DEFAULT_CC=clang');
         GlobalEnvManager::putenv('SPC_LINUX_DEFAULT_CXX=clang++');
         GlobalEnvManager::putenv('SPC_LINUX_DEFAULT_AR=ar');
+        GlobalEnvManager::putenv('SPC_LINUX_DEFAULT_RANLIB=ranlib');
         GlobalEnvManager::putenv('SPC_LINUX_DEFAULT_LD=ld');
     }
 

--- a/src/SPC/toolchain/GccNativeToolchain.php
+++ b/src/SPC/toolchain/GccNativeToolchain.php
@@ -18,6 +18,7 @@ class GccNativeToolchain implements ToolchainInterface
         GlobalEnvManager::putenv('SPC_LINUX_DEFAULT_CC=gcc');
         GlobalEnvManager::putenv('SPC_LINUX_DEFAULT_CXX=g++');
         GlobalEnvManager::putenv('SPC_LINUX_DEFAULT_AR=ar');
+        GlobalEnvManager::putenv('SPC_LINUX_DEFAULT_RANLIB=ranlib');
         GlobalEnvManager::putenv('SPC_LINUX_DEFAULT_LD=ld');
     }
 

--- a/src/SPC/toolchain/MuslToolchain.php
+++ b/src/SPC/toolchain/MuslToolchain.php
@@ -16,6 +16,7 @@ class MuslToolchain implements ToolchainInterface
         GlobalEnvManager::putenv("SPC_LINUX_DEFAULT_CC={$arch}-linux-musl-gcc");
         GlobalEnvManager::putenv("SPC_LINUX_DEFAULT_CXX={$arch}-linux-musl-g++");
         GlobalEnvManager::putenv("SPC_LINUX_DEFAULT_AR={$arch}-linux-musl-ar");
+        GlobalEnvManager::putenv("SPC_LINUX_DEFAULT_RANLIB={$arch}-linux-musl-ranlib");
         GlobalEnvManager::putenv("SPC_LINUX_DEFAULT_LD={$arch}-linux-musl-ld");
         GlobalEnvManager::addPathIfNotExists('/usr/local/musl/bin');
         GlobalEnvManager::addPathIfNotExists("/usr/local/musl/{$arch}-linux-musl/bin");

--- a/src/SPC/toolchain/ZigToolchain.php
+++ b/src/SPC/toolchain/ZigToolchain.php
@@ -16,6 +16,7 @@ class ZigToolchain implements ToolchainInterface
         GlobalEnvManager::putenv('SPC_LINUX_DEFAULT_CC=zig-cc');
         GlobalEnvManager::putenv('SPC_LINUX_DEFAULT_CXX=zig-c++');
         GlobalEnvManager::putenv('SPC_LINUX_DEFAULT_AR=zig-ar');
+        GlobalEnvManager::putenv('SPC_LINUX_DEFAULT_RANLIB=zig-ranlib');
         GlobalEnvManager::putenv('SPC_LINUX_DEFAULT_LD=zig-ld.lld');
     }
 

--- a/src/SPC/toolchain/ZigToolchain.php
+++ b/src/SPC/toolchain/ZigToolchain.php
@@ -17,27 +17,6 @@ class ZigToolchain implements ToolchainInterface
         GlobalEnvManager::putenv('SPC_LINUX_DEFAULT_CXX=zig-c++');
         GlobalEnvManager::putenv('SPC_LINUX_DEFAULT_AR=zig-ar');
         GlobalEnvManager::putenv('SPC_LINUX_DEFAULT_LD=zig-ld.lld');
-
-        // Generate additional objects needed for zig toolchain
-        $paths = ['/usr/lib/gcc', '/usr/local/lib/gcc'];
-        $objects = ['crtbeginS.o', 'crtendS.o'];
-        $found = [];
-
-        foreach ($objects as $obj) {
-            $located = null;
-            foreach ($paths as $base) {
-                $output = shell_exec("find {$base} -name {$obj} 2>/dev/null | grep -v '/32/' | head -n 1");
-                $line = trim((string) $output);
-                if ($line !== '') {
-                    $located = $line;
-                    break;
-                }
-            }
-            if ($located) {
-                $found[] = $located;
-            }
-        }
-        GlobalEnvManager::putenv('SPC_EXTRA_RUNTIME_OBJECTS=' . implode(' ', $found));
     }
 
     public function afterInit(): void

--- a/src/SPC/util/DependencyUtil.php
+++ b/src/SPC/util/DependencyUtil.php
@@ -101,11 +101,15 @@ class DependencyUtil
     /**
      * Get extension dependencies in correct order
      *
-     * @param  array $exts            Array of extension names
-     * @param  array $additional_libs Array of additional libraries
-     * @return array Ordered array of extension names
+     * @param  array      $exts                   Array of extension names
+     * @param  array      $additional_libs        Array of additional libraries
+     * @param  bool       $include_suggested_exts Whether to follow ext-suggests edges
+     * @param  array|bool $include_suggested_libs true = follow all lib-suggests edges;
+     *                                            false = follow none;
+     *                                            array = follow lib-suggests edges only when the suggested lib is in this list (i.e. it's already being built)
+     * @return array      Ordered array of extension names
      */
-    public static function getExtsAndLibs(array $exts, array $additional_libs = [], bool $include_suggested_exts = false, bool $include_suggested_libs = false): array
+    public static function getExtsAndLibs(array $exts, array $additional_libs = [], bool $include_suggested_exts = false, array|bool $include_suggested_libs = false): array
     {
         $dep_list = self::platExtToLibs();
 
@@ -127,16 +131,20 @@ class DependencyUtil
             }
         }
 
-        // include suggested libraries
-        if ($include_suggested_libs) {
-            // check every deps suggests
+        // include suggested libraries (all, or only those in the available set)
+        if ($include_suggested_libs !== false) {
+            $available = is_array($include_suggested_libs) ? $include_suggested_libs : null;
             foreach ($dep_list as $name => $obj) {
                 $del_list = [];
                 foreach ($obj['suggests'] as $id => $suggest) {
-                    if (!str_starts_with($suggest, 'ext@')) {
-                        $dep_list[$name]['depends'][] = $suggest;
-                        $del_list[] = $id;
+                    if (str_starts_with($suggest, 'ext@')) {
+                        continue;
                     }
+                    if ($available !== null && !in_array($suggest, $available, true)) {
+                        continue;
+                    }
+                    $dep_list[$name]['depends'][] = $suggest;
+                    $del_list[] = $id;
                 }
                 foreach ($del_list as $id) {
                     unset($dep_list[$name]['suggests'][$id]);

--- a/src/SPC/util/LicenseDumper.php
+++ b/src/SPC/util/LicenseDumper.php
@@ -117,7 +117,7 @@ class LicenseDumper
     /**
      * Loads a source license file from the specified path.
      */
-    private function loadSourceFile(string $source_name, int $index, null|array|string $in_path, ?string $custom_base_path = null): string
+    private function loadSourceFile(string $source_name, int $index, array|string|null $in_path, ?string $custom_base_path = null): string
     {
         if (is_null($in_path)) {
             throw new SPCInternalException("source [{$source_name}] license file is not set, please check config/source.json");

--- a/src/SPC/util/LicenseDumper.php
+++ b/src/SPC/util/LicenseDumper.php
@@ -117,7 +117,7 @@ class LicenseDumper
     /**
      * Loads a source license file from the specified path.
      */
-    private function loadSourceFile(string $source_name, int $index, array|string|null $in_path, ?string $custom_base_path = null): string
+    private function loadSourceFile(string $source_name, int $index, null|array|string $in_path, ?string $custom_base_path = null): string
     {
         if (is_null($in_path)) {
             throw new SPCInternalException("source [{$source_name}] license file is not set, please check config/source.json");

--- a/src/SPC/util/PgoManager.php
+++ b/src/SPC/util/PgoManager.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\util;
+
+use SPC\exception\WrongUsageException;
+use SPC\store\FileSystem;
+
+/**
+ * Two-call PGO driver: --pgi instruments, --pgo uses the .profraw the user
+ * collected by running the instrumented binaries. PgoManager only sets the
+ * compiler flags; it does not run any workload itself.
+ */
+class PgoManager
+{
+    /**
+     * SAPIs whose clang-compiled output can be PGO'd. frankenphp is included
+     * because its cgo glue is C compiled by zig — the Go side it wraps is
+     * not clang-PGO'd here. libphp.so is the embed SAPI; running frankenphp
+     * produces profile data for embed (because it loads libphp.so) AND for
+     * frankenphp (because the cgo glue runs too).
+     */
+    private const TRAINABLE = [
+        'cli'        => BUILD_TARGET_CLI,
+        'micro'      => BUILD_TARGET_MICRO,
+        'cgi'        => BUILD_TARGET_CGI,
+        'fpm'        => BUILD_TARGET_FPM,
+        'embed'      => BUILD_TARGET_EMBED,
+        'frankenphp' => BUILD_TARGET_FRANKENPHP,
+    ];
+
+    public const MODE_INSTRUMENT = 'instrument';
+
+    public const MODE_USE = 'use';
+
+    private string $profileRoot;
+
+    private string $mode;
+
+    private static ?self $active = null;
+
+    public function __construct()
+    {
+        $this->profileRoot = BUILD_ROOT_PATH . '/pgo-data';
+    }
+
+    public static function active(): ?self
+    {
+        return self::$active;
+    }
+
+    /** Setup --pgi: build with -fprofile-generate=<sapi-dir>. */
+    public function setupInstrument(int $rule): void
+    {
+        $this->validateRule($rule);
+        FileSystem::removeDir($this->profileRoot);
+        f_mkdir($this->profileRoot, recursive: true);
+        foreach ($this->trainableIn($rule) as $sapi) {
+            f_mkdir($this->rawDir($sapi), recursive: true);
+        }
+        $this->mode = self::MODE_INSTRUMENT;
+        self::$active = $this;
+        $this->applyForSapi($this->trainableIn($rule)[0]);
+        logger()->info('pgo --pgi: instrumented build, profraw will land under ' . $this->profileRoot . '/<sapi>/');
+    }
+
+    /** Setup --pgo: merge collected .profraw, then build with -fprofile-use=<sapi.profdata>. */
+    public function setupUse(int $rule): void
+    {
+        $this->validateRule($rule);
+        if (trim((string) shell_exec('command -v llvm-profdata 2>/dev/null')) === '') {
+            throw new WrongUsageException('--pgo: llvm-profdata not on PATH');
+        }
+        foreach ($this->trainableIn($rule) as $sapi) {
+            $this->mergeSapi($sapi);
+        }
+        $this->mode = self::MODE_USE;
+        self::$active = $this;
+        $this->applyForSapi($this->trainableIn($rule)[0]);
+    }
+
+    /**
+     * Set EXTRA_CFLAGS / EXTRA_LDFLAGS_PROGRAM for the SAPI about to be built.
+     * Non-trainable SAPIs (e.g. frankenphp's Go side) are left untouched.
+     */
+    public function applyForSapi(string $sapi): void
+    {
+        $sapi = $this->resolveSapi($sapi);
+        if (!isset(self::TRAINABLE[$sapi])) {
+            return;
+        }
+        $flags = $this->mode === self::MODE_INSTRUMENT
+            ? '-fprofile-generate=' . $this->rawDir($sapi) . ' -fprofile-continuous -mllvm -disable-vp'
+            : '-fprofile-use=' . $this->profDataFile($sapi) . ' -Wno-error=profile-instr-unprofiled -Wno-error=profile-instr-out-of-date -Wno-backend-plugin';
+        $this->setFlag('SPC_CMD_VAR_PHP_MAKE_EXTRA_CFLAGS', $flags);
+        $this->setFlag('SPC_CMD_VAR_PHP_MAKE_EXTRA_LDFLAGS_PROGRAM', $this->ldOnly($flags));
+        logger()->info("pgo {$this->mode} ({$sapi})");
+    }
+
+    /**
+     * In static-embed mode libphp.a is linked into frankenphp, and the linker
+     * resolves all `__llvm_profile_filename` references to a single path —
+     * the embed SAPI's per-TU `-fprofile-generate=…` setting is silently
+     * dropped. Compile libphp.a with frankenphp's path so all counter writes
+     * agree on one file, and read libphp.a's PGO from frankenphp.profdata.
+     */
+    private function resolveSapi(string $sapi): string
+    {
+        if ($sapi === 'embed' && getenv('SPC_CMD_VAR_PHP_EMBED_TYPE') === 'static') {
+            return 'frankenphp';
+        }
+        return $sapi;
+    }
+
+    private function validateRule(int $rule): void
+    {
+        if (empty($this->trainableIn($rule))) {
+            throw new WrongUsageException('--pgi/--pgo: no trainable SAPI in build rule (need one of: ' . implode(', ', array_keys(self::TRAINABLE)) . ')');
+        }
+    }
+
+    private function mergeSapi(string $sapi): void
+    {
+        $raws = glob($this->rawDir($sapi) . '/*.profraw') ?: [];
+        if (empty($raws)) {
+            throw new WrongUsageException("--pgo: no .profraw for {$sapi}; run --pgi, exercise the binary, then re-run --pgo");
+        }
+        $out = $this->profDataFile($sapi);
+        $argv = implode(' ', array_map('escapeshellarg', $raws));
+        shell()->exec('llvm-profdata merge --failure-mode=warn -output=' . escapeshellarg($out) . ' ' . $argv);
+        if (!is_file($out) || filesize($out) === 0) {
+            throw new WrongUsageException("--pgo: empty merge output for {$sapi}");
+        }
+        logger()->info("pgo merged {$sapi}: " . filesize($out) . ' bytes');
+    }
+
+    private function rawDir(string $sapi): string
+    {
+        return $this->profileRoot . '/' . $sapi;
+    }
+
+    private function profDataFile(string $sapi): string
+    {
+        return $this->profileRoot . '/' . $sapi . '.profdata';
+    }
+
+    /** @return list<string> */
+    private function trainableIn(int $rule): array
+    {
+        $out = [];
+        foreach (self::TRAINABLE as $sapi => $mask) {
+            if (($rule & $mask) !== $mask) {
+                continue;
+            }
+            $resolved = $this->resolveSapi($sapi);
+            if (!in_array($resolved, $out, true)) {
+                $out[] = $resolved;
+            }
+        }
+        return $out;
+    }
+
+    /** Strip the previous PGO flags from $var and append the new ones. */
+    private function setFlag(string $var, string $append): void
+    {
+        $cur = (string) getenv($var);
+        $cur = preg_replace('/\s*-fprofile-(generate|use)=\S+/', '', $cur) ?? $cur;
+        $cur = str_replace([' -fprofile-continuous', ' -mllvm -disable-vp'], '', $cur);
+        $cur = preg_replace('/\s*-Wno-error=profile-instr-unprofiled\s+-Wno-error=profile-instr-out-of-date\s+-Wno-backend-plugin/', '', $cur) ?? $cur;
+        f_putenv($var . '=' . trim($cur . ' ' . $append));
+    }
+
+    /** Linker only takes -fprofile-{generate,use}; strip the codegen-only -mllvm and warning flags. */
+    private function ldOnly(string $flags): string
+    {
+        return preg_replace(['/\s*-mllvm\s+\S+/', '/\s*-Wno-error=\S+/', '/\s*-Wno-backend-plugin/'], '', $flags) ?? $flags;
+    }
+}

--- a/src/SPC/util/PgoManager.php
+++ b/src/SPC/util/PgoManager.php
@@ -6,11 +6,11 @@ namespace SPC\util;
 
 use SPC\exception\WrongUsageException;
 use SPC\store\FileSystem;
+use SPC\store\SourcePatcher;
 
 /**
  * Two-call PGO driver: --pgi instruments, --pgo uses the .profraw the user
- * collected by running the instrumented binaries. PgoManager only sets the
- * compiler flags; it does not run any workload itself.
+ * collected by running the instrumented binaries.
  */
 class PgoManager
 {
@@ -18,13 +18,6 @@ class PgoManager
 
     public const MODE_USE = 'use';
 
-    /**
-     * SAPIs whose clang-compiled output can be PGO'd. frankenphp is included
-     * because its cgo glue is C compiled by zig — the Go side it wraps is
-     * not clang-PGO'd here. libphp.so is the embed SAPI; running frankenphp
-     * produces profile data for embed (because it loads libphp.so) AND for
-     * frankenphp (because the cgo glue runs too).
-     */
     private const TRAINABLE = [
         'cli' => BUILD_TARGET_CLI,
         'micro' => BUILD_TARGET_MICRO,
@@ -32,6 +25,15 @@ class PgoManager
         'fpm' => BUILD_TARGET_FPM,
         'embed' => BUILD_TARGET_EMBED,
         'frankenphp' => BUILD_TARGET_FRANKENPHP,
+    ];
+
+    /**
+     * Applied during --pgi only: explicit __llvm_profile_write_file() at
+     * shutdown, since Go/frankenphp exits skip libc atexit.
+     */
+    private const SHUTDOWN_PATCHES = [
+        'php-src' => 'spc_pgo_flush_php_main.patch',
+        'frankenphp' => 'spc_pgo_flush_frankenphp.patch',
     ];
 
     private string $profileRoot;
@@ -61,6 +63,7 @@ class PgoManager
         }
         $this->mode = self::MODE_INSTRUMENT;
         self::$active = $this;
+        $this->applyShutdownPatches();
         $this->applyForSapi($this->trainableIn($rule)[0]);
         logger()->info('pgo --pgi: instrumented build, profraw will land under ' . $this->profileRoot . '/<sapi>/');
     }
@@ -80,30 +83,33 @@ class PgoManager
         $this->applyForSapi($this->trainableIn($rule)[0]);
     }
 
-    /**
-     * Set EXTRA_CFLAGS / EXTRA_LDFLAGS_PROGRAM for the SAPI about to be built.
-     * Non-trainable SAPIs (e.g. frankenphp's Go side) are left untouched.
-     */
     public function applyForSapi(string $sapi): void
     {
         $sapi = $this->resolveSapi($sapi);
         if (!isset(self::TRAINABLE[$sapi])) {
             return;
         }
+        if ($this->mode === self::MODE_USE && !is_file($this->profDataFile($sapi))) {
+            logger()->warning("pgo --pgo: no profdata for {$sapi}, building without PGO for this sapi");
+            $this->setFlag('SPC_CMD_VAR_PHP_MAKE_EXTRA_CFLAGS', '');
+            $this->setFlag('SPC_CMD_VAR_PHP_MAKE_EXTRA_LDFLAGS_PROGRAM', '');
+            return;
+        }
         $flags = $this->mode === self::MODE_INSTRUMENT
-            ? '-fprofile-generate=' . $this->rawDir($sapi) . ' -fprofile-continuous -mllvm -disable-vp'
-            : '-fprofile-use=' . $this->profDataFile($sapi) . ' -Wno-error=profile-instr-unprofiled -Wno-error=profile-instr-out-of-date -Wno-backend-plugin';
+            ? '-fprofile-generate=' . $this->rawDir($sapi)
+            : '-fprofile-use=' . $this->profDataFile($sapi)
+                . ' -Wno-error=profile-instr-unprofiled'
+                . ' -Wno-error=profile-instr-out-of-date'
+                . ' -Wno-backend-plugin';
         $this->setFlag('SPC_CMD_VAR_PHP_MAKE_EXTRA_CFLAGS', $flags);
-        $this->setFlag('SPC_CMD_VAR_PHP_MAKE_EXTRA_LDFLAGS_PROGRAM', $this->ldOnly($flags));
+        $this->setFlag('SPC_CMD_VAR_PHP_MAKE_EXTRA_LDFLAGS_PROGRAM', $this->ldOnly($flags, $sapi));
         logger()->info("pgo {$this->mode} ({$sapi})");
     }
 
     /**
-     * In static-embed mode libphp.a is linked into frankenphp, and the linker
-     * resolves all `__llvm_profile_filename` references to a single path —
-     * the embed SAPI's per-TU `-fprofile-generate=…` setting is silently
-     * dropped. Compile libphp.a with frankenphp's path so all counter writes
-     * agree on one file, and read libphp.a's PGO from frankenphp.profdata.
+     * Static-embed mode links libphp.a into frankenphp; both end up in one
+     * binary so must share one profdata. Shared-embed mode keeps libphp.so
+     * standalone — embed and frankenphp keep separate profiles.
      */
     private function resolveSapi(string $sapi): string
     {
@@ -124,6 +130,10 @@ class PgoManager
     {
         $raws = glob($this->rawDir($sapi) . '/*.profraw') ?: [];
         if (empty($raws)) {
+            if ($sapi === 'frankenphp') {
+                logger()->warning('pgo --pgo: no .profraw for frankenphp (cgo glue PGO will be skipped); run --pgi, exercise frankenphp longer, then re-run --pgo to include it');
+                return;
+            }
             throw new WrongUsageException("--pgo: no .profraw for {$sapi}; run --pgi, exercise the binary, then re-run --pgo");
         }
         $out = $this->profDataFile($sapi);
@@ -166,14 +176,69 @@ class PgoManager
     {
         $cur = (string) getenv($var);
         $cur = preg_replace('/\s*-fprofile-(generate|use)=\S+/', '', $cur) ?? $cur;
-        $cur = str_replace([' -fprofile-continuous', ' -mllvm -disable-vp'], '', $cur);
-        $cur = preg_replace('/\s*-Wno-error=profile-instr-unprofiled\s+-Wno-error=profile-instr-out-of-date\s+-Wno-backend-plugin/', '', $cur) ?? $cur;
+        $cur = preg_replace('/\s*-Wno-error=profile-instr-\S+/', '', $cur) ?? $cur;
+        $cur = preg_replace('/\s*-Wno-backend-plugin/', '', $cur) ?? $cur;
         f_putenv($var . '=' . trim($cur . ' ' . $append));
     }
 
-    /** Linker only takes -fprofile-{generate,use}; strip the codegen-only -mllvm and warning flags. */
-    private function ldOnly(string $flags): string
+    /**
+     * Linker flags: cli wants -fprofile-use= at link too (LTO does its
+     * profile-driven inlining/reordering at link time). Strip -Wno-error
+     * flags (linker doesn't accept them).
+     */
+    private function ldOnly(string $flags, string $sapi = ''): string
     {
-        return preg_replace(['/\s*-mllvm\s+\S+/', '/\s*-Wno-error=\S+/', '/\s*-Wno-backend-plugin/'], '', $flags) ?? $flags;
+        $patterns = ['/\s*-Wno-error=\S+/', '/\s*-Wno-backend-plugin/'];
+        if ($sapi === 'frankenphp') {
+            $patterns[] = '/\s*-fprofile-use=\S+/';
+        }
+        return trim(preg_replace($patterns, '', $flags) ?? $flags);
+    }
+
+    /** --pgi patch: inject __llvm_profile_write_file() flush handler to php and frankenphp sources. */
+    private function applyShutdownPatches(): void
+    {
+        $applied = [];
+        foreach (self::SHUTDOWN_PATCHES as $dir => $patch) {
+            $cwd = SOURCE_PATH . '/' . $dir;
+            if (!is_dir($cwd)) {
+                continue;
+            }
+            if (!SourcePatcher::patchFile($patch, $cwd)) {
+                throw new WrongUsageException("--pgi: patch {$patch} failed to apply in {$cwd}");
+            }
+            $applied[] = ['cwd' => $cwd, 'patch' => $patch];
+            logger()->info("pgo --pgi: applied {$patch}");
+        }
+        if ($applied === []) {
+            return;
+        }
+        register_shutdown_function(static function () use ($applied): void {
+            foreach ($applied as $entry) {
+                $cwd = $entry['cwd'];
+                $patch = $entry['patch'];
+                if (!is_dir($cwd)) {
+                    continue;
+                }
+                $patch_file = ROOT_DIR . "/src/globals/patch/{$patch}";
+                if (!is_file($patch_file)) {
+                    continue;
+                }
+                $args = ' -p1 -s -R -F0 ';
+                exec('cd ' . escapeshellarg($cwd) . ' && patch --dry-run' . $args
+                    . ' < ' . escapeshellarg($patch_file) . ' >/dev/null 2>&1', $_, $detect_status);
+                if ($detect_status !== 0) {
+                    logger()->info("pgo --pgi: {$patch} already clean, skipping revert");
+                    continue;
+                }
+                exec('cd ' . escapeshellarg($cwd) . ' && patch' . $args
+                    . ' < ' . escapeshellarg($patch_file), $out, $apply_status);
+                if ($apply_status === 0) {
+                    logger()->info("pgo --pgi: reverted {$patch}");
+                } else {
+                    logger()->warning("pgo --pgi: failed to revert {$patch} (status {$apply_status}): " . implode("\n", $out));
+                }
+            }
+        });
     }
 }

--- a/src/SPC/util/PgoManager.php
+++ b/src/SPC/util/PgoManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SPC\util;
 
+use SPC\builder\BuilderBase;
 use SPC\exception\WrongUsageException;
 use SPC\store\FileSystem;
 use SPC\store\SourcePatcher;
@@ -15,6 +16,8 @@ use SPC\store\SourcePatcher;
 class PgoManager
 {
     public const MODE_INSTRUMENT = 'instrument';
+
+    public const MODE_CS_INSTRUMENT = 'cs-instrument';
 
     public const MODE_USE = 'use';
 
@@ -68,6 +71,23 @@ class PgoManager
         logger()->info('pgo --pgi: instrumented build, profraw will land under ' . $this->profileRoot . '/<sapi>/');
     }
 
+    /** Setup --cs-pgi: build with -fprofile-use=<sapi.profdata> -fcs-profile-generate=<cs-dir>. Requires existing .profdata. */
+    public function setupCsInstrument(int $rule): void
+    {
+        $this->validateRule($rule);
+        foreach ($this->trainableIn($rule) as $sapi) {
+            if (!is_file($this->profDataFile($sapi))) {
+                throw new WrongUsageException("--cs-pgi: missing {$sapi}.profdata; run --pgi + --pgo first");
+            }
+            f_mkdir($this->csRawDir($sapi), recursive: true);
+        }
+        $this->mode = self::MODE_CS_INSTRUMENT;
+        self::$active = $this;
+        $this->applyShutdownPatches();
+        $this->applyForSapi($this->trainableIn($rule)[0]);
+        logger()->info('pgo --cs-pgi: cs-instrumented build, cs-profraw under ' . $this->profileRoot . '/cs-<sapi>/');
+    }
+
     /** Setup --pgo: merge collected .profraw, then build with -fprofile-use=<sapi.profdata>. */
     public function setupUse(int $rule): void
     {
@@ -83,6 +103,29 @@ class PgoManager
         $this->applyForSapi($this->trainableIn($rule)[0]);
     }
 
+    /** Patches php-src/libtool to passthrough -fcs-profile-* flags (otherwise dropped during shared lib link). */
+    public static function patchBeforeMake(BuilderBase $builder): void
+    {
+        if (!$builder->getOption('cs-pgi')) {
+            return;
+        }
+        $libtool = SOURCE_PATH . '/php-src/libtool';
+        if (!is_file($libtool)) {
+            return;
+        }
+        $contents = file_get_contents($libtool);
+        if (str_contains($contents, '-fcs-profile-*')) {
+            return;
+        }
+        $patched = str_replace('-fprofile-*|-F*', '-fprofile-*|-fcs-profile-*|-F*', $contents);
+        if ($patched === $contents) {
+            logger()->warning('pgo --cs-pgi: could not patch libtool for -fcs-profile-* passthrough');
+            return;
+        }
+        file_put_contents($libtool, $patched);
+        logger()->info('pgo --cs-pgi: patched libtool for -fcs-profile-* passthrough');
+    }
+
     public function applyForSapi(string $sapi): void
     {
         $sapi = $this->resolveSapi($sapi);
@@ -95,12 +138,18 @@ class PgoManager
             $this->setFlag('SPC_CMD_VAR_PHP_MAKE_EXTRA_LDFLAGS_PROGRAM', '');
             return;
         }
-        $flags = $this->mode === self::MODE_INSTRUMENT
-            ? '-fprofile-generate=' . $this->rawDir($sapi)
-            : '-fprofile-use=' . $this->profDataFile($sapi)
+        $flags = match ($this->mode) {
+            self::MODE_INSTRUMENT => '-fprofile-generate=' . $this->rawDir($sapi),
+            self::MODE_CS_INSTRUMENT => '-fprofile-use=' . $this->profDataFile($sapi)
+                . ' -fcs-profile-generate=' . $this->csRawDir($sapi)
                 . ' -Wno-error=profile-instr-unprofiled'
                 . ' -Wno-error=profile-instr-out-of-date'
-                . ' -Wno-backend-plugin';
+                . ' -Wno-backend-plugin',
+            default => '-fprofile-use=' . $this->profDataFile($sapi)
+                . ' -Wno-error=profile-instr-unprofiled'
+                . ' -Wno-error=profile-instr-out-of-date'
+                . ' -Wno-backend-plugin',
+        };
         $this->setFlag('SPC_CMD_VAR_PHP_MAKE_EXTRA_CFLAGS', $flags);
         $this->setFlag('SPC_CMD_VAR_PHP_MAKE_EXTRA_LDFLAGS_PROGRAM', $this->ldOnly($flags, $sapi));
         logger()->info("pgo {$this->mode} ({$sapi})");
@@ -129,7 +178,8 @@ class PgoManager
     private function mergeSapi(string $sapi): void
     {
         $raws = glob($this->rawDir($sapi) . '/*.profraw') ?: [];
-        if (empty($raws)) {
+        $csRaws = glob($this->csRawDir($sapi) . '/*.profraw') ?: [];
+        if (empty($raws) && empty($csRaws)) {
             if ($sapi === 'frankenphp') {
                 logger()->warning('pgo --pgo: no .profraw for frankenphp (cgo glue PGO will be skipped); run --pgi, exercise frankenphp longer, then re-run --pgo to include it');
                 return;
@@ -137,7 +187,8 @@ class PgoManager
             throw new WrongUsageException("--pgo: no .profraw for {$sapi}; run --pgi, exercise the binary, then re-run --pgo");
         }
         $out = $this->profDataFile($sapi);
-        $argv = implode(' ', array_map('escapeshellarg', $raws));
+        $inputs = array_merge($raws, $csRaws);
+        $argv = implode(' ', array_map('escapeshellarg', $inputs));
         shell()->exec('llvm-profdata merge --failure-mode=warn -output=' . escapeshellarg($out) . ' ' . $argv);
         if (!is_file($out) || filesize($out) === 0) {
             throw new WrongUsageException("--pgo: empty merge output for {$sapi}");
@@ -148,6 +199,11 @@ class PgoManager
     private function rawDir(string $sapi): string
     {
         return $this->profileRoot . '/' . $sapi;
+    }
+
+    private function csRawDir(string $sapi): string
+    {
+        return $this->profileRoot . '/cs-' . $sapi;
     }
 
     private function profDataFile(string $sapi): string
@@ -175,7 +231,7 @@ class PgoManager
     private function setFlag(string $var, string $append): void
     {
         $cur = (string) getenv($var);
-        $cur = preg_replace('/\s*-fprofile-(generate|use)=\S+/', '', $cur) ?? $cur;
+        $cur = preg_replace('/\s*-f(cs-)?profile-(generate|use)=\S+/', '', $cur) ?? $cur;
         $cur = preg_replace('/\s*-Wno-error=profile-instr-\S+/', '', $cur) ?? $cur;
         $cur = preg_replace('/\s*-Wno-backend-plugin/', '', $cur) ?? $cur;
         f_putenv($var . '=' . trim($cur . ' ' . $append));
@@ -191,6 +247,7 @@ class PgoManager
         $patterns = ['/\s*-Wno-error=\S+/', '/\s*-Wno-backend-plugin/'];
         if ($sapi === 'frankenphp') {
             $patterns[] = '/\s*-fprofile-use=\S+/';
+            $patterns[] = '/\s*-fcs-profile-generate=\S+/';
         }
         return trim(preg_replace($patterns, '', $flags) ?? $flags);
     }

--- a/src/SPC/util/PgoManager.php
+++ b/src/SPC/util/PgoManager.php
@@ -104,9 +104,11 @@ class PgoManager
             return;
         }
         $flags = match ($this->mode) {
-            self::MODE_INSTRUMENT => '-fprofile-generate=' . $this->rawDir($sapi),
+            self::MODE_INSTRUMENT => '-fprofile-generate=' . $this->rawDir($sapi)
+                . ' -fprofile-update=atomic',
             self::MODE_CS_INSTRUMENT => '-fprofile-use=' . $this->profDataFile($sapi)
                 . ' -fcs-profile-generate=' . $this->csRawDir($sapi)
+                . ' -fprofile-update=atomic'
                 . ' -Wno-error=profile-instr-unprofiled'
                 . ' -Wno-error=profile-instr-out-of-date'
                 . ' -Wno-backend-plugin',

--- a/src/SPC/util/PgoManager.php
+++ b/src/SPC/util/PgoManager.php
@@ -43,64 +43,29 @@ class PgoManager
 
     private string $mode;
 
-    private static ?self $active = null;
-
-    public function __construct()
+    private function __construct()
     {
         $this->profileRoot = BUILD_ROOT_PATH . '/pgo-data';
     }
 
-    public static function active(): ?self
+    /** Build a PgoManager for the active --pgi/--cs-pgi/--pgo option, or null if none set. */
+    public static function fromBuilder(BuilderBase $builder, int $rule): ?self
     {
-        return self::$active;
-    }
-
-    /** Setup --pgi: build with -fprofile-generate=<sapi-dir>. */
-    public function setupInstrument(int $rule): void
-    {
-        $this->validateRule($rule);
-        FileSystem::removeDir($this->profileRoot);
-        f_mkdir($this->profileRoot, recursive: true);
-        foreach ($this->trainableIn($rule) as $sapi) {
-            f_mkdir($this->rawDir($sapi), recursive: true);
+        $modes = array_filter(['pgi', 'cs-pgi', 'pgo'], fn ($m) => (bool) $builder->getOption($m));
+        if (count($modes) > 1) {
+            throw new WrongUsageException('--pgi, --cs-pgi, and --pgo are mutually exclusive');
         }
-        $this->mode = self::MODE_INSTRUMENT;
-        self::$active = $this;
-        $this->applyShutdownPatches();
-        $this->applyForSapi($this->trainableIn($rule)[0]);
-        logger()->info('pgo --pgi: instrumented build, profraw will land under ' . $this->profileRoot . '/<sapi>/');
-    }
-
-    /** Setup --cs-pgi: build with -fprofile-use=<sapi.profdata> -fcs-profile-generate=<cs-dir>. Requires existing .profdata. */
-    public function setupCsInstrument(int $rule): void
-    {
-        $this->validateRule($rule);
-        foreach ($this->trainableIn($rule) as $sapi) {
-            if (!is_file($this->profDataFile($sapi))) {
-                throw new WrongUsageException("--cs-pgi: missing {$sapi}.profdata; run --pgi + --pgo first");
-            }
-            f_mkdir($this->csRawDir($sapi), recursive: true);
+        $mode = array_values($modes)[0] ?? null;
+        if ($mode === null) {
+            return null;
         }
-        $this->mode = self::MODE_CS_INSTRUMENT;
-        self::$active = $this;
-        $this->applyShutdownPatches();
-        $this->applyForSapi($this->trainableIn($rule)[0]);
-        logger()->info('pgo --cs-pgi: cs-instrumented build, cs-profraw under ' . $this->profileRoot . '/cs-<sapi>/');
-    }
-
-    /** Setup --pgo: merge collected .profraw, then build with -fprofile-use=<sapi.profdata>. */
-    public function setupUse(int $rule): void
-    {
-        $this->validateRule($rule);
-        if (trim((string) shell_exec('command -v llvm-profdata 2>/dev/null')) === '') {
-            throw new WrongUsageException('--pgo: llvm-profdata not on PATH');
-        }
-        foreach ($this->trainableIn($rule) as $sapi) {
-            $this->mergeSapi($sapi);
-        }
-        $this->mode = self::MODE_USE;
-        self::$active = $this;
-        $this->applyForSapi($this->trainableIn($rule)[0]);
+        $instance = new self();
+        match ($mode) {
+            'pgi' => $instance->setupInstrument($rule),
+            'cs-pgi' => $instance->setupCsInstrument($rule),
+            'pgo' => $instance->setupUse($rule),
+        };
+        return $instance;
     }
 
     /** Patches php-src/libtool to passthrough -fcs-profile-* flags (otherwise dropped during shared lib link). */
@@ -153,6 +118,51 @@ class PgoManager
         $this->setFlag('SPC_CMD_VAR_PHP_MAKE_EXTRA_CFLAGS', $flags);
         $this->setFlag('SPC_CMD_VAR_PHP_MAKE_EXTRA_LDFLAGS_PROGRAM', $this->ldOnly($flags, $sapi));
         logger()->info("pgo {$this->mode} ({$sapi})");
+    }
+
+    /** Setup --pgi: build with -fprofile-generate=<sapi-dir>. */
+    private function setupInstrument(int $rule): void
+    {
+        $this->validateRule($rule);
+        FileSystem::removeDir($this->profileRoot);
+        f_mkdir($this->profileRoot, recursive: true);
+        foreach ($this->trainableIn($rule) as $sapi) {
+            f_mkdir($this->rawDir($sapi), recursive: true);
+        }
+        $this->mode = self::MODE_INSTRUMENT;
+        $this->applyShutdownPatches();
+        $this->applyForSapi($this->trainableIn($rule)[0]);
+        logger()->info('pgo --pgi: instrumented build, profraw will land under ' . $this->profileRoot . '/<sapi>/');
+    }
+
+    /** Setup --cs-pgi: build with -fprofile-use=<sapi.profdata> -fcs-profile-generate=<cs-dir>. Requires existing .profdata. */
+    private function setupCsInstrument(int $rule): void
+    {
+        $this->validateRule($rule);
+        foreach ($this->trainableIn($rule) as $sapi) {
+            if (!is_file($this->profDataFile($sapi))) {
+                throw new WrongUsageException("--cs-pgi: missing {$sapi}.profdata; run --pgi + --pgo first");
+            }
+            f_mkdir($this->csRawDir($sapi), recursive: true);
+        }
+        $this->mode = self::MODE_CS_INSTRUMENT;
+        $this->applyShutdownPatches();
+        $this->applyForSapi($this->trainableIn($rule)[0]);
+        logger()->info('pgo --cs-pgi: cs-instrumented build, cs-profraw under ' . $this->profileRoot . '/cs-<sapi>/');
+    }
+
+    /** Setup --pgo: merge collected .profraw, then build with -fprofile-use=<sapi.profdata>. */
+    private function setupUse(int $rule): void
+    {
+        $this->validateRule($rule);
+        if (trim((string) shell_exec('command -v llvm-profdata 2>/dev/null')) === '') {
+            throw new WrongUsageException('--pgo: llvm-profdata not on PATH');
+        }
+        foreach ($this->trainableIn($rule) as $sapi) {
+            $this->mergeSapi($sapi);
+        }
+        $this->mode = self::MODE_USE;
+        $this->applyForSapi($this->trainableIn($rule)[0]);
     }
 
     /**

--- a/src/SPC/util/PgoManager.php
+++ b/src/SPC/util/PgoManager.php
@@ -14,6 +14,10 @@ use SPC\store\FileSystem;
  */
 class PgoManager
 {
+    public const MODE_INSTRUMENT = 'instrument';
+
+    public const MODE_USE = 'use';
+
     /**
      * SAPIs whose clang-compiled output can be PGO'd. frankenphp is included
      * because its cgo glue is C compiled by zig — the Go side it wraps is
@@ -22,17 +26,13 @@ class PgoManager
      * frankenphp (because the cgo glue runs too).
      */
     private const TRAINABLE = [
-        'cli'        => BUILD_TARGET_CLI,
-        'micro'      => BUILD_TARGET_MICRO,
-        'cgi'        => BUILD_TARGET_CGI,
-        'fpm'        => BUILD_TARGET_FPM,
-        'embed'      => BUILD_TARGET_EMBED,
+        'cli' => BUILD_TARGET_CLI,
+        'micro' => BUILD_TARGET_MICRO,
+        'cgi' => BUILD_TARGET_CGI,
+        'fpm' => BUILD_TARGET_FPM,
+        'embed' => BUILD_TARGET_EMBED,
         'frankenphp' => BUILD_TARGET_FRANKENPHP,
     ];
-
-    public const MODE_INSTRUMENT = 'instrument';
-
-    public const MODE_USE = 'use';
 
     private string $profileRoot;
 

--- a/src/SPC/util/SPCConfigUtil.php
+++ b/src/SPC/util/SPCConfigUtil.php
@@ -42,17 +42,18 @@ class SPCConfigUtil
     /**
      * Generate configuration for building PHP extensions.
      *
-     * @param array $extensions          Extension name list
-     * @param array $libraries           Additional library name list
-     * @param bool  $include_suggest_ext Include suggested extensions
-     * @param bool  $include_suggest_lib Include suggested libraries
+     * @param array      $extensions          Extension name list
+     * @param array      $libraries           Additional library name list
+     * @param bool       $include_suggest_ext Include suggested extensions
+     * @param array|bool $include_suggest_lib true/false to include all/no suggested libs; array to include only suggests that point at libs in the array erse of libs being built)
      * @return array{
      *     cflags: string,
      *     ldflags: string,
      *     libs: string
      * }
+     * @throws WrongUsageException
      */
-    public function config(array $extensions = [], array $libraries = [], bool $include_suggest_ext = false, bool $include_suggest_lib = false): array
+    public function config(array $extensions = [], array $libraries = [], bool $include_suggest_ext = false, array|bool $include_suggest_lib = false): array
     {
         logger()->debug('config extensions: ' . implode(',', $extensions));
         logger()->debug('config libs: ' . implode(',', $libraries));

--- a/src/SPC/util/SPCTarget.php
+++ b/src/SPC/util/SPCTarget.php
@@ -127,4 +127,19 @@ class SPCTarget
             default => PHP_OS_FAMILY,
         };
     }
+
+    /**
+     * Returns the target OS arch, e.g. x86_64, aarch64, arm, x86.
+     */
+    public static function getTargetArch(): string
+    {
+        $target = (string) getenv('SPC_TARGET');
+        return match (true) {
+            str_starts_with($target, 'aarch64') => 'aarch64',
+            str_starts_with($target, 'arm-') => 'arm',
+            str_starts_with($target, 'x86_64-') => 'x86_64',
+            str_starts_with($target, 'x86-') => 'x86',
+            default => GNU_ARCH,
+        };
+    }
 }

--- a/src/SPC/util/executor/UnixCMakeExecutor.php
+++ b/src/SPC/util/executor/UnixCMakeExecutor.php
@@ -216,9 +216,11 @@ set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES "{$include}")
 set(CMAKE_C_STANDARD_LIBRARIES "-ldl -lpthread -lm -lutil")
 set(CMAKE_CXX_STANDARD_LIBRARIES "-ldl -lpthread -lm -lutil")
 CMAKE;
-        // Whoops, linux may need CMAKE_AR sometimes
         if (PHP_OS_FAMILY === 'Linux') {
-            $toolchain .= "\nSET(CMAKE_AR \"ar\")";
+            $ar = getenv('SPC_LINUX_DEFAULT_AR') ?: getenv('AR') ?: 'ar';
+            $ranlib = getenv('SPC_LINUX_DEFAULT_RANLIB') ?: (getenv('RANLIB') ?: 'ranlib');
+            $toolchain .= "\nSET(CMAKE_AR \"{$ar}\")";
+            $toolchain .= "\nSET(CMAKE_RANLIB \"{$ranlib}\")";
         }
         FileSystem::writeFile(SOURCE_PATH . '/toolchain.cmake', $toolchain);
         return $created = realpath(SOURCE_PATH . '/toolchain.cmake');

--- a/src/SPC/util/executor/UnixCMakeExecutor.php
+++ b/src/SPC/util/executor/UnixCMakeExecutor.php
@@ -213,7 +213,8 @@ set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES "{$include}")
 set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES "{$include}")
-set(CMAKE_EXE_LINKER_FLAGS "-ldl -lpthread -lm -lutil")
+set(CMAKE_C_STANDARD_LIBRARIES "-ldl -lpthread -lm -lutil")
+set(CMAKE_CXX_STANDARD_LIBRARIES "-ldl -lpthread -lm -lutil")
 CMAKE;
         // Whoops, linux may need CMAKE_AR sometimes
         if (PHP_OS_FAMILY === 'Linux') {

--- a/src/globals/patch/spc_pgo_flush_frankenphp.patch
+++ b/src/globals/patch/spc_pgo_flush_frankenphp.patch
@@ -1,0 +1,15 @@
+--- a/frankenphp.c
++++ b/frankenphp.c
+@@ -1254,6 +1254,12 @@
+
+   go_frankenphp_shutdown_main_thread();
+
++  /* spc-pgo: explicit profile flush so the cgo-instrumented frankenphp
++   * still writes .profraw on Go-runtime exit (which bypasses libc atexit).
++   * Weak symbol → no-op in non-PGO builds. */
++  { extern int __llvm_profile_write_file(void) __attribute__((weak));
++    if (__llvm_profile_write_file) __llvm_profile_write_file(); }
++
+   return NULL;
+ }
+

--- a/src/globals/patch/spc_pgo_flush_php_main.patch
+++ b/src/globals/patch/spc_pgo_flush_php_main.patch
@@ -1,0 +1,15 @@
+--- a/main/main.c
++++ b/main/main.c
+@@ -2563,6 +2563,12 @@
+ #endif
+
+ 	zend_observer_shutdown();
++
++	/* spc-pgo: explicit profile flush so embed/frankenphp callers that exit
++	 * via SYS_exit_group (skipping libc atexit) still get .profraw written.
++	 * Weak symbol → no-op in non-PGO builds. */
++	{ extern int __llvm_profile_write_file(void) __attribute__((weak));
++	  if (__llvm_profile_write_file) __llvm_profile_write_file(); }
+ }
+ /* }}} */
+

--- a/src/globals/patch/spc_pgo_flush_php_main.patch
+++ b/src/globals/patch/spc_pgo_flush_php_main.patch
@@ -1,13 +1,10 @@
 --- a/main/main.c
 +++ b/main/main.c
-@@ -2563,6 +2563,12 @@
+@@ -2563,6 +2563,9 @@
  #endif
 
  	zend_observer_shutdown();
 +
-+	/* spc-pgo: explicit profile flush so embed/frankenphp callers that exit
-+	 * via SYS_exit_group (skipping libc atexit) still get .profraw written.
-+	 * Weak symbol → no-op in non-PGO builds. */
 +	{ extern int __llvm_profile_write_file(void) __attribute__((weak));
 +	  if (__llvm_profile_write_file) __llvm_profile_write_file(); }
  }


### PR DESCRIPTION
## What does this PR do?

Disclaimer: zig/clang ONLY!

- reworks Zig patches to happen on zig-cc instead of patching shared extensions makefiles
- instead of looking for shared runtime begin and end objects on the host machine, compile them from llvm source - this fixes also libraries if we decide to build them as shared libraries instead of static, useful for v3

adds profile guided optimizations to the project
- closely aligned to windows' --enable-pgi -> --with-pgo workflow
- function level profiling and value profiling
- cs profiling for an optional second pgo pass
- full and thin lto compatibility, required a few library patches
- coincidentally figured out that our cmake $AR set caused issues

not so nice:
- need to patch because Go doesn't call libc's atexit handlers that are usually responsible for writing out profile data
- -fprofile-continuous works without it, but can't do vp and also confuses older llvm-profdata binaries...
- need a llvm toolchain on the computer... older version is fine, but I'm not sure how far back. 19+ work for zigs llvm 21/22 (dev).

also adds required pre-work for: https://github.com/php/frankenphp/pull/2361
- pgo for frankenphp (just add `SPC_CMD_VAR_FRANKENPHP_XCADDY_MODULES=... ${FRANKENPHP_SOURCE_DIR}` and rewrite the env var to be set before the second GlobalEnvManager pass)

Little preview of frankenphp benchmarks:
```
❯❯ frankenphp git:(perf-tests) 23:04 LD_LIBRARY_PATH=/home/m/static-php-cli/pgobuild FRANKENPHP_BIN=/home/m/static-php-cli/pgobuild/frankenphp ./profiles/benchmark.sh
/home/m/static-php-cli/pgobuild/frankenphp
script                      req/s        avg        p50        p99
cookies_headers             36044     7.42ms     6.40ms    25.15ms
file_io                   7568.43    33.41ms    32.67ms    43.67ms
frankenphp_log            38847.7     6.84ms     6.00ms    21.43ms
helloworld                42319.7     6.23ms     5.49ms    19.86ms
large_response               9931    21.11ms    18.06ms    61.10ms
mandelbrot                1437.94   173.65ms   164.08ms   239.88ms
post_body                 36753.9     7.18ms     6.32ms    22.20ms
random                    13163.2    19.65ms    17.58ms    60.17ms
status_codes              35443.7     7.44ms     6.55ms    22.96ms
streaming                 19274.1    13.32ms    12.32ms    35.60ms
total req/s                240784
❯❯ frankenphp git:(perf-tests) 23:06 ./profiles/benchmark.sh
/home/m/frankenphp/caddy/frankenphp/frankenphp
script                      req/s        avg        p50        p99
cookies_headers             27353     9.32ms     8.84ms    16.48ms
file_io                   5483.86    45.96ms    43.31ms    74.65ms
frankenphp_log            26572.2     9.52ms     9.07ms    17.25ms
helloworld                27481.2     9.20ms     8.74ms    17.74ms
large_response            5292.43    47.75ms    45.78ms    73.83ms
mandelbrot                2188.24   113.81ms   101.98ms   187.42ms
post_body                 26340.5     9.59ms     9.16ms    18.00ms
random                     2754.5    91.28ms    89.72ms   118.68ms
status_codes              26327.5     9.62ms     9.13ms    19.67ms
streaming                 2224.59   113.31ms   110.16ms   153.59ms
total req/s                152019
```

Little preview of php-cli benchmarks:
```
❯❯ frankenphp git:(perf-tests)  19:30 yes n | PHP_BIN=/home/static-php-cli/buildroot/bin/php phoronix-test-suite benchmark phpbench
    Estimated Trial Run Count:    3
    Estimated Time To Completion: 2 Minutes [12:32 UTC]
        Started Run 1 @ 12:31:21
        Started Run 2 @ 12:31:39
        Started Run 3 @ 12:31:54

    [8192] Using null as an array offset is deprecated, use an empty string instead in pts_strings:586

    PHP Benchmark Suite:
        1892968
        1903458
        1923582

    Average: 1906669 Score
    Deviation: 0.82%
❯❯ frankenphp git:(perf-tests)  19:32 yes n | PHP_BIN=/usr/bin/php-zts phoronix-test-suite benchmark phpbench
    Estimated Trial Run Count:    3
    Estimated Time To Completion: 2 Minutes [12:34 UTC]
        Started Run 1 @ 12:32:57
        Started Run 2 @ 12:33:18
        Started Run 3 @ 12:33:34

    [8192] Using null as an array offset is deprecated, use an empty string instead in pts_strings:586

    PHP Benchmark Suite:
        1646683
        1646953
        1635145

    Average: 1642927 Score
    Deviation: 0.41%
❯❯ frankenphp git:(perf-tests) 19:44 yes n | PHP_BIN=/usr/bin/php phoronix-test-suite benchmark phpbench
    Estimated Trial Run Count:    3
    Estimated Time To Completion: 2 Minutes [12:46 UTC]
        Started Run 1 @ 12:44:49
        Started Run 2 @ 12:45:13
        Started Run 3 @ 12:45:32

    [8192] Using null as an array offset is deprecated, use an empty string instead in pts_strings:586

    PHP Benchmark Suite:
        1340276
        1323430
        1315188

    Average: 1326298 Score
    Deviation: 0.96%
 ```