### PR TITLE
add windows static build support for libxslt, gmp, gettext

### DIFF
--- a/config/ext.json
+++ b/config/ext.json
@@ -1210,11 +1210,11 @@
     },
     "xsl": {
         "support": {
-            "Windows": "wip",
             "BSD": "wip"
         },
         "type": "builtin",
         "arg-type": "with-path",
+        "arg-type-windows": "with",
         "lib-depends": [
             "libxslt"
         ],

--- a/config/ext.json
+++ b/config/ext.json
@@ -211,13 +211,16 @@
     },
     "gettext": {
         "support": {
-            "Windows": "wip",
             "BSD": "wip"
         },
         "type": "builtin",
         "arg-type": "with-path",
+        "arg-type-windows": "with",
         "lib-depends": [
             "gettext"
+        ],
+        "lib-depends-windows": [
+            "libintl-win"
         ]
     },
     "glfw": {

--- a/config/ext.json
+++ b/config/ext.json
@@ -237,13 +237,16 @@
     },
     "gmp": {
         "support": {
-            "Windows": "wip",
             "BSD": "wip"
         },
         "type": "builtin",
         "arg-type": "with-path",
+        "arg-type-windows": "with",
         "lib-depends": [
             "gmp"
+        ],
+        "lib-depends-windows": [
+            "mpir-win"
         ]
     },
     "gmssl": {

--- a/config/lib.json
+++ b/config/lib.json
@@ -730,6 +730,10 @@
             "libxslt.a",
             "libexslt.a"
         ],
+        "static-libs-windows": [
+            "libxslt.lib",
+            "libexslt.lib"
+        ],
         "lib-depends": [
             "libxml2"
         ]

--- a/config/lib.json
+++ b/config/lib.json
@@ -178,9 +178,6 @@
         "static-libs-unix": [
             "libgmp.a"
         ],
-        "static-libs-windows": [
-            "libgmp.lib"
-        ],
         "headers": [
             "gmp.h"
         ]
@@ -785,6 +782,15 @@
         "source": "mimalloc",
         "static-libs-unix": [
             "libmimalloc.a"
+        ]
+    },
+    "mpir-win": {
+        "source": "mpir-win",
+        "static-libs-windows": [
+            "mpir_a.lib"
+        ],
+        "headers-windows": [
+            "mpir/gmp.h"
         ]
     },
     "ncurses": {

--- a/config/lib.json
+++ b/config/lib.json
@@ -481,6 +481,15 @@
             "libiconv_a.lib"
         ]
     },
+    "libintl-win": {
+        "source": "libintl-win",
+        "static-libs-windows": [
+            "libintl_a.lib"
+        ],
+        "headers-windows": [
+            "libintl.h"
+        ]
+    },
     "libjpeg": {
         "source": "libjpeg",
         "static-libs-unix": [

--- a/config/source.json
+++ b/config/source.json
@@ -910,6 +910,14 @@
             "path": "LICENSE"
         }
     },
+    "mpir-win": {
+        "type": "url",
+        "url": "https://downloads.php.net/~windows/php-sdk/deps/vs17/x64/mpir-3.0.0-1-vs17-x64.zip",
+        "license": {
+            "type": "text",
+            "text": "MPIR is licensed under the GNU Lesser General Public License v3 or later. Full text: https://www.gnu.org/licenses/lgpl-3.0.txt"
+        }
+    },
     "msgpack": {
         "type": "url",
         "url": "https://pecl.php.net/get/msgpack",

--- a/config/source.json
+++ b/config/source.json
@@ -646,6 +646,14 @@
             "path": "source/COPYING"
         }
     },
