### PR TITLE
[v3] fix(macos): static build remove -fno-plt from macOS CFLAGS

### DIFF
--- a/config/env.ini
+++ b/config/env.ini
@@ -142,7 +142,7 @@ CXX=${SPC_DEFAULT_CXX}
 AR=${SPC_DEFAULT_AR}
 LD=${SPC_DEFAULT_LD}
 ; default compiler flags, used in CMake toolchain file, openssl and pkg-config build
-SPC_DEFAULT_CFLAGS="--target=${MAC_ARCH}-apple-darwin -O3 -fno-plt -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -ffunction-sections -fdata-sections"
+SPC_DEFAULT_CFLAGS="--target=${MAC_ARCH}-apple-darwin -O3 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -ffunction-sections -fdata-sections"
 SPC_DEFAULT_CXXFLAGS="${SPC_DEFAULT_CFLAGS}"
 SPC_DEFAULT_LDFLAGS="-Wl,-dead_strip"
 ; phpmicro patches, for more info, see: https://github.com/easysoft/phpmicro/tree/master/patches


### PR DESCRIPTION
-fno-plt is an ELF-only flag that has no effect on macOS Mach-O targets, clang emits "argument unused" when it encounters it. Libraries like xz that run -Werror sanity checks during configure promote that warning to a fatal error, breaking the build. Can only find this issue if you static build with an extension that uses xz e.g. libxml2, libzip, libtiff, imagemagick
