### PR TITLE
Add macports support

### DIFF
--- a/src/Package/Library/unixodbc.php
+++ b/src/Package/Library/unixodbc.php
@@ -20,8 +20,8 @@ class unixodbc extends LibraryPackage
     {
         $sysconf_selector = match ($os = SystemTarget::getTargetOS()) {
             'Darwin' => match (SystemTarget::getTargetArch()) {
-                'x86_64' => '/usr/local/etc',
-                'aarch64' => '/opt/homebrew/etc',
+                'x86_64' => is_dir('/usr/local/etc') ? '/usr/local/etc' : '/opt/local/etc',
+                'aarch64' => is_dir('/opt/homebrew/etc') ? '/opt/homebrew/etc' : '/opt/local/etc',
                 default => throw new WrongUsageException('Unsupported architecture: ' . GNU_ARCH),
             },
             'Linux' => '/etc',

--- a/src/StaticPHP/Doctor/Item/MacOSToolCheck.php
+++ b/src/StaticPHP/Doctor/Item/MacOSToolCheck.php
@@ -45,6 +45,18 @@ class MacOSToolCheck
         return CheckResult::ok();
     }
 
+    #[CheckItem('if macports has installed', limit_os: 'Darwin', level: 998)]
+    public function checkPorts(): ?CheckResult
+    {
+        if (($path = MacOSUtil::findCommand('port')) === null) {
+            return CheckResult::fail('MacPorts is not installed', 'port');
+        }
+        if ($path !== '/opt/local/bin/port' && getenv('GNU_ARCH') === 'aarch64') {
+            return CheckResult::fail('Current macports (/opt/local/bin/port) is not installed for M1 Mac, please re-install macports!');
+        }
+        return CheckResult::ok();
+    }
+
     #[CheckItem('if necessary tools are installed', limit_os: 'Darwin')]
     public function checkCliTools(): ?CheckResult
     {
@@ -74,6 +86,20 @@ class MacOSToolCheck
         return null;
     }
 
+    #[CheckItem('if macports llvm are installed', limit_os: 'Darwin')]
+    public function checkPortsLLVM(): ?CheckResult
+    {
+        if (getenv('SPC_USE_LLVM') === 'port') {
+            $macports_prefix = getenv('MACPORTS_PREFIX') ?: '/opt/local';
+
+            if (($path = MacOSUtil::findCommand('clang', ["{$macports_prefix}/bin"])) === null) {
+                return CheckResult::fail('MacPorts llvm is not installed', 'build-tools', ['missing' => ['llvm']]);
+            }
+            return CheckResult::ok($path);
+        }
+        return null;
+    }
+
     #[CheckItem('if bison version is 3.0 or later', limit_os: 'Darwin')]
     public function checkBisonVersion(array $command_path = []): ?CheckResult
     {
@@ -91,7 +117,7 @@ class MacOSToolCheck
                 if ($command_path !== []) {
                     return CheckResult::fail("Current {$bison} version is too old: " . $matches[0]);
                 }
-                return $this->checkBisonVersion(['/opt/homebrew/opt/bison/bin', '/usr/local/opt/bison/bin']);
+                return $this->checkBisonVersion(['/opt/homebrew/opt/bison/bin', '/usr/local/opt/bison/bin', '/opt/local/bin']);
             }
             return CheckResult::ok($matches[0]);
         }
@@ -108,6 +134,9 @@ class MacOSToolCheck
     #[FixItem('build-tools')]
     public function fixBuildTools(array $missing): bool
     {
+        $hasBrew = $this->checkBrew()?->isOK();
+        $hasMacports = $this->checkPorts()?->isOK();
+
         $replacement = [
             'glibtoolize' => 'libtool',
         ];
@@ -115,7 +144,18 @@ class MacOSToolCheck
             if (isset($replacement[$cmd])) {
                 $cmd = $replacement[$cmd];
             }
-            shell()->exec('brew install --formula ' . escapeshellarg($cmd));
+
+            if ($hasBrew) {
+                shell()->exec('brew install --formula ' . escapeshellarg($cmd));
+                continue;
+            }
+
+            if ($hasMacports) {
+                shell()->exec('port install ' . escapeshellarg($cmd));
+                continue;
+            }
+
+            return false;
         }
         return true;
     }

