### PR TITLE
[v3] fix: use ftpmirror.gnu.org instead of ftp.gnu.org

### DIFF
--- a/config/artifact/ncurses.yml
+++ b/config/artifact/ncurses.yml
@@ -4,5 +4,5 @@ ncurses:
       - COPYING
   source:
     type: filelist
-    url: 'https://ftp.gnu.org/pub/gnu/ncurses/'
+    url: 'https://ftpmirror.gnu.org/gnu/ncurses/'
     regex: '/href="(?<file>ncurses-(?<version>[^"]+)\.tar\.gz)"/'

--- a/config/pkg/lib/gettext.yml
+++ b/config/pkg/lib/gettext.yml
@@ -3,7 +3,7 @@ gettext:
   artifact:
     source:
       type: filelist
-      url: 'https://ftp.gnu.org/pub/gnu/gettext/'
+      url: 'https://ftpmirror.gnu.org/gnu/gettext/'
       regex: '/href="(?<file>gettext-(?<version>[^"]+)\.tar\.xz)"/'
     metadata:
       license-files: [gettext-runtime/intl/COPYING.LIB]

--- a/config/pkg/lib/gmp.yml
+++ b/config/pkg/lib/gmp.yml
@@ -3,7 +3,7 @@ gmp:
   artifact:
     source:
       type: filelist
-      url: 'https://ftp.gnu.org/gnu/gmp/'
+      url: 'https://ftpmirror.gnu.org/gnu/gmp/'
       regex: '/href="(?<file>gmp-(?<version>[^"]+)\.tar\.xz)"/'
     source-mirror:
       type: url

--- a/config/pkg/lib/idn2.yml
+++ b/config/pkg/lib/idn2.yml
@@ -3,7 +3,7 @@ idn2:
   artifact:
     source:
       type: filelist
-      url: 'https://ftp.gnu.org/gnu/libidn/'
+      url: 'https://ftpmirror.gnu.org/gnu/libidn/'
       regex: '/href="(?<file>libidn2-(?<version>[^"]+)\.tar\.gz)"/'
     metadata:
       license-files: [COPYING.LESSERv3]

--- a/config/pkg/lib/libiconv.yml
+++ b/config/pkg/lib/libiconv.yml
@@ -3,7 +3,7 @@ libiconv:
   artifact:
     source:
       type: filelist
-      url: 'https://ftp.gnu.org/gnu/libiconv/'
+      url: 'https://ftpmirror.gnu.org/gnu/libiconv/'
       regex: '/href="(?<file>libiconv-(?<version>[^"]+)\.tar\.gz)"/'
     metadata:
       license-files: [COPYING.LIB]

--- a/config/pkg/lib/libunistring.yml
+++ b/config/pkg/lib/libunistring.yml
@@ -3,7 +3,7 @@ libunistring:
   artifact:
     source:
       type: filelist
-      url: 'https://ftp.gnu.org/gnu/libunistring/'
+      url: 'https://ftpmirror.gnu.org/gnu/libunistring/'
       regex: '/href="(?<file>libunistring-(?<version>[^"]+)\.tar\.gz)"/'
     metadata:
       license-files: [COPYING.LIB]

--- a/config/pkg/lib/readline.yml
+++ b/config/pkg/lib/readline.yml
@@ -3,7 +3,7 @@ readline:
   artifact:
     source:
       type: filelist
-      url: 'https://ftp.gnu.org/pub/gnu/readline/'
+      url: 'https://ftpmirror.gnu.org/gnu/readline/'
       regex: '/href="(?<file>readline-(?<version>[^"]+)\.tar\.gz)"/'
     metadata:
       license-files: [COPYING]


### PR DESCRIPTION
for some reason the ftp was down for me from my home and there's a perfectly fine mirror that worked fine, slight chance you dont want this one but thought i'd offer.