### PR TITLE
fix: update libaom POSIX_C_SOURCE patch context for current CMakeLists.txt

### DIFF
--- a/src/globals/patch/libaom_posix_implict.patch
+++ b/src/globals/patch/libaom_posix_implict.patch
@@ -3,10 +3,10 @@ https://bugs.gentoo.org/869419
 POSIX_C_SOURCE is needed for ftello.
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -269,6 +269,7 @@ add_library(aom_rtcd OBJECT ${AOM_RTCD_SOURCES})
- add_dependencies(aom_rtcd aom_version)
+@@ -311,6 +311,7 @@ endif()
 
- if(ENABLE_EXAMPLES)
+ if(ENABLE_APPS)
+   # Only used by aomenc.
 +  add_definitions(-D_POSIX_C_SOURCE=200112L)
    add_library(aom_encoder_stats OBJECT ${AOM_ENCODER_STATS_SOURCES})
    set(AOM_LIB_TARGETS ${AOM_LIB_TARGETS} aom_encoder_stats)


### PR DESCRIPTION
libaom's `main` moved the `aom_encoder_stats` target from `if(ENABLE_EXAMPLES)` at CMakeLists.txt:269 to `if(ENABLE_APPS)` at line 312 (a `CONFIG_HIGHWAY` block got inserted above it). Since `libaom_posix_implict.patch` is applied with plain `patch -p1` against a fresh git checkout of libaom's `main`, the hunk no longer matches and `patch` fails outright, aborting the whole build.

This breaks https://github.com/php/frankenphp CI on `main`/v2 (musl targets falling back to source build for libaom):
```
patching file CMakeLists.txt
Hunk #1 FAILED at 269.
1 out of 1 hunk FAILED -- saving rejects to file CMakeLists.txt.rej
✗ File system error: Cannot extract source libaom: Patch file [libaom_posix_implict.patch] failed to apply
```

Same root cause as #1223, which fixed this on `v3` only. This backports the identical hunk-context update to `main`.