### PR TITLE
Fix Swoole thread context handling for NTS builds

### DIFF
--- a/src/Package/Extension/swoole.php
+++ b/src/Package/Extension/swoole.php
@@ -73,7 +73,7 @@ class swoole extends PhpExtensionPackage
         // commonly used feature: coroutine-time
         $arg .= ' --enable-swoole-coro-time';
 
-        $arg .= $builder->getOption('enable-zts') ? ' --enable-swoole-thread --disable-thread-context' : ' --disable-swoole-thread --enable-thread-context';
+        $arg .= $builder->getOption('enable-zts') ? ' --enable-swoole-thread --disable-thread-context' : ' --disable-swoole-thread --disable-thread-context';
 
         // required features: curl, openssl (but curl hook is buggy for php 8.0)
         $arg .= php::getPHPVersionID() >= 80100 ? ' --enable-swoole-curl' : ' --disable-swoole-curl';


### PR DESCRIPTION
## What does this PR do?

<!-- Please describe the changes made in this PR here. -->
swoole thread mode (multi-threading) requires ZTS. Our chosen swoole-thread and thread-context are mutually exclusive, because thread-context uses process-global state (a single lock and reactor pointer), which conflicts with multi-reactor thread mode. For NTS builds, just use the upstream default (boost asm context): it is faster and better tested. 

Enabling thread-context on NTS is known to cause segfaults, e.g. Process::signal() in onManagerStart. I will submit the real patch upstream later.

## Checklist before merging

- If you modified `*.php` or `*.yml`, run them locally to ensure your changes are valid:
  - [ ] `composer cs-fix`
  - [ ] `composer analyse`
  - [ ] `composer test`
  - [ ] `bin/spc dev:lint-config`
