### PR TITLE
[v3] - feat(windows): static embed SAPI build support

### DIFF
--- a/src/Package/Target/php/windows.php
+++ b/src/Package/Target/php/windows.php
@@ -317,6 +317,25 @@ trait windows
             $content
         );
 
+        // Embed SAPI objects are compiled as DLL consumers (dllimport for PHP/Zend APIs).
+        // For our fat static lib, they need direct linkage. Add export defines to CFLAGS_EMBED
+        // so php_embed.obj references symbols directly instead of through __imp_ thunks.
+        $content = preg_replace(
+            '/^CFLAGS_EMBED=(.+)$/m',
+            'CFLAGS_EMBED=$1 /D PHP_EXPORTS /D LIBZEND_EXPORTS /D SAPI_EXPORTS /D TSRM_EXPORTS',
+            $content,
+            1
+        );
+
+        // In DLL builds each SAPI has its own _tsrm_ls_cache via TSRMLS_CACHE_DEFINE().
+        // In our fat static lib all objects share one binary, so the duplicate TLS definition
+        // from php_embed.c collides with the one in zend.c, producing LNK4006 and a corrupt
+        // binary. Remove it so php_embed.obj uses the core's copy.
+        $embed_src = "{$package->getSourceDir()}\\sapi\\embed\\php_embed.c";
+        if (file_exists($embed_src)) {
+            FileSystem::replaceFileStr($embed_src, 'ZEND_TSRMLS_CACHE_DEFINE()', '/* removed for static embed */');
+        }
+
         // Patch embed lib target to build a REAL static library instead of just an import lib.
         // The default embed target only includes embed SAPI objects and links against php8.lib (import lib).
         // We need to include PHP core objects (PHP_GLOBAL_OBJS) and static extension objects (STATIC_EXT_OBJS)
