### PR TITLE
fix windows test failures: path separators and arch normalization

### DIFF
--- a/src/StaticPHP/Artifact/Artifact.php
+++ b/src/StaticPHP/Artifact/Artifact.php
@@ -327,7 +327,7 @@ class Artifact
     public function getSourceRoot(): string
     {
         if (isset($this->config['metadata']['source-root'])) {
-            return $this->getSourceDir() . '/' . ltrim($this->config['metadata']['source-root'], '/');
+            return FileSystem::convertPath($this->getSourceDir() . '/' . ltrim($this->config['metadata']['source-root'], '/'));
         }
         return $this->getSourceDir();
     }

--- a/src/StaticPHP/Artifact/ArtifactCache.php
+++ b/src/StaticPHP/Artifact/ArtifactCache.php
@@ -223,8 +223,8 @@ class ArtifactCache
     public function getCacheFullPath(array $cache_info): string
     {
         return match ($cache_info['cache_type']) {
-            'archive', 'file' => DOWNLOAD_PATH . '/' . $cache_info['filename'],
-            'git' => DOWNLOAD_PATH . '/' . $cache_info['dirname'],
+            'archive', 'file' => FileSystem::convertPath(DOWNLOAD_PATH . '/' . $cache_info['filename']),
+            'git' => FileSystem::convertPath(DOWNLOAD_PATH . '/' . $cache_info['dirname']),
             'local' => $cache_info['dirname'], // local dirname is absolute path
             default => throw new SPCInternalException("Unknown cache type: {$cache_info['cache_type']}"),
         };

--- a/tests/StaticPHP/Artifact/ArtifactTest.php
+++ b/tests/StaticPHP/Artifact/ArtifactTest.php
@@ -254,11 +254,16 @@ class ArtifactTest extends TestCase
         ApplicationContext::initialize();
         ApplicationContext::set(ArtifactCache::class, $cache);
 
+        // Use a platform-appropriate absolute path: a Unix-style /tmp/... isn't
+        // absolute on Windows (no drive letter), so the test would otherwise
+        // fall through into the SOURCE_PATH-prefixed branch on Windows.
+        $extract = DIRECTORY_SEPARATOR === '\\' ? 'C:\tmp\my-pkg-extract' : '/tmp/my-pkg-extract';
+
         $artifact = new Artifact('my-pkg', [
-            'source' => ['type' => 'url', 'url' => 'https://example.com/file.tar.gz', 'extract' => '/tmp/my-pkg-extract'],
+            'source' => ['type' => 'url', 'url' => 'https://example.com/file.tar.gz', 'extract' => $extract],
         ]);
 
-        $expected = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, '/tmp/my-pkg-extract');
+        $expected = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $extract);
         $this->assertSame($expected, $artifact->getSourceDir());
     }
 
@@ -703,11 +708,7 @@ class ArtifactTest extends TestCase
             'Windows' => 'windows',
             default => 'linux',
         };
-        $arch = php_uname('m');
-        if ($arch === 'arm64') {
-            $arch = 'aarch64';
-        }
-        return "{$os}-{$arch}";
+        return "{$os}-" . arch2gnu(php_uname('m'));
     }
 
     private function injectArtifactConfig(string $name, array $config): void


### PR DESCRIPTION
## What does this PR do?
Running phpunit on Windows surfaces 12 problems (3 errors + 9 failures) that all pass on Linux CI. Reproducer: `runtime\php.exe vendor\phpunit\phpunit\phpunit tests\ --no-coverage`

Before the changes: `Tests: 399, Assertions: 601, Errors: 3, Failures: 9, Warnings: 7, Deprecations: 4.`

Three buckets of failures, all in `tests/StaticPHP/Artifact/`:

  - `Invalid platform architecture 'AMD64'` errors `php_uname('m')` returns uppercase `AMD64` on Windows, and the test helper `getCurrentPlatform()` only normalized macOS's `arm64`. Affected: `testHasPlatformBinaryReturnsTrueWithCustomCallback`, `testSetAndGetCustomBinaryCallback`, `testSetAndGetCustomBinaryCheckUpdateCallback`, plus four
  downstream test failures that depend on the same helper (`testHasPlatformBinaryReturnsTrueWhenConfigHasBinaryForCurrentPlatform`,
  `testSetAndGetBinaryExtractCallbackForCurrentPlatform`, `testGetBinaryExtractCallbackReturnsNullForNonMatchingPlatform`,
  `testShouldUseBinaryReturnsTrueWhenDownloadedAndHasBinaryConfig`).
  - Mixed path separator — `ArtifactCache::getCacheFullPath()` produced `\...\downloads/file.ext` instead of `\...\downloads\file.ext`. Same shape in `Artifact::getSourceRoot()`. Affected: `testGetCacheFullPathForArchiveType`, `testGetCacheFullPathForGitType`, `testGetCacheFullPathForFileType`, `testGetSourceRootUsesMetadataSourceRoot`.
  - `testGetSourceDirWithAbsoluteExtractInConfig` — used a Unix-style `/tmp/...` as "absolute," but on Windows that has no drive letter so `isRelativePath()` returns true and the test landed in the wrong code branch.

After these changes we wrap path concatenations in the existing `FileSystem::convertPath()`, and the test helper uses the existing `arch2gnu()` (which already lowercases input and maps `amd64`/`x64`/`x86_64` -> `x86_64`) instead of the hand-rolled partial fixup. Linux/macOS behavior is unchanged because the separator wraps are no-ops where slashes already match, the test's arch helper is now using what the rest of the codebase already uses everywhere, and the absolute-path test now picks a Windows-realistic absolute path on Windows only.

After the changes: `Tests: 399, Assertions: 604, Failures: 0, Warnings: 7, Deprecations: 4.`