### PR TITLE
[v3] - fix(windows): define LEXBOR_STATIC for PHP 8.5+ static builds

### DIFF
--- a/src/Package/Target/php/windows.php
+++ b/src/Package/Target/php/windows.php
@@ -226,6 +226,21 @@ trait windows
         $this->deployWindowsBinary($builder, $package, 'php-cgi');
     }
 
+    #[BeforeStage('php', [self::class, 'makeForWindows'])]
+    #[PatchDescription('Define LEXBOR_STATIC for static builds (PHP 8.5+ uri extension)')]
+    public function patchLexborStaticDefine(TargetPackage $package): void
+    {
+        if ($this->getPHPVersionID() < 80500) {
+            return;
+        }
+        $makefile_path = "{$package->getSourceDir()}\\Makefile";
+        $content = FileSystem::readFile($makefile_path);
+        // ext/uri references lexbor headers which default to __declspec(dllimport) on Windows.
+        // LEXBOR_STATIC makes LXB_API expand to nothing, required for static linking.
+        $content = preg_replace('/^CFLAGS_URI=(.+)$/m', 'CFLAGS_URI=$1 /D LEXBOR_STATIC', $content, 1);
+        FileSystem::writeFile($makefile_path, $content);
+    }
+
     #[Stage]
     public function makeForWindows(TargetPackage $package, PackageInstaller $installer): void
     {


### PR DESCRIPTION
The ext/uri extension introduced in PHP 8.5 vendors lexbor headers. On Windows, lexbor's LXB_API macro defaults to __declspec(dllimport), which breaks static linking with unresolved external symbols for all lxb_* functions.

Adding a BeforeStage patch that injects /D LEXBOR_STATIC into CFLAGS_URI makes LXB_API expand to nothing, allowing the uri extension to link into the static PHP build.

Only applies to PHP >= 8.5.0 where ext/uri exists.