### PR TITLE
LinuxMuslCheck: pass tool env via setEnv instead of command prefixes

### DIFF
--- a/src/StaticPHP/Doctor/Item/LinuxMuslCheck.php
+++ b/src/StaticPHP/Doctor/Item/LinuxMuslCheck.php
@@ -73,13 +73,20 @@ class LinuxMuslCheck
             $prefix = 'sudo ';
             logger()->warning('Current user is not root, using sudo for running command');
         }
+        $sysEnv = ['CC' => 'gcc', 'CXX' => 'g++', 'AR' => 'ar', 'LD' => 'ld', 'RANLIB' => 'ranlib'];
+        $envFlags = '';
+        foreach ($sysEnv as $k => $v) {
+            $envFlags .= "{$k}={$v} ";
+        }
+        $envFlags = rtrim($envFlags);
         $shell = shell()->cd(SOURCE_PATH . '/musl-wrapper')
-            ->exec('CC=gcc CXX=g++ AR=ar LD=ld ./configure --disable-gcc-wrapper')
-            ->exec('CC=gcc CXX=g++ AR=ar LD=ld make -j');
+            ->setEnv($sysEnv)
+            ->exec('./configure --disable-gcc-wrapper')
+            ->exec('make -j');
         if ($prefix !== '') {
-            f_passthru('cd ' . SOURCE_PATH . "/musl-wrapper && CC=gcc CXX=g++ AR=ar LD=ld {$prefix}make install");
+            f_passthru('cd ' . SOURCE_PATH . "/musl-wrapper && {$envFlags} {$prefix}make install");
         } else {
-            $shell->exec("CC=gcc CXX=g++ AR=ar LD=ld {$prefix}make install");
+            $shell->exec("{$prefix}make install");
         }
         return true;
     }


### PR DESCRIPTION
Build the CC/CXX/AR/LD/RANLIB map once and hand it to shell()->setEnv() so the configure/make invocations don't have to repeat the same prefix on every line. For the sudo make-install path the env still needs to be on the command line (sudo strips the parent env), so the same map is rendered into $envFlags and prepended there. Also adds RANLIB, which the upstream Makefile honours.

## What does this PR do?

<!-- Please describe the changes made in this PR here. -->


## Checklist before merging

- If you modified `*.php` or `*.yml`, run them locally to ensure your changes are valid:
  - [ ] `composer cs-fix`
  - [ ] `composer analyse`
  - [ ] `composer test`
  - [ ] `bin/spc dev:lint-config`
