### PR TITLE
frankenphp: build the Mercure hub with its 0.x compatibility tags

### DIFF
--- a/src/Package/Target/php/frankenphp.php
+++ b/src/Package/Target/php/frankenphp.php
@@ -144,7 +144,7 @@ trait frankenphp
                 '-X \'github.com/caddyserver/caddy/v2.CustomBinaryName=frankenphp\' ' .
                 '-X \'github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP ' .
                 "v{$frankenphp_version} PHP {$libphp_version} Caddy'\\\" " .
-                "-tags={$muslTags}nobadger,nomysql,nopgx{$no_brotli}{$no_watcher}",
+                "-tags={$muslTags}nobadger,nomysql,nopgx,deprecated_topic,deprecated_claim{$no_brotli}{$no_watcher}",
             'LD_LIBRARY_PATH' => BUILD_LIB_PATH,
         ];
         InteractiveTerm::setMessage('Building frankenphp: ' . ConsoleColor::yellow('building with xcaddy'));
@@ -303,7 +303,7 @@ trait frankenphp
         ])));
 
         // build tags: skip watcher (no inotify/kqueue on Windows)
-        $go_build_tags = 'nobadger,nomysql,nopgx,nowatcher';
+        $go_build_tags = 'nobadger,nomysql,nopgx,deprecated_topic,deprecated_claim,nowatcher';
         if (!$installer->isPackageResolved('brotli')) {
             $go_build_tags .= ',nobrotli';
         }


### PR DESCRIPTION
Mercure 1.0 (https://github.com/dunglas/mercure/releases/tag/v1.0.0-alpha.3) gates its 0.x behaviors behind two build tags, `deprecated_topic` and `deprecated_claim`, and only honors them when the Caddyfile sets `protocol_version_compatibility 8`. Without the tags, a hub in compatibility mode rejects 0.x tokens and `topic=` selectors outright.

FrankenPHP is adopting the 1.0 hub in https://github.com/php/frankenphp/pull/2611 and ships both tags in its Docker images and CI builds, like the official Mercure binaries, so users can migrate progressively. Static binaries take their `-tags` list from here, and `GOFLAGS` cannot add to a `-tags` given on the command line, hence this change.

Go ignores unknown build tags, so FrankenPHP versions still on Mercure 0.24 build unchanged.