--- a/src/StaticPHP/Doctor/Item/MacOSToolCheck.php
+++ b/src/StaticPHP/Doctor/Item/MacOSToolCheck.php
@@ -48,11 +48,8 @@ class MacOSToolCheck
     #[CheckItem('if macports has installed', limit_os: 'Darwin', level: 998)]
     public function checkPorts(): ?CheckResult
     {
-        if (($path = MacOSUtil::findCommand('port')) === null) {
+        if (MacOSUtil::findCommand('port') === null) {
             return CheckResult::fail('MacPorts is not installed', 'port');
-        }
-        if ($path !== '/opt/local/bin/port' && getenv('GNU_ARCH') === 'aarch64') {
-            return CheckResult::fail('Current macports (/opt/local/bin/port) is not installed for M1 Mac, please re-install macports!');
         }
         return CheckResult::ok();
     }
@@ -127,6 +124,11 @@ class MacOSToolCheck
     #[FixItem('brew')]
     public function fixBrew(): bool
     {
+        $hasMacports = $this->checkPorts();
+        if ($hasMacports->isOK()) {
+            return true; // Nothing to fix - will use macports instead
+        }
+
         shell(true)->exec('/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"');
         return true;
     }

--- a/src/StaticPHP/Doctor/Item/MacOSToolCheck.php
+++ b/src/StaticPHP/Doctor/Item/MacOSToolCheck.php
@@ -33,24 +33,20 @@ class MacOSToolCheck
         'glibtoolize',
     ];
 
-    #[CheckItem('if homebrew has installed', limit_os: 'Darwin', level: 998)]
-    public function checkBrew(): ?CheckResult
+    #[CheckItem('if homebrew or macports has installed', limit_os: 'Darwin', level: 998)]
+    public function checkBrewOrPorts(): ?CheckResult
     {
-        if (($path = MacOSUtil::findCommand('brew')) === null) {
-            return CheckResult::fail('Homebrew is not installed', 'brew');
-        }
-        if ($path !== '/opt/homebrew/bin/brew' && getenv('GNU_ARCH') === 'aarch64') {
+        $brewPath = MacOSUtil::findCommand('brew');
+        $portPath = MacOSUtil::findCommand('port');
+
+        if ($brewPath && $brewPath !== '/opt/homebrew/bin/brew' && getenv('GNU_ARCH') === 'aarch64') {
             return CheckResult::fail('Current homebrew (/usr/local/bin/homebrew) is not installed for M1 Mac, please re-install homebrew in /opt/homebrew/ !');
         }
-        return CheckResult::ok();
-    }
 
-    #[CheckItem('if macports has installed', limit_os: 'Darwin', level: 998)]
-    public function checkPorts(): ?CheckResult
-    {
-        if (MacOSUtil::findCommand('port') === null) {
-            return CheckResult::fail('MacPorts is not installed', 'port');
+        if ($brewPath === null && $portPath === null) {
+            return CheckResult::fail('Homebrew is not installed', 'brew');
         }
+
         return CheckResult::ok();
     }
 
@@ -69,8 +65,8 @@ class MacOSToolCheck
         return CheckResult::ok();
     }
 
-    #[CheckItem('if homebrew llvm are installed', limit_os: 'Darwin')]
-    public function checkBrewLLVM(): ?CheckResult
+    #[CheckItem('if homebrew or macports llvm are installed', limit_os: 'Darwin')]
+    public function checkBrewOrPortsLLVM(): ?CheckResult
     {
         if (getenv('SPC_USE_LLVM') === 'brew') {
             $homebrew_prefix = getenv('HOMEBREW_PREFIX') ?: (SystemTarget::getTargetArch() === 'aarch64' ? '/opt/homebrew' : '/usr/local/homebrew');
@@ -80,20 +76,16 @@ class MacOSToolCheck
             }
             return CheckResult::ok($path);
         }
-        return null;
-    }
 
