### PR TITLE
fix(frankenphp): strip Go's -mthreads so the Windows build survives Clang >= 20

### DIFF
--- a/src/Package/Target/php/frankenphp.php
+++ b/src/Package/Target/php/frankenphp.php
@@ -381,9 +381,12 @@ trait frankenphp
     /**
      * Return the [CC, CXX] cgo should use to build FrankenPHP on Windows.
      *
-     * Go passes the MinGW-only `-mthreads` flag to the C compiler for cgo builds
-     * (golang/go#16932); Clang >= 20 rejects it for the MSVC target. When it does,
-     * wrap Clang with a tiny .bat that strips the flag before forwarding.
+     * Go passes the MinGW-only `-mthreads` flag to the C compiler for cgo builds;
+     * Clang >= 20 rejects it for the MSVC target. When it does, wrap Clang with
+     * a tiny .bat that strips the flag before forwarding.
+     *
+     * Workaround for https://github.com/golang/go/issues/80290, remove once Go
+     * stops passing the flag.
      *
      * @return array{0: string, 1: string}
      */
@@ -398,7 +401,7 @@ trait frankenphp
             return ['clang.exe', 'clang++.exe'];
         }
 
-        logger()->info('Clang rejects -mthreads; wrapping it to strip the flag (golang/go#16932)');
+        logger()->info('Clang rejects -mthreads; wrapping it to strip the flag (golang/go#80290)');
         $dir = dirname($clang);
         $cc = $package->getSourceDir() . '\cc-nothreads.bat';
         $cxx = $package->getSourceDir() . '\cxx-nothreads.bat';

--- a/src/Package/Target/php/frankenphp.php
+++ b/src/Package/Target/php/frankenphp.php
@@ -273,10 +273,11 @@ trait frankenphp
         // Fix: prepend clang's directory to PATH and use plain executable names instead,
         // which matches FrankenPHP's official CI approach (CC=clang, CXX=clang++).
         $clang_dir = dirname($clang_info['clang']);
+        [$cc, $cxx] = $this->windowsCgoCompilers($package, $clang_info['clang']);
         $env = [
             'CGO_ENABLED' => '1',
-            'CC' => 'clang.exe',
-            'CXX' => 'clang++.exe',
+            'CC' => $cc,
+            'CXX' => $cxx,
             'PATH' => $clang_dir . ';' . getenv('PATH'),
             'CGO_CFLAGS' => clean_spaces($cgo_cflags),
             'CGO_LDFLAGS' => $cgo_ldflags,
@@ -375,6 +376,38 @@ trait frankenphp
                 validation_module: 'FrankenPHP smoke test'
             );
         }
+    }
+
+    /**
+     * Return the [CC, CXX] cgo should use to build FrankenPHP on Windows.
+     *
+     * Go passes the MinGW-only `-mthreads` flag to the C compiler for cgo builds
+     * (golang/go#16932); Clang >= 20 rejects it for the MSVC target. When it does,
+     * wrap Clang with a tiny .bat that strips the flag before forwarding.
+     *
+     * @return array{0: string, 1: string}
+     */
+    protected function windowsCgoCompilers(TargetPackage $package, string $clang): array
+    {
+        $probe = $package->getSourceDir() . '\mthreads-probe.c';
+        file_put_contents($probe, "int main(void){return 0;}\n");
+        [$ret] = cmd()->execWithResult('"' . $clang . '" -mthreads -c ' . escapeshellarg($probe) . ' -o ' . escapeshellarg($probe . '.o'), false);
+        FileSystem::removeFileIfExists($probe);
+        FileSystem::removeFileIfExists($probe . '.o');
+        if ($ret === 0) {
+            return ['clang.exe', 'clang++.exe'];
+        }
+
+        logger()->info('Clang rejects -mthreads; wrapping it to strip the flag (golang/go#16932)');
+        $dir = dirname($clang);
+        $cc = $package->getSourceDir() . '\cc-nothreads.bat';
+        $cxx = $package->getSourceDir() . '\cxx-nothreads.bat';
+        // %*: the whole command line; the substring replace drops the -mthreads token,
+        // preserving quoting of paths that a for-loop would mangle.
+        file_put_contents($cc, "@echo off\r\nset \"a=%*\"\r\nset \"a=%a: -mthreads = %\"\r\n\"{$dir}\\clang.exe\" %a%\r\n");
+        file_put_contents($cxx, "@echo off\r\nset \"a=%*\"\r\nset \"a=%a: -mthreads = %\"\r\n\"{$dir}\\clang++.exe\" %a%\r\n");
+
+        return [$cc, $cxx];
     }
 
     protected function getFrankenPHPVersion(TargetPackage $package): string


