### PR TITLE
fix imap c-client headers leaking into configure

### DIFF
--- a/src/Package/Library/imap.php
+++ b/src/Package/Library/imap.php
@@ -73,12 +73,14 @@ class imap
                 throw $e;
             }
         }
+        $cClientIncludeDir = "{$lib->getIncludeDir()}/c-client";
+        FileSystem::createDir($cClientIncludeDir);
         try {
             shell()
                 ->exec("cp -rf {$lib->getSourceDir()}/c-client/c-client.a {$lib->getLibDir()}/libc-client.a")
                 ->exec("cp -rf {$lib->getSourceDir()}/c-client/*.c {$lib->getLibDir()}/")
-                ->exec("cp -rf {$lib->getSourceDir()}/c-client/*.h {$lib->getIncludeDir()}/")
-                ->exec("cp -rf {$lib->getSourceDir()}/src/osdep/unix/*.h {$lib->getIncludeDir()}/");
+                ->exec("cp -rf {$lib->getSourceDir()}/c-client/*.h {$cClientIncludeDir}/")
+                ->exec("cp -rf {$lib->getSourceDir()}/src/osdep/unix/*.h {$cClientIncludeDir}/");
         } catch (\Throwable) {
             // last command throws an exception, no idea why since it works
         }
@@ -111,12 +113,14 @@ class imap
                 throw $e;
             }
         }
+        $cClientIncludeDir = "{$lib->getIncludeDir()}/c-client";
+        FileSystem::createDir($cClientIncludeDir);
         try {
             shell()
                 ->exec("cp -rf {$lib->getSourceDir()}/c-client/c-client.a {$lib->getLibDir()}/libc-client.a")
                 ->exec("cp -rf {$lib->getSourceDir()}/c-client/*.c {$lib->getLibDir()}/")
-                ->exec("cp -rf {$lib->getSourceDir()}/c-client/*.h {$lib->getIncludeDir()}/")
-                ->exec("cp -rf {$lib->getSourceDir()}/src/osdep/unix/*.h {$lib->getIncludeDir()}/");
+                ->exec("cp -rf {$lib->getSourceDir()}/c-client/*.h {$cClientIncludeDir}/")
+                ->exec("cp -rf {$lib->getSourceDir()}/src/osdep/unix/*.h {$cClientIncludeDir}/");
         } catch (\Throwable) {
             // last command throws an exception, no idea why since it works
         }


### PR DESCRIPTION
## What does this PR do?

c-client currently installs its private headers, including `unix.h`, into the global include directory. PHP's configure check then detects that private header and defines `HAVE_UNIX_H`, causing installed PHP development headers to include a file that is not shipped with the PHP SDK package. As a result, downstream extensions fail to compile when they include `php.h`.

This keeps c-client headers under `include/c-client`, the layout already expected by ext-imap, so they are no longer visible to unrelated PHP configure checks.

### Verification

- Reproduced the downstream SDK failure with the unmodified package: https://github.com/edram/mise-php/actions/runs/33045639321/job/98428862980
- Built and packaged the same PHP 8.3 GNU/Laravel target successfully with this change: https://github.com/edram/mise-php/actions/runs/33048935705/job/98439439481
- Installed and loaded `asgrim/example-pie-extension` through PIE, including `phpize`, configure, build, and install
- Built, installed, and loaded `ds-1.8.0` through PECL
- Built PHP 8.3 with IMAP locally and verified the resulting CLI loads IMAP

## Checklist before merging

- If you modified `*.php` or `*.yml`, run them locally to ensure your changes are valid:
  - [x] `composer cs-fix`
  - [x] `composer analyse`
  - [x] `composer test`
  - [x] `bin/spc dev:lint-config`
