### PR TITLE
[v3] fix: remove no-op ulimit call from ZigToolchain

### DIFF
--- a/src/StaticPHP/Toolchain/ZigToolchain.php
+++ b/src/StaticPHP/Toolchain/ZigToolchain.php
@@ -43,7 +43,6 @@ class ZigToolchain implements UnixToolchainInterface
     public function afterInit(): void
     {
         GlobalEnvManager::addPathIfNotExists($this->getPath());
-        f_passthru('ulimit -n 2048'); // zig opens extra file descriptors, so when a lot of extensions are built statically, 1024 is not enough
         $cflags = getenv('SPC_DEFAULT_CFLAGS') ?: '';
         $cxxflags = getenv('SPC_DEFAULT_CXXFLAGS') ?: '';
         $extraCflags = getenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_CFLAGS') ?: '';


### PR DESCRIPTION
I'm going to make an argument why this ulimit call is unnecessary, if you call this from php you fork into a new shell and call ulimit there and immediately exit losing the change. The real fix is to call ulimit from the shell before you call spc build or do some pcntl_setrlimit from inside the running php process.

In addition ulimit will silently fail if the value it is trying to set is smaller than the current value, you are probably getting along just fine in your environments not noticing that this is actually failing. I'm running this in a container that was defaulted to 1024 and this call exit with non-zero status code and fails the build.

I think this call should be removed mostly because it does nothing but onus should be placed on the spc build callee and you should let spc build fail with too many open files errors on it's own rather than try to elevate and change rconfigs, those are easily diagnosed problems by sysadmins who can decide the level of elevated access. For instance, my build server can pass in higher rates to the pods so I update my config and move on.