### PR TITLE
Add a Log Filter to Strip Github Tokens

### DIFF
--- a/src/StaticPHP/Artifact/Downloader/Type/GitHubTokenSetupTrait.php
+++ b/src/StaticPHP/Artifact/Downloader/Type/GitHubTokenSetupTrait.php
@@ -16,8 +16,9 @@ trait GitHubTokenSetupTrait
         // GITHUB_TOKEN support
         if (($token = getenv('GITHUB_TOKEN')) !== false && ($user = getenv('GITHUB_USER')) !== false) {
             logger()->debug("Using 'GITHUB_TOKEN' with user {$user} for authentication");
-            spc_add_log_filter([$user, $token]);
-            return ['Authorization: Basic ' . base64_encode("{$user}:{$token}")];
+            $encoded = base64_encode("{$user}:{$token}");
+            spc_add_log_filter([$user, $token, $encoded]);
+            return ["Authorization: Basic {$encoded}"];
         }
         if (($token = getenv('GITHUB_TOKEN')) !== false) {
             logger()->debug("Using 'GITHUB_TOKEN' for authentication");

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -33,6 +33,23 @@ ConsoleLogger::$date_format = 'H:i:s';
 ConsoleLogger::$format = '[%date% %level_long%] %body%';
 $ob_logger = new ConsoleLogger(LogLevel::WARNING);
 
+$ob_logger->addLogCallback(function ($level, &$output, &$message, &$context, bool $shouldLog) {
+    global $spc_log_filters;
+    if (!is_array($spc_log_filters)) {
+        $spc_log_filters = [];
+    }
+    // filter message and context
+    $output = str_replace($spc_log_filters, '***', $output);
+    $message = str_replace($spc_log_filters, '***', $message);
+    $context = array_map(function ($item) use ($spc_log_filters) {
+        if (is_string($item)) {
+            return str_replace($spc_log_filters, '***', $item);
+        }
+        return $item;
+    }, $context);
+    return true;
+});
+
 // setup log file
 if (filter_var(getenv('SPC_ENABLE_LOG_FILE'), FILTER_VALIDATE_BOOLEAN)) {
     // init spc log files

--- a/tests/GlobalsFunctionsTest.php
+++ b/tests/GlobalsFunctionsTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LogLevel;
+use ZM\Logger\ConsoleLogger;
+
+/**
+ * @internal
+ */
+class GlobalsFunctionsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['spc_log_filters'] = null;
+    }
+
+    protected function tearDown(): void
+    {
+        $GLOBALS['spc_log_filters'] = null;
+    }
+
+    public function testAddLogFilterDeduplicates(): void
+    {
+        spc_add_log_filter('secret-value');
+        spc_add_log_filter('secret-value');
+        spc_add_log_filter(['secret-value', 'other']);
+
+        $this->assertSame(['secret-value', 'other'], $GLOBALS['spc_log_filters']);
+    }
+
+    public function testWriteLogMasksRegisteredValues(): void
+    {
+        spc_add_log_filter(['octocat', 'ghp_abcdef1234567890']);
+
+        $stream = fopen('php://memory', 'r+');
+        spc_write_log($stream, 'user=octocat token=ghp_abcdef1234567890');
+        rewind($stream);
+        $written = stream_get_contents($stream);
+        fclose($stream);
+
+        $this->assertSame('user=*** token=***', $written);
+    }
+
+    public function testLoggerCallbackMasksOutput(): void
+    {
+        $token = 'ghp_abcdef1234567890';
+        spc_add_log_filter($token);
+
+        $stream = fopen('php://memory', 'r+');
+        $logger = new ConsoleLogger(LogLevel::DEBUG, $stream, false);
+        $logger->addLogCallback(function ($level, &$output, &$message, &$context, bool $shouldLog) {
+            global $spc_log_filters;
+            if (!is_array($spc_log_filters)) {
+                $spc_log_filters = [];
+            }
+            $output = str_replace($spc_log_filters, '***', $output);
+            $message = str_replace($spc_log_filters, '***', $message);
+            $context = array_map(function ($item) use ($spc_log_filters) {
+                if (is_string($item)) {
+                    return str_replace($spc_log_filters, '***', $item);
+                }
+                return $item;
+            }, $context);
+            return true;
+        });
+
+        $logger->debug("[PASSTHRU] curl -H\"Authorization: Bearer {$token}\" https://api.github.com/x");
+
+        rewind($stream);
+        $written = stream_get_contents($stream);
+        fclose($stream);
+
+        $this->assertStringNotContainsString($token, $written);
+        $this->assertStringContainsString('***', $written);
+    }
+
+    public function testGitHubTokenTraitRegistersEncodedBasicAuthBlob(): void
+    {
+        $user = 'octocat';
+        $token = 'ghp_abcdef1234567890';
+        $original_token = getenv('GITHUB_TOKEN');
+        $original_user = getenv('GITHUB_USER');
+
+        putenv("GITHUB_TOKEN={$token}");
+        putenv("GITHUB_USER={$user}");
+
+        try {
+            $headers = \StaticPHP\Artifact\Downloader\Type\GitHubRelease::getGitHubTokenHeadersStatic();
+
+            $encoded = base64_encode("{$user}:{$token}");
+            $this->assertSame(["Authorization: Basic {$encoded}"], $headers);
+            $this->assertContains($user, $GLOBALS['spc_log_filters']);
+            $this->assertContains($token, $GLOBALS['spc_log_filters']);
+            $this->assertContains($encoded, $GLOBALS['spc_log_filters']);
+        } finally {
+            $original_token === false ? putenv('GITHUB_TOKEN') : putenv("GITHUB_TOKEN={$original_token}");
+            $original_user === false ? putenv('GITHUB_USER') : putenv("GITHUB_USER={$original_user}");
+        }
+    }
+}


### PR DESCRIPTION
if you run a build locally with --debug=true and an env var for GITHUB_USER and GITHUB_TOKEN you'll get some passthru logs which include the bearer token for curl requests to github calls. this was caught with local builds as i have those envvars set for quick gh cli usage and claude noticed the token was getting leaked into /log/spc.output.log

now this was with v2 and v3 tried to add a [log filter](https://github.com/crazywhalecc/static-php-cli/blob/v3/src/StaticPHP/Artifact/Downloader/Type/GitHubTokenSetupTrait.php#L19) but overlooked adding the encoded username:token (which is the actual contents of the bearer token) to the filters and sending the passthru logs through the filter and this PR remedies that.

i sent claude through your action logs and it found no leaks so it looks like your tokens havent leaked but you probably need to double check just to be safe. note that this would have leaked through the gha scrubbers as it would have only known to scrub GITHUB_USER and GITHUB_TOKEN and not the b64(user:token).

closes #1144