### PR TITLE
deduplicate_flags: keep paired flag+value tokens together

### DIFF
--- a/src/globals/functions.php
+++ b/src/globals/functions.php
@@ -256,10 +256,30 @@ function clean_spaces(string $string): string
  */
 function deduplicate_flags(string $flags): string
 {
-    $tokens = preg_split('/\s+/', trim($flags));
+    // Flags that take their value as a separate token.
+    static $paired = [
+        '-Xclang', '-Xpreprocessor', '-Xlinker', '-Xassembler',
+        '-framework', '-arch', '-target',
+        '-include', '-imacros', '-isystem', '-isysroot', '-iquote', '-idirafter',
+        '-MT', '-MF', '-MQ',
+    ];
+
+    $tokens = preg_split('/\s+/', trim($flags)) ?: [];
+
+    // Group paired flag+value into a single atom before dedup.
+    $atoms = [];
+    $n = count($tokens);
+    for ($i = 0; $i < $n; ++$i) {
+        if (in_array($tokens[$i], $paired, true) && $i + 1 < $n) {
+            $atoms[] = $tokens[$i] . ' ' . $tokens[$i + 1];
+            ++$i;
+        } else {
+            $atoms[] = $tokens[$i];
+        }
+    }
 
     // Reverse, unique, reverse back - keeps last occurrence of duplicates
-    $deduplicated = array_reverse(array_unique(array_reverse($tokens)));
+    $deduplicated = array_reverse(array_unique(array_reverse($atoms)));
 
     return implode(' ', $deduplicated);
 }


### PR DESCRIPTION
deduplicate_flags() split flags on whitespace then ran a per-token unique. For paired flags like `-Xclang -mllvm` or `-framework Cocoa`, where the value is a separate token, the value token could collide with an unrelated flag or value and get dropped, corrupting the command line.

Group known paired flags (-Xclang, -Xpreprocessor, -Xlinker, -Xassembler, -framework, -arch, -target, -include, -imacros, -isystem, -isysroot, -iquote, -idirafter, -MT, -MF, -MQ) with their following token into a single atom before the unique pass.

## What does this PR do?

<!-- Please describe the changes made in this PR here. -->


## Checklist before merging

- If you modified `*.php` or `*.yml`, run them locally to ensure your changes are valid:
  - [ ] `composer cs-fix`
  - [ ] `composer analyse`
  - [ ] `composer test`
  - [ ] `bin/spc dev:lint-config`
