### PR TITLE
mongodb: export PHP_VERSION_ID for in-tree builds

### DIFF
--- a/src/Package/Extension/mongodb.php
+++ b/src/Package/Extension/mongodb.php
@@ -16,6 +16,14 @@ use StaticPHP\Util\FileSystem;
 #[Extension('mongodb')]
 class mongodb extends PhpExtensionPackage
 {
+    #[BeforeStage('php', [php::class, 'configureForUnix'], 'ext-mongodb')]
+    #[PatchDescription('Export PHP_VERSION_ID so mongo-php-driver >= 2.3.3 skips its php-config lookup (in-tree builds have no php-config).')]
+    public function exportPhpVersionIdForUnix(): void
+    {
+        $id = php::getPHPVersionID();
+        f_putenv("PHP_VERSION_ID={$id}");
+    }
+
     #[BeforeStage('php', [php::class, 'buildconfForWindows'], 'ext-mongodb')]
     #[PatchDescription('Add /utf-8 flag to CFLAGS_MONGODB for Windows build to fix compilation error on non-English Windows.')]
     public function patchBeforeBuild(): void


### PR DESCRIPTION
mongo-php-driver 2.3.3 added a config.m4 check that falls back to php-config when PHP_VERSION_ID is unset in the shell env. In-tree PHP source builds have no php-config, so configure fails with:

    checking PHP version... configure: error: php-config not found

Set PHP_VERSION_ID from main/php_version.h before configureForUnix so the lookup short-circuits.