+    "libintl-win": {
+        "type": "url",
+        "url": "https://downloads.php.net/~windows/php-sdk/deps/vs17/x64/libintl-0.18.3-9-vs17-x64.zip",
+        "license": {
+            "type": "text",
+            "text": "GNU gettext is licensed under the GNU Lesser General Public License v2.1 or later. Full text: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt"
+        }
+    },
     "libidn2": {
         "type": "filelist",
         "url": "https://ftp.gnu.org/gnu/libidn/",

--- a/src/SPC/builder/windows/library/libintl_win.php
+++ b/src/SPC/builder/windows/library/libintl_win.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\windows\library;
+
+use SPC\store\FileSystem;
+
+class libintl_win extends WindowsLibraryBase
+{
+    public const NAME = 'libintl-win';
+
+    protected function build(): void
+    {
+        FileSystem::createDir(BUILD_LIB_PATH);
+        FileSystem::createDir(BUILD_INCLUDE_PATH);
+
+        copy($this->source_dir . '\lib\libintl_a.lib', BUILD_LIB_PATH . '\libintl_a.lib');
+        copy($this->source_dir . '\include\libintl.h', BUILD_INCLUDE_PATH . '\libintl.h');
+    }
+}

--- a/src/SPC/builder/windows/library/libxslt.php
+++ b/src/SPC/builder/windows/library/libxslt.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\windows\library;
+
+use SPC\store\FileSystem;
+
+class libxslt extends WindowsLibraryBase
+{
+    public const NAME = 'libxslt';
+
+    protected function build(): void
+    {
+        // reset cmake
+        FileSystem::resetDir($this->source_dir . '\build');
+
+        // start build
+        cmd()->cd($this->source_dir)
+            ->execWithWrapper(
+                $this->builder->makeSimpleWrapper('cmake'),
+                '-B build ' .
+                '-A x64 ' .
+                "-DCMAKE_TOOLCHAIN_FILE={$this->builder->cmake_toolchain_file} " .
+                '-DBUILD_SHARED_LIBS=OFF ' .
+                '-DLIBXSLT_WITH_PYTHON=OFF ' .
+                '-DLIBXSLT_WITH_CRYPTO=OFF ' .
+                '-DLIBXSLT_WITH_DEBUGGER=OFF ' .
+                '-DLIBXSLT_WITH_PROGRAMS=OFF ' .
+                '-DLIBXSLT_WITH_TESTS=OFF ' .
+                '-DLIBXSLT_WITH_MODULES=OFF ' .
+                '-DLibXml2_ROOT=' . BUILD_ROOT_PATH . ' ' .
+                '-DCMAKE_PREFIX_PATH=' . BUILD_ROOT_PATH . ' ' .
+                '-DCMAKE_INSTALL_PREFIX=' . BUILD_ROOT_PATH . ' '
+            )
+            ->execWithWrapper(
+                $this->builder->makeSimpleWrapper('cmake'),
+                "--build build --config Release --target install -j{$this->builder->concurrency}"
+            );
+        copy(BUILD_LIB_PATH . '\libxslts.lib', BUILD_LIB_PATH . '\libxslt.lib');
+        copy(BUILD_LIB_PATH . '\libexslts.lib', BUILD_LIB_PATH . '\libexslt.lib');
+    }
+}

--- a/src/SPC/builder/windows/library/mpir_win.php
+++ b/src/SPC/builder/windows/library/mpir_win.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SPC\builder\windows\library;
+
+use SPC\store\FileSystem;
+
+class mpir_win extends WindowsLibraryBase
+{
+    public const NAME = 'mpir-win';
+
+    protected function build(): void
+    {
+        FileSystem::createDir(BUILD_LIB_PATH);
+        FileSystem::createDir(BUILD_INCLUDE_PATH . '\mpir');
+
+        copy($this->source_dir . '\lib\mpir_a.lib', BUILD_LIB_PATH . '\mpir_a.lib');
+
+        foreach (['gmp.h', 'mpir.h', 'gmp-mparam.h', 'config.h'] as $header) {
+            copy(
+                $this->source_dir . '\include\mpir\\' . $header,
+                BUILD_INCLUDE_PATH . '\mpir\\' . $header,
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Flips three Windows-`wip` extensions to supported by adding native static-build Windows library builders. Each library is a separate commit.

### `xsl` — `libxslt` via CMake
Mirrors the existing `windows/library/libxml2.php` pattern. libxslt 1.1.34+ ships native `CMakeLists.txt`; build options match the existing unix trait (`--without-python`, `--without-crypto`, `--without-debugger`, `--without-debug`, libxml2 prefix). CMake install produces suffixed `libxsltS.lib` / `libexsltS.lib` which are renamed to `libxslt.lib` / `libexslt.lib`, same shape as libxml2.php's `libxml2s.lib` → `libxml2_a.lib`.

### `gmp` — MPIR via PHP-SDK deps
GNU GMP has no native MSVC build. This uses the same MPIR (GMP-compatible fork) build that PHP itself bundles for its official Windows builds, pulled from `downloads.php.net/~windows/php-sdk/deps/vs17/x64/mpir-3.0.0-1-vs17-x64.zip`. Pattern follows `postgresql-win` — declarative copy of `lib/mpir_a.lib` + `include/mpir/*.h` into the build root. New \`mpir-win\` lib is wired in via \`lib-depends-windows: [\"mpir-win\"]\` on the `gmp` ext, leaving the unix `gmp` library untouched.

### `gettext` — `libintl` via PHP-SDK deps
GNU gettext has no native MSVC build either. Same approach: pull `libintl-0.18.3-9-vs17-x64.zip` from the canonical PHP-SDK deps server, copy `lib/libintl_a.lib` + `include/libintl.h`. New \`libintl-win\` lib wired in via \`lib-depends-windows\` on `gettext`.

## Metadata cleanup

For all three extensions:
- removed \`\"Windows\": \"wip\"\` from \`support\`
- added \`\"arg-type-windows\": \"with\"\` (Windows \`configure.bat\` doesn't accept \`with-foo=PATH\` the same way autoconf does — matches the existing bz2/iconv/curl/gd pattern)

Also dropped a stale `static-libs-windows: ["libgmp.lib"]` from the `gmp` lib entry — the unix `gmp` lib is now never reached on Windows.

## Constraints

- **vs17 only.** Both PHP-SDK deps zips are version-pinned. Builds on VS 2019 (vs16) will not find these libs; the PHP-SDK deps server has vs16 variants if that becomes a real need (`mpir-3.0.0-vs16-x64.zip`, `libintl-0.18.3-8-vs16-x64.zip`). Most users targeting current PHP on Windows are on VS 2022 already.
- License pointers are short SPDX-style notes pointing at the canonical LGPL text URLs (LGPL v3 for MPIR, LGPL v2.1 for gettext), matching the style of the existing `gmp` source entry rather than the inlined-text style of `postgresql-win`. Easy follow-up to inline full text if `dump-license` consumers want it.

## Test plan

- [x] PHP lint clean on all three new builder classes
- [x] JSON parses (lib.json, ext.json, source.json)
- [x] `spc download mpir-win,libintl-win` resolves both URLs and downloads successfully
- [x] Zip layouts match builder expectations (`lib/mpir_a.lib` + `include/mpir/{gmp,mpir,gmp-mparam,config}.h`, `lib/libintl_a.lib` + `include/libintl.h`)
- [x] Manually executed both builders' copy logic — produces exactly the files declared in `static-libs-windows` / `headers-windows`
- [x] Header API surface verified (`mpir/gmp.h` exposes `__gmpz_*` etc.; `libintl.h` exposes `gettext()` and `__USE_GNU_GETTEXT`)
- [ ] Full end-to-end Windows build with VS 2022 — \`spc build-libs mpir-win,libintl-win,libxslt\` then \`spc build --build-cli "gmp,gettext,xsl"\` — not yet executed; requires a box with VS 2022 installed