@@ -646,16 +665,17 @@ HEADER;
 #include <sapi/embed/php_embed.h>
 
 int main(int argc, char **argv) {
-    PHP_EMBED_START_BLOCK(argc, argv)
-
-    zend_file_handle file_handle;
-    zend_stream_init_filename(&file_handle, "embed.php");
-
-    if (!php_execute_script(&file_handle)) {
-        php_printf("Failed to execute PHP script.\n");
+    if (php_embed_init(argc, argv) == FAILURE) {
+        return 1;
     }
 
-    PHP_EMBED_END_BLOCK()
+    zend_first_try {
+        zend_file_handle file_handle;
+        zend_stream_init_filename(&file_handle, "embed.php");
+        php_execute_script(&file_handle);
+    } zend_end_try();
+
+    php_embed_shutdown();
     return 0;
 }
 C_CODE;
@@ -683,7 +703,8 @@ C_CODE;
         $zts_define = $ts ? ' /D ZTS=1' : '';
         $include_flags = sprintf(
             '/I"%s" /I"%s\main" /I"%s\Zend" /I"%s\TSRM" /I"%s" ' .
-            '/D ZEND_WIN32=1 /D PHP_WIN32=1 /D WIN32 /D _WINDOWS /D WINDOWS=1 /D _MBCS /D _USE_MATH_DEFINES%s',
+            '/D ZEND_WIN32=1 /D PHP_WIN32=1 /D WIN32 /D _WINDOWS /D WINDOWS=1 /D _MBCS /D _USE_MATH_DEFINES' .
+            ' /D PHP_EXPORTS /D LIBZEND_EXPORTS /D SAPI_EXPORTS /D TSRM_EXPORTS%s',
             $build_dir,
             $source_dir,
             $source_dir,
@@ -692,15 +713,14 @@ C_CODE;
             $zts_define
         );
 
-        // MSVC cl.exe format: compiler flags must come before /link, linker flags after
-        // ldflags contains /LIBPATH which must be after /link
-        // /FORCE:MULTIPLE: in ZTS mode both zend.obj and php_embed.obj (both packed into the fat php8embed.lib) define _tsrm_ls_cache as a __declspec(thread) variable.
+        // MSVC cl.exe format: compiler flags must come before /link, linker flags after.
+        // ldflags contains /LIBPATH which must be after /link.
         $compile_cmd = sprintf(
-            'cl.exe /nologo /O2 /MT /Z7 %s embed.c /Fe:embed.exe /link /FORCE:MULTIPLE /LIBPATH:"%s\lib" %s %s',
+            'cl.exe /nologo /O2 /MT /Z7 %s embed.c /Fe:embed.exe /link /LIBPATH:"%s\lib" %s %s',
             $include_flags,
             BUILD_ROOT_PATH,
             $config['libs'],
-            'kernel32.lib ole32.lib user32.lib advapi32.lib shell32.lib ws2_32.lib dnsapi.lib psapi.lib bcrypt.lib'  // Windows system libs (match Makefile LIBS)
+            'kernel32.lib ole32.lib user32.lib advapi32.lib shell32.lib ws2_32.lib dnsapi.lib psapi.lib bcrypt.lib pathcch.lib'
         );
 
         // Log command explicitly (workaround for cmd() not logging complex commands properly)
@@ -718,9 +738,9 @@ C_CODE;
         InteractiveTerm::setMessage('Running php-embed run smoke test');
         [$ret, $output] = cmd()->cd($test_dir)->execWithResult('embed.exe');
         $raw_output = implode('', $output);
-        if ($ret !== 0 || trim($raw_output) !== 'hello') {
+        if ($ret !== 0 || !str_contains($raw_output, 'hello')) {
             throw new ValidationException(
-                'embed failed to run. Error message: ' . $raw_output,
+                sprintf('embed failed to run (exit code %d). Output: %s', $ret, $raw_output),
                 validation_module: 'php-embed run smoke test'
             );
         }


### PR DESCRIPTION
From the beginning I couldn't really get windows static builds to work in v3 as you can probably tell by my 4 PRs tonight, if for some reason these changes are not welcome because I'm missing something that already works in v3 please let me know. 

---

Enable building and validating php8embed as a fat static library on Windows (no DLL dependency at runtime). This consists of three Makefile patches and a rewritten compile-time smoke test.

1. CFLAGS_EMBED export defines

   Embed SAPI objects are compiled as DLL consumers by default, so calls into PHP/Zend APIs go through __imp_ thunks. For a fat static lib they need direct linkage. Inject PHP_EXPORTS, LIBZEND_EXPORTS, SAPI_EXPORTS, TSRM_EXPORTS into CFLAGS_EMBED so php_embed.obj references symbols directly.

2. Strip duplicate TSRM cache definition from php_embed.c

   In DLL builds each SAPI has its own _tsrm_ls_cache via TSRMLS_CACHE_DEFINE(). In our fat static lib all objects share one binary, so php_embed.c's definition collides with zend.c's, producing LNK4006 and a corrupt binary. Remove the duplicate in-source so php_embed.obj uses zend.c's copy.

3. Rewrite embed smoke test

   The PHP_EMBED_START_BLOCK/END_BLOCK macros expand to setjmp/longjmp and a zend_first_try wrapper that doesn't work cleanly when the embed lib's TSRM cache was stripped above. Use the explicit php_embed_init / zend_first_try / php_embed_shutdown form instead.

   Also:
   - Add PHP_EXPORTS/LIBZEND_EXPORTS/SAPI_EXPORTS/TSRM_EXPORTS to the test compile flags (mirroring CFLAGS_EMBED).
   - Add pathcch.lib (PHP 8.x main/streams calls PathCchCanonicalizeEx).
   - Remove /FORCE:MULTIPLE from the link line - no longer needed since the TSRM cache duplicate is fixed at source above.
   - Use str_contains() for output validation instead of exact match, so optional stderr noise from the loaded extensions doesn't break the test.