-    #[CheckItem('if macports llvm are installed', limit_os: 'Darwin')]
-    public function checkPortsLLVM(): ?CheckResult
-    {
         if (getenv('SPC_USE_LLVM') === 'port') {
-            $macports_prefix = getenv('MACPORTS_PREFIX') ?: '/opt/local';
+            $macportsPrefix = '/opt/local';
 
-            if (($path = MacOSUtil::findCommand('clang', ["{$macports_prefix}/bin"])) === null) {
+            if (($path = MacOSUtil::findCommand('clang', ["{$macportsPrefix}/bin"])) === null) {
                 return CheckResult::fail('MacPorts llvm is not installed', 'build-tools', ['missing' => ['llvm']]);
             }
             return CheckResult::ok($path);
         }
+
         return null;
     }
 
@@ -124,11 +116,6 @@ class MacOSToolCheck
     #[FixItem('brew')]
     public function fixBrew(): bool
     {
-        $hasMacports = $this->checkPorts();
-        if ($hasMacports->isOK()) {
-            return true; // Nothing to fix - will use macports instead
-        }
-
         shell(true)->exec('/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"');
         return true;
     }
@@ -136,8 +123,8 @@ class MacOSToolCheck
     #[FixItem('build-tools')]
     public function fixBuildTools(array $missing): bool
     {
-        $hasBrew = $this->checkBrew()?->isOK();
-        $hasMacports = $this->checkPorts()?->isOK();
+        $brewPath = MacOSUtil::findCommand('brew');
+        $portPath = MacOSUtil::findCommand('port');
 
         $replacement = [
             'glibtoolize' => 'libtool',
@@ -147,12 +134,12 @@ class MacOSToolCheck
                 $cmd = $replacement[$cmd];
             }
 
-            if ($hasBrew) {
+            if ($brewPath !== null) {
                 shell()->exec('brew install --formula ' . escapeshellarg($cmd));
                 continue;
             }
 
-            if ($hasMacports) {
+            if ($portPath !== null) {
                 shell()->exec('port install ' . escapeshellarg($cmd));
                 continue;
             }

--- a/src/StaticPHP/Toolchain/ClangPortsToolchain.php
+++ b/src/StaticPHP/Toolchain/ClangPortsToolchain.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StaticPHP\Toolchain;
+
+use StaticPHP\Util\GlobalEnvManager;
+
+class ClangPortsToolchain extends ClangNativeToolchain
+{
+    public function initEnv(): void
+    {
+        $macports_prefix = getenv('MACPORTS_PREFIX') ?: '/opt/local';
+        GlobalEnvManager::putenv("SPC_DEFAULT_CC={$macports_prefix}/bin/clang");
+        GlobalEnvManager::putenv("SPC_DEFAULT_CXX={$macports_prefix}/bin/clang++");
+        GlobalEnvManager::putenv("SPC_DEFAULT_AR={$macports_prefix}/bin/llvm-ar");
+        GlobalEnvManager::putenv('SPC_DEFAULT_LD=ld');
+        GlobalEnvManager::addPathIfNotExists("{$macports_prefix}/bin");
+    }
+}

--- a/src/StaticPHP/Toolchain/ToolchainManager.php
+++ b/src/StaticPHP/Toolchain/ToolchainManager.php
@@ -41,6 +41,7 @@ class ToolchainManager
             'Windows' => MSVCToolchain::class,
             'Darwin' => match (getenv('SPC_USE_LLVM') ?: 'system') {
                 'brew' => ClangBrewToolchain::class,
+                'port' => ClangPortsToolchain::class,
                 default => ClangNativeToolchain::class,
             },
             default => throw new WrongUsageException('Unsupported OS family: ' . PHP_OS_FAMILY),

--- a/src/StaticPHP/Util/GlobalEnvManager.php
+++ b/src/StaticPHP/Util/GlobalEnvManager.php
@@ -134,10 +134,10 @@ class GlobalEnvManager
         }
         // test bison
         if (PHP_OS_FAMILY === 'Darwin') {
-            if ($bison = MacOSUtil::findCommand('bison', ['/opt/homebrew/opt/bison/bin', '/usr/local/opt/bison/bin'])) {
+            if ($bison = MacOSUtil::findCommand('bison', ['/opt/homebrew/opt/bison/bin', '/usr/local/opt/bison/bin', '/opt/local/bin/bison'])) {
                 self::putenv("BISON={$bison}");
             }
-            if ($yacc = MacOSUtil::findCommand('yacc', ['/opt/homebrew/opt/bison/bin', '/usr/local/opt/bison/bin'])) {
+            if ($yacc = MacOSUtil::findCommand('yacc', ['/opt/homebrew/opt/bison/bin', '/usr/local/opt/bison/bin', '/opt/local/bin/yacc'])) {
                 self::putenv("YACC={$yacc}");
             }
         }


### PR DESCRIPTION
## What does this PR do?

This PR attempts to add support for operating in a MacPorts environment, if detected & if a Homebrew environment is not found.

(I do not use Homebrew at all, so I was unable to use spc until I addressed this in my local checkout.)

I have a concern that this change may not play nicely on a system that has Homebrew but does not have MacPorts, as I was only able to test the inverse of that. Perhaps I should add a fixPort method that detects if brew is installed (preferably in a non-circular way), and no-ops the macports check failure? Or will the lack of a fixPort method accomplish this implicitly?

Also, this is branched off of `v3`, not `feat/pgo-v3`. Unsure if that complicates things, but hopefully it isn't an issue.

## Checklist before merging

- If you modified `*.php` or `*.yml`, run them locally to ensure your changes are valid:
  - [x] `composer cs-fix`
  - [x] `composer analyse`
  - [x] `composer test`
  - [x] `bin/spc dev:lint-config`