### PR DESCRIPTION
Retargeted onto `fable-v3-windows` and cut down to the one thing that branch is missing: the `-mthreads` fix. The linking fixes I originally had here are already on your branch (and more complete), so I dropped them.

Go passes the MinGW-only `-mthreads` flag to the C compiler for cgo builds ([golang/go#16932](https://github.com/golang/go/issues/16932)), and the Clang on current `windows-latest` (VS 18 / LLVM 20+) rejects it for the MSVC target. So the final frankenphp `go build` fails there.

This wraps Clang with a generated `.bat` that drops the `-mthreads` token and forwards the rest (substring replace, so quoted paths survive). It only kicks in when the detected Clang refuses the flag, so older toolchains are untouched.

Verified on `windows-latest`: `fable-v3-windows` as-is fails at `go build` with `unsupported option '-mthreads'`; with this, `frankenphp.exe` builds and passes `version` and `php-server`.

<details>
<summary>Workflow used to build and smoke-test the binary</summary>

```yaml
name: Check FrankenPHP Windows build

on:
  workflow_dispatch:
    inputs:
      version:
        description: php version
        default: '8.5'
        type: string
      extensions:
        description: extensions to compile (comma separated)
        default: 'bcmath,ctype,curl,dom,filter,fileinfo,iconv,mbstring,opcache,openssl,pdo,pdo_sqlite,phar,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib'
        type: string
  push:
    paths:
      - src/Package/Target/php/frankenphp.php
      - .github/workflows/frankenphp-windows-check.yml

env:
  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  PHP_VER: ${{ inputs.version || '8.5' }}
  EXTS: ${{ inputs.extensions || 'bcmath,ctype,curl,dom,filter,fileinfo,iconv,mbstring,opcache,openssl,pdo,pdo_sqlite,phar,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib' }}

jobs:
  build:
    name: frankenphp ${{ inputs.version || '8.5' }} on Windows x86_64
    runs-on: windows-latest
    timeout-minutes: 180
    steps:
      - uses: actions/checkout@v4
      - uses: shivammathur/setup-php@v2
        with:
          php-version: '8.4'
      - run: composer update --no-dev --classmap-authoritative
      # FrankenPHP requires Go >= 1.26; make sure the runner's older Go cannot shadow it
      - uses: actions/setup-go@v6
        with:
          go-version: stable
          cache: false
      - run: go version
      - run: ./bin/spc doctor --auto-fix
      - run: ./bin/spc download --with-php="$env:PHP_VER" --for-extensions="$env:EXTS" --for-libs=nghttp2 --ignore-cache-sources=php-src --retry 5
      - name: Build php-embed
        run: ./bin/spc build:php-embed --enable-zts "--with-libs=nghttp2,pthreads4w" "$env:EXTS"
      - name: Inspect php8embed.lib for zend_atomic_bool_store
        run: |
          $lib = Get-ChildItem -Recurse -Filter php8embed.lib | Select-Object -First 1
          Write-Host "lib: $($lib.FullName)"
          $dumpbin = (Get-ChildItem "C:/Program Files/Microsoft Visual Studio/*/*/VC/Tools/MSVC/*/bin/HostX64/x64/dumpbin.exe" | Select-Object -First 1).FullName
          & $dumpbin /SYMBOLS $lib.FullName | Select-String "zend_atomic_bool_store|InitSecurityInterface|PathCchCanonicalize" | Select-Object -First 20
      - name: Build frankenphp
        run: ./bin/spc build:frankenphp --enable-zts --with-libs=nghttp2 "$env:EXTS"
      - name: Smoke test binary
        run: |
          $bin = Get-ChildItem -Recurse -Filter frankenphp.exe | Select-Object -First 1
          & $bin.FullName version
          & $bin.FullName build-info
      - uses: actions/upload-artifact@v7
        if: always()
        with:
          name: frankenphp-windows-x86_64
          path: buildroot/bin/frankenphp.exe
          if-no-files-found: ignore
      - uses: actions/upload-artifact@v7
        if: failure()
        with:
          name: spc-logs
          path: log/
```
</details>
