### PR TITLE
[v3] fix(windows): static builds vswhere.exe -product *

### DIFF
--- a/src/StaticPHP/Util/System/WindowsUtil.php
+++ b/src/StaticPHP/Util/System/WindowsUtil.php
@@ -54,6 +54,7 @@ class WindowsUtil
         }
         $args = [
             '-latest',
+            '-products', '*',
             '-format', 'json',
             '-requires', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
         ];


### PR DESCRIPTION
visual studio has [headless buildtools](https://learn.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio?view=visualstudio) which is typically used in build pipelines, for some reason vswhere.exe only knows to look for Enterprise/Professional/Community unless you specify with the parameter `-product *`. This allows it to use any VS product to which there is only one other one... buildtools. this is kind of a dumb problem but here we are. this was tested and for sure works, I was building with buildtools in v2 with no issues so in v3 switching to vswhere.exe is where this bug snuck in.