### PR TITLE
fix pgsql and other polyfill libs leaking into configure

### DIFF
--- a/src/Package/Library/openssl.php
+++ b/src/Package/Library/openssl.php
@@ -89,7 +89,7 @@ class openssl
             '--with-zlib-lib=' . BUILD_LIB_PATH . ' ';
 
         $openssl_dir = getenv('OPENSSLDIR') ?: null;
-        $openssl_dir ??= LinuxUtil::getOSRelease()['dist'] === 'redhat' ? '/etc/pki/tls' : '/etc/ssl';
+        $openssl_dir ??= self::detectOpenSSLDir();
         $ex_lib = trim($ex_lib);
 
         // anything we want included (PGO -fprofile-*, LTO, custom hardening)
@@ -115,6 +115,19 @@ class openssl
             ->exec("make -j{$lib->getBuilder()->concurrency} CNF_EX_LIBS=\"{$ex_lib}\"")
             ->exec('make install_sw');
         $this->patchPkgConfig($lib);
+    }
+
+    private static function detectOpenSSLDir(): string
+    {
+        // /etc/centos-release exists on AlmaLinux and Rocky, so getOSRelease() reports
+        // 'centos' there and the name check missed the RHEL layout
+        foreach (['/etc/ssl', '/etc/pki/tls'] as $dir) {
+            if (file_exists("{$dir}/cert.pem") || glob("{$dir}/certs/*.0")) {
+                return $dir;
+            }
+        }
+
+        return LinuxUtil::getOSRelease()['dist'] === 'redhat' ? '/etc/pki/tls' : '/etc/ssl';
     }
 
     private function patchPkgConfig(LibraryPackage $pkg): void

--- a/src/Package/Target/php/unix.php
+++ b/src/Package/Target/php/unix.php
@@ -143,15 +143,12 @@ trait unix
             $configure_str = str_replace('--with-pic', '--enable-pic', $configure_str);
         }
 
-        // reuse the same make vars so configure conftest links use the same LIBS (incl. -framework flags)
-        $vars = $this->makeVars($installer);
-
         // run ./configure with args
         $this->seekPhpSrcLogFileOnException(fn () => shell()->cd($package->getSourceDir())->setEnv([
             'CFLAGS' => getenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_CFLAGS'),
             'CPPFLAGS' => "-I{$package->getIncludeDir()}",
             'LDFLAGS' => "-L{$package->getLibDir()} " . getenv('SPC_CMD_VAR_PHP_MAKE_EXTRA_LDFLAGS'),
-            'LIBS' => $vars['EXTRA_LIBS'] ?? '',
+            'LIBS' => SystemTarget::getRuntimeLibs(),
         ])->exec($configure_str), $package->getSourceDir());
     }
 

--- a/src/StaticPHP/Artifact/ArtifactExtractor.php
+++ b/src/StaticPHP/Artifact/ArtifactExtractor.php
@@ -523,7 +523,7 @@ class ArtifactExtractor
      *
      * Supports: tar, tar.gz, tgz, tar.bz2, tar.xz, txz, zip, exe
      *
-     * @param bool $merge when true, merge zip contents into existing target dir instead of wiping it
+     * @param bool $merge when true, merge contents into existing target dir instead of wiping it
      */
     protected function extractArchive(string $filename, string $target, bool $merge = false): void
     {
@@ -532,10 +532,17 @@ class ArtifactExtractor
 
         $extname = FileSystem::extname($filename);
 
-        if ($extname !== 'exe' && !is_dir($target)) {
-            FileSystem::createDir($target);
+        if ($extname !== 'exe') {
+            // tar extraction merges into whatever is already there, so a re-extract would
+            // leave files from the previous version behind
+            if (!$merge && is_dir($target)) {
+                FileSystem::removeDir($target);
+            }
             if (!is_dir($target)) {
-                throw new FileSystemException("Failed to create target directory: {$target}");
+                FileSystem::createDir($target);
+                if (!is_dir($target)) {
+                    throw new FileSystemException("Failed to create target directory: {$target}");
+                }
             }
         }
         match (SystemTarget::getTargetOS()) {


### PR DESCRIPTION
currently when building pgsql on old glibc systems the polyfill libs from pgsql and libedit advertise `strlcpy` and `strlcat` as available, even though they only are when linking against those libs.