### PR TITLE
PackageBuilder: honour OBJCOPY env and use llvm-strip under ZigToolchain

### DIFF
--- a/src/StaticPHP/DI/ApplicationContext.php
+++ b/src/StaticPHP/DI/ApplicationContext.php
@@ -99,6 +99,25 @@ class ApplicationContext
     }
 
     /**
+     * Resolve $id, returning null if it can't be constructed.
+     * PHP-DI's has() returns true for any autowirable class even when get()
+     * would throw on missing scalar args — for "is this resolvable right now"
+     * semantics use this.
+     *
+     * @template T
+     * @param  class-string<T> $id
+     * @return null|T
+     */
+    public static function tryGet(string $id): mixed
+    {
+        try {
+            return self::getContainer()->get($id);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
      * Set a service in the container.
      * Use sparingly - prefer configuration-based definitions.
      */

--- a/src/StaticPHP/Package/PackageBuilder.php
+++ b/src/StaticPHP/Package/PackageBuilder.php
@@ -11,6 +11,8 @@ use StaticPHP\Exception\SPCInternalException;
 use StaticPHP\Exception\WrongUsageException;
 use StaticPHP\Runtime\Shell\Shell;
 use StaticPHP\Runtime\SystemTarget;
+use StaticPHP\Toolchain\Interface\ToolchainInterface;
+use StaticPHP\Toolchain\ZigToolchain;
 use StaticPHP\Util\FileSystem;
 use StaticPHP\Util\GlobalPathTrait;
 use StaticPHP\Util\InteractiveTerm;
@@ -178,14 +180,15 @@ class PackageBuilder
         if (SystemTarget::getTargetOS() === 'Darwin') {
             shell()->exec("dsymutil -f {$binary_path} -o {$debug_file}");
         } elseif (SystemTarget::getTargetOS() === 'Linux') {
+            $objcopy = getenv('OBJCOPY') ?: 'objcopy';
             if ($eu_strip = LinuxUtil::findCommand('eu-strip')) {
                 shell()
                     ->exec("{$eu_strip} -f {$debug_file} {$binary_path}")
-                    ->exec("objcopy --add-gnu-debuglink={$debug_file} {$binary_path}");
+                    ->exec("{$objcopy} --add-gnu-debuglink={$debug_file} {$binary_path}");
             } else {
                 shell()
-                    ->exec("objcopy --only-keep-debug {$binary_path} {$debug_file}")
-                    ->exec("objcopy --add-gnu-debuglink={$debug_file} {$binary_path}");
+                    ->exec("{$objcopy} --only-keep-debug {$binary_path} {$debug_file}")
+                    ->exec("{$objcopy} --add-gnu-debuglink={$debug_file} {$binary_path}");
             }
         } else {
             logger()->debug('extractDebugInfo is only supported on Linux and macOS');
@@ -199,9 +202,12 @@ class PackageBuilder
      */
     public function stripBinary(string $binary_path): void
     {
+        $strip = ApplicationContext::tryGet(ToolchainInterface::class) instanceof ZigToolchain
+            ? PKG_ROOT_PATH . '/llvm-tools/bin/llvm-strip'
+            : 'strip';
         shell()->exec(match (SystemTarget::getTargetOS()) {
-            'Darwin' => "strip -S {$binary_path}",
-            'Linux' => "strip --strip-unneeded {$binary_path}",
+            'Darwin' => "{$strip} -S {$binary_path}",
+            'Linux' => "{$strip} --strip-unneeded {$binary_path}",
             'Windows' => 'echo "Skip strip on Windows"', // Windows strip is not available for now
             default => throw new SPCInternalException('stripBinary is only supported on Linux and macOS'),
         });


### PR DESCRIPTION
extractDebugInfo() now picks up OBJCOPY from the environment (falling back to plain `objcopy`), so cross builds that ship their own objcopy (e.g. llvm-objcopy via zig) don't have to inject it into PATH or shim the binary name.

stripBinary() asks ApplicationContext for the active toolchain and, when it's ZigToolchain, runs the llvm-strip shipped under PKG_ROOT_PATH/llvm-tools/bin instead of the system strip — system strip doesn't understand zig-produced archives and bitcode sections. Other toolchains keep using plain `strip`.

ApplicationContext::tryGet() wraps get() in a try/catch and returns null on failure, so callers can ask "is this resolvable right now" without PHP-DI's has() lying about autowirable-but-unconstructable classes.

## What does this PR do?

<!-- Please describe the changes made in this PR here. -->


## Checklist before merging

- If you modified `*.php` or `*.yml`, run them locally to ensure your changes are valid:
  - [ ] `composer cs-fix`
  - [ ] `composer analyse`
  - [ ] `composer test`
  - [ ] `bin/spc dev:lint-config